### PR TITLE
Add Fortran 95 support to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # fortran-src
 
-Provides lexing, parsing, and basic analyses of Fortran code covering standards: FORTRAN 66, FORTRAN 77, and Fortran 90. Includes data flow and basic block analysis, a renamer, and type analysis. For example usage, see the 'camfort' project (https://github.com/camfort/camfort), which uses fortran-src as its front end.
+Provides lexing, parsing, and basic analyses of Fortran code covering standards:
+FORTRAN 66, FORTRAN 77, Fortran 90, and Fortran 95. Includes data flow and basic
+block analysis, a renamer, and type analysis. For example usage, see the
+'camfort' project (https://github.com/camfort/camfort), which uses fortran-src
+as its front end.

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -108,7 +108,7 @@ data ProgramUnit a =
   | PUFunction
       a SrcSpan
       (Maybe (TypeSpec a)) -- Return type
-      Bool -- Recursive or not
+      PUFunctionOpt -- Function Options
       Name
       (Maybe (AList Expression a)) -- Arguments
       (Maybe (Expression a)) -- Result
@@ -120,6 +120,8 @@ data ProgramUnit a =
       [Block a] -- Body
   | PUComment a SrcSpan (Comment a)
   deriving (Eq, Show, Data, Typeable, Generic, Functor)
+
+data PUFunctionOpt = None Bool | Pure Bool | Elemental
 
 programUnitBody :: ProgramUnit a -> [Block a]
 programUnitBody (PUMain _ _ _ bs _)              = bs

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -138,6 +138,11 @@ buildPUFunctionOpt a b =
     (_, (Pure () r)) -> Right (Pure () r)
     ((None () r), (None () r')) -> Right (None () (r || r'))
 
+buildPUFunctionOpts :: [PUFunctionOpt ()] -> Either String (PUFunctionOpt())
+buildPUFunctionOpts =
+  foldr merge . Right $ None () False
+  where merge a = either Left $ buildPUFunctionOpt a
+
 functionIsRecursive :: (PUFunctionOpt a) -> Bool
 functionIsRecursive (Elemental _) = False
 functionIsRecursive (Pure _ r) = r

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -134,9 +134,10 @@ buildPUFunctionOpt a b =
       then Left "Function cannot be both elemental and recursive. "
       else Right (Elemental ())
     (_, (Elemental ())) -> buildPUFunctionOpt b a
-    ((Pure () r), _) -> Right (Pure () r)
-    (_, (Pure () r)) -> Right (Pure () r)
+    ((Pure () r), b) -> Right (Pure () (r || functionIsRecursive b))
+    (b, (Pure () r)) -> Right (Pure () (r || functionIsRecursive b))
     ((None () r), (None () r')) -> Right (None () (r || r'))
+-- Should parse: "elemental pure recursive function f()\nend": Right (Elemental ()) FAILED [4]
 
 buildPUFunctionOpts :: [PUFunctionOpt ()] -> Either String (PUFunctionOpt())
 buildPUFunctionOpts =

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -109,7 +109,11 @@ tokens :-
 <scN> "function" / { typeSpecP }                  { addSpan TFunction }
 <0> "end"\ *"function"                            { addSpan TEndFunction }
 <scN> "result" / { resultP }                      { addSpan TResult }
+<0> "pure"                                        { toSC 0 >> addSpan TPure }
+<0> "elemental"                                   { toSC 0 >> addSpan TElemental }
 <0> "recursive"                                   { toSC 0 >> addSpan TRecursive }
+<scN> "pure" / { typeSpecP }                      { toSC 0 >> addSpan TPure }
+<scN> "elemental" / { typeSpecP }                 { toSC 0 >> addSpan TElemental }
 <scN> "recursive" / { typeSpecP }                 { toSC 0 >> addSpan TRecursive }
 <0> "subroutine"                                  { addSpan TSubroutine }
 <0> "end"\ *"subroutine"                          { addSpan TEndSubroutine }
@@ -997,6 +1001,8 @@ data Token =
   | TFunction           SrcSpan
   | TEndFunction        SrcSpan
   | TResult             SrcSpan
+  | TPure          SrcSpan
+  | TElemental          SrcSpan
   | TRecursive          SrcSpan
   | TSubroutine         SrcSpan
   | TEndSubroutine      SrcSpan

--- a/src/Language/Fortran/Parser/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fortran66.y
@@ -128,9 +128,9 @@ MAIN_PROGRAM_UNIT
 OTHER_PROGRAM_UNIT :: { ProgramUnit A0 }
 OTHER_PROGRAM_UNIT
 : TYPE_SPEC function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
-  { PUFunction () (getTransSpan $1 $7) (Just $1) False $3 $4 Nothing (reverse $6) Nothing }
+  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () False) $3 $4 Nothing (reverse $6) Nothing }
 | function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
-  { PUFunction () (getTransSpan $1 $6) Nothing False $2 $3 Nothing (reverse $5) Nothing  }
+  { PUFunction () (getTransSpan $1 $6) Nothing (None () False) $2 $3 Nothing (reverse $5) Nothing  }
 | subroutine NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
   { PUSubroutine () (getTransSpan $1 $6) False $2 $3 (reverse $5) Nothing }
 | blockData NEWLINE BLOCKS end MAYBE_NEWLINE { PUBlockData () (getTransSpan $1 $4) Nothing (reverse $3) }

--- a/src/Language/Fortran/Parser/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fortran66.y
@@ -128,9 +128,9 @@ MAIN_PROGRAM_UNIT
 OTHER_PROGRAM_UNIT :: { ProgramUnit A0 }
 OTHER_PROGRAM_UNIT
 : TYPE_SPEC function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
-  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () False) $3 $4 Nothing (reverse $6) Nothing }
+  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () initSrcSpan False) $3 $4 Nothing (reverse $6) Nothing }
 | function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
-  { PUFunction () (getTransSpan $1 $6) Nothing (None () False) $2 $3 Nothing (reverse $5) Nothing  }
+  { PUFunction () (getTransSpan $1 $6) Nothing (None () initSrcSpan False) $2 $3 Nothing (reverse $5) Nothing  }
 | subroutine NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end MAYBE_NEWLINE
   { PUSubroutine () (getTransSpan $1 $6) False $2 $3 (reverse $5) Nothing }
 | blockData NEWLINE BLOCKS end MAYBE_NEWLINE { PUBlockData () (getTransSpan $1 $4) Nothing (reverse $3) }

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -155,9 +155,9 @@ PROGRAM_UNIT :: { ProgramUnit A0 }
 PROGRAM_UNIT
 : program NAME NEWLINE BLOCKS end { PUMain () (getTransSpan $1 $5) (Just $2) (reverse $4) Nothing }
 | TYPE_SPEC function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
-  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () False) $3 $4 Nothing (reverse $6) Nothing }
+  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () initSrcSpan False) $3 $4 Nothing (reverse $6) Nothing }
 | function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
-  { PUFunction () (getTransSpan $1 $6) Nothing (None () False) $2 $3 Nothing (reverse $5) Nothing }
+  { PUFunction () (getTransSpan $1 $6) Nothing (None () initSrcSpan False) $2 $3 Nothing (reverse $5) Nothing }
 | subroutine NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
   { PUSubroutine () (getTransSpan $1 $6) False $2 $3 (reverse $5) Nothing }
 | blockData NEWLINE BLOCKS end { PUBlockData () (getTransSpan $1 $4) Nothing (reverse $3) }

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -155,9 +155,9 @@ PROGRAM_UNIT :: { ProgramUnit A0 }
 PROGRAM_UNIT
 : program NAME NEWLINE BLOCKS end { PUMain () (getTransSpan $1 $5) (Just $2) (reverse $4) Nothing }
 | TYPE_SPEC function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
-  { PUFunction () (getTransSpan $1 $7) (Just $1) False $3 $4 Nothing (reverse $6) Nothing }
+  { PUFunction () (getTransSpan $1 $7) (Just $1) (None () False) $3 $4 Nothing (reverse $6) Nothing }
 | function NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
-  { PUFunction () (getTransSpan $1 $6) Nothing False $2 $3 Nothing (reverse $5) Nothing }
+  { PUFunction () (getTransSpan $1 $6) Nothing (None () False) $2 $3 Nothing (reverse $5) Nothing }
 | subroutine NAME MAYBE_ARGUMENTS NEWLINE BLOCKS end
   { PUSubroutine () (getTransSpan $1 $6) False $2 $3 (reverse $5) Nothing }
 | blockData NEWLINE BLOCKS end { PUBlockData () (getTransSpan $1 $4) Nothing (reverse $3) }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -239,16 +239,16 @@ SUBPROGRAM_UNITS :: { [ ProgramUnit A0 ] }
 SUBPROGRAM_UNIT :: { ProgramUnit A0 }
 : TYPE_SPEC function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $10 $3;
-          return $ PUFunction () (getTransSpan $1 $10) (Just $1) (None () False) $3 $4 $6 (reverse $8) $9 } }
+          return $ PUFunction () (getTransSpan $1 $10) (Just $1) (None () initSrcSpan False) $3 $4 $6 (reverse $8) $9 } }
 | TYPE_SPEC recursive function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
-          return $ PUFunction () (getTransSpan $1 $11) (Just $1) (None () True) $4 $5 $7 (reverse $9) $10 } }
+          return $ PUFunction () (getTransSpan $1 $11) (Just $1) (None () (getSpan $2) True) $4 $5 $7 (reverse $9) $10 } }
 | recursive TYPE_SPEC function NAME MAYBE_ARGUMENTS RESULT MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
-          return $ PUFunction () (getTransSpan $1 $11) (Just $2) (None () True) $4 $5 $6 (reverse $9) $10 } }
+          return $ PUFunction () (getTransSpan $1 $11) (Just $2) (None () (getSpan $1) True) $4 $5 $6 (reverse $9) $10 } }
 | function NAME MAYBE_ARGUMENTS RESULT MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $9 $2;
-          return $ PUFunction () (getTransSpan $1 $9) Nothing (None () False) $2 $3 $4 (reverse $7) $8 } }
+          return $ PUFunction () (getTransSpan $1 $9) Nothing (None () initSrcSpan False) $2 $3 $4 (reverse $7) $8 } }
 | subroutine NAME MAYBE_ARGUMENTS MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS SUBROUTINE_END
   {% do { unitNameCheck $8 $2;
           return $ PUSubroutine () (getTransSpan $1 $8) False $2 $3 (reverse $6) $7 } }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -237,16 +237,16 @@ SUBPROGRAM_UNITS :: { [ ProgramUnit A0 ] }
 SUBPROGRAM_UNIT :: { ProgramUnit A0 }
 : TYPE_SPEC function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $10 $3;
-          return $ PUFunction () (getTransSpan $1 $10) (Just $1) False $3 $4 $6 (reverse $8) $9 } }
+          return $ PUFunction () (getTransSpan $1 $10) (Just $1) (None () False) $3 $4 $6 (reverse $8) $9 } }
 | TYPE_SPEC recursive function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
-          return $ PUFunction () (getTransSpan $1 $11) (Just $1) True $4 $5 $7 (reverse $9) $10 } }
+          return $ PUFunction () (getTransSpan $1 $11) (Just $1) (None () True) $4 $5 $7 (reverse $9) $10 } }
 | recursive TYPE_SPEC function NAME MAYBE_ARGUMENTS RESULT MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
-          return $ PUFunction () (getTransSpan $1 $11) (Just $2) True $4 $5 $6 (reverse $9) $10 } }
+          return $ PUFunction () (getTransSpan $1 $11) (Just $2) (None () True) $4 $5 $6 (reverse $9) $10 } }
 | function NAME MAYBE_ARGUMENTS RESULT MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $9 $2;
-          return $ PUFunction () (getTransSpan $1 $9) Nothing False $2 $3 $4 (reverse $7) $8 } }
+          return $ PUFunction () (getTransSpan $1 $9) Nothing (None () False) $2 $3 $4 (reverse $7) $8 } }
 | subroutine NAME MAYBE_ARGUMENTS MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS SUBROUTINE_END
   {% do { unitNameCheck $8 $2;
           return $ PUSubroutine () (getTransSpan $1 $8) False $2 $3 (reverse $6) $7 } }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -467,10 +467,14 @@ EXECUTABLE_STATEMENT :: { Statement A0 }
 | cycle VARIABLE { StCycle () (getTransSpan $1 $2) (Just $2) }
 | exit { StExit () (getSpan $1) Nothing }
 | exit VARIABLE { StExit () (getTransSpan $1 $2) (Just $2) }
+-- GO TO label
 | goto INTEGER_LITERAL { StGotoUnconditional () (getTransSpan $1 $2) $2 }
+-- GO TO scalar-int-variable
 | goto VARIABLE { StGotoUnconditional () (getTransSpan $1 $2) $2 }
+-- GO TO scalar-int-variable [,] label-list
 | goto VARIABLE MAYBE_COMMA '(' INTEGERS ')'
   { StGotoAssigned () (getTransSpan $1 $6) $2 (fromReverseList $5) }
+-- GO TO label-list [,] scalar-int-expression
 | goto '(' INTEGERS ')' MAYBE_COMMA EXPRESSION
   { StGotoComputed () (getTransSpan $1 $6) (fromReverseList $3) $6 }
 | assign INTEGER_LITERAL to VARIABLE

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -1,6 +1,7 @@
 -- -*- Mode: Haskell -*-
 {
 module Language.Fortran.Parser.Fortran90 ( statementParser
+                                         , functionParser
                                          , fortran90Parser
                                          , fortran90ParserWithModFiles
                                          ) where
@@ -27,6 +28,7 @@ import Debug.Trace
 }
 
 %name programParser PROGRAM
+%name functionParser SUBPROGRAM_UNIT
 %name statementParser STATEMENT
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -121,7 +121,6 @@ import Debug.Trace
   nullify                     { TNullify _ }
   none                        { TNone _ }
   goto                        { TGoto _ }
-  assign                      { TAssign _ }
   to                          { TTo _ }
   continue                    { TContinue _ }
   stop                        { TStop _ }
@@ -467,14 +466,11 @@ EXECUTABLE_STATEMENT :: { Statement A0 }
 | cycle VARIABLE { StCycle () (getTransSpan $1 $2) (Just $2) }
 | exit { StExit () (getSpan $1) Nothing }
 | exit VARIABLE { StExit () (getTransSpan $1 $2) (Just $2) }
+-- GO TO label
 | goto INTEGER_LITERAL { StGotoUnconditional () (getTransSpan $1 $2) $2 }
-| goto VARIABLE { StGotoUnconditional () (getTransSpan $1 $2) $2 }
-| goto VARIABLE MAYBE_COMMA '(' INTEGERS ')'
-  { StGotoAssigned () (getTransSpan $1 $6) $2 (fromReverseList $5) }
+-- GO TO label-list [,] scalar-int-expression
 | goto '(' INTEGERS ')' MAYBE_COMMA EXPRESSION
   { StGotoComputed () (getTransSpan $1 $6) (fromReverseList $3) $6 }
-| assign INTEGER_LITERAL to VARIABLE
-  { StLabelAssign () (getTransSpan $1 $4) $2 $4 }
 | continue { StContinue () (getSpan $1) }
 | stop { StStop () (getSpan $1) Nothing }
 | stop EXPRESSION { StStop () (getTransSpan $1 $2) (Just $2) }
@@ -1139,6 +1135,7 @@ parseError token = do
       ++ '\n' : show tokens
 #endif
   where specifics (TPause _) = "\nPAUSE statements are not supported in Fortran 95 or later. "
+        specifics (TAssign _) = "\nASSIGN statements are not supported in Fortran 95 or later. "
         specifics _ = ""
 
 }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -1,6 +1,7 @@
 -- -*- Mode: Haskell -*-
 {
-module Language.Fortran.Parser.Fortran95Experimental ( statementParser
+module Language.Fortran.Parser.Fortran95Experimental ( functionParser
+                                         , statementParser
                                          , fortran95Parser
                                          , fortran95ParserWithModFiles
                                          ) where
@@ -30,6 +31,7 @@ import Debug.Trace
 
 %name programParser PROGRAM
 %name statementParser STATEMENT
+%name functionParser SUBPROGRAM_UNIT 
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
 %tokentype { Token }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -261,11 +261,7 @@ FUNCTION_SPEC :: { PUFunctionOpt () }
 : PFUNCTION_SPECS {% do
     if nub $1 /= $1
     then fail "Function properties specified multiple times."
-    else
-      let result = foldr (\a b -> either (Left) (buildPUFunctionOpt a) $ b) (Right (None () False)) $1 :: Either String (PUFunctionOpt ()) in
-      case result of
-        Left str -> fail str
-        Right fOpt -> return fOpt
+    else either fail return $ buildPUFunctionOpts $1
   }
 
 PFUNCTION_SPECS :: { [PUFunctionOpt ()] }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -1128,14 +1128,17 @@ fortran95ParserWithModFiles mods sourceCode filename =
     parseState = initParseState sourceCode Fortran95 filename
 
 parseError :: Token -> LexAction a
-parseError _ = do
+parseError token = do
     parseState <- get
 #ifdef DEBUG
     tokens <- reverse <$> aiPreviousTokensInLine <$> getAlex
 #endif
     fail $ psFilename parseState ++ ": parsing failed. "
+      ++ specifics token
 #ifdef DEBUG
       ++ '\n' : show tokens
 #endif
+  where specifics (TPause _) = "\nPAUSE statements are not supported in Fortran 95 or later. "
+        specifics _ = ""
 
 }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -234,12 +234,9 @@ SUBPROGRAM_UNITS :: { [ ProgramUnit A0 ] }
 | {- EMPTY -} { [ ] }
 
 SUBPROGRAM_UNIT :: { ProgramUnit A0 }
-: TYPE_SPEC function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
-  {% do { unitNameCheck $10 $3;
-          return $ PUFunction () (getTransSpan $1 $10) (Just $1) False $3 $4 $6 (reverse $8) $9 } }
-| TYPE_SPEC recursive function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
+: TYPE_SPEC MAYBE_RECURSIVE function NAME MAYBE_ARGUMENTS MAYBE_COMMENT RESULT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
-          return $ PUFunction () (getTransSpan $1 $11) (Just $1) True $4 $5 $7 (reverse $9) $10 } }
+          return $ PUFunction () (getTransSpan $1 $11) (Just $1) $2 $4 $5 $7 (reverse $9) $10 } }
 | recursive TYPE_SPEC function NAME MAYBE_ARGUMENTS RESULT MAYBE_COMMENT NEWLINE BLOCKS MAYBE_SUBPROGRAM_UNITS FUNCTION_END
   {% do { unitNameCheck $11 $4;
           return $ PUFunction () (getTransSpan $1 $11) (Just $2) True $4 $5 $6 (reverse $9) $10 } }
@@ -253,6 +250,10 @@ SUBPROGRAM_UNIT :: { ProgramUnit A0 }
   {% do { unitNameCheck $9 $3;
           return $ PUSubroutine () (getTransSpan $1 $9) True $3 $4 (reverse $7) $8 } }
 | comment { let (TComment s c) = $1 in PUComment () s (Comment c) }
+
+MAYBE_RECURSIVE :: { Bool }
+: recursive { True }
+| {- EMPTY -} { False }
 
 MAYBE_ARGUMENTS :: { Maybe (AList Expression A0) }
 : '(' MAYBE_VARIABLES ')' { $2 }

--- a/src/Language/Fortran/Parser/Fortran95Experimental.y
+++ b/src/Language/Fortran/Parser/Fortran95Experimental.y
@@ -125,7 +125,6 @@ import Debug.Trace
   to                          { TTo _ }
   continue                    { TContinue _ }
   stop                        { TStop _ }
-  pause                       { TPause _ }
   do                          { TDo _ }
   enddo                       { TEndDo _ }
   while                       { TWhile _ }
@@ -479,8 +478,6 @@ EXECUTABLE_STATEMENT :: { Statement A0 }
 | continue { StContinue () (getSpan $1) }
 | stop { StStop () (getSpan $1) Nothing }
 | stop EXPRESSION { StStop () (getTransSpan $1 $2) (Just $2) }
-| pause { StPause () (getSpan $1) Nothing }
-| pause EXPRESSION { StPause () (getTransSpan $1 $2) (Just $2) }
 | selectcase '(' EXPRESSION ')'
   { StSelectCase () (getTransSpan $1 $4) Nothing $3 }
 | id ':' selectcase '(' EXPRESSION ')'

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -131,8 +131,8 @@ instance IndentablePretty (ProgramUnit a) where
                     else incIndentation fixedForm
 
     pprint v (PUFunction _ _ mRetType fSpec name mArgs mRes body mSubs) i
-      | (Elemental _) <- fSpec, v < Fortran95 = tooOld v "Elemental function" Fortran90
-      | (Pure _ _) <- fSpec, v < Fortran95 = tooOld v "Pure function" Fortran90
+      | (Elemental _ _) <- fSpec, v < Fortran95 = tooOld v "Elemental function" Fortran90
+      | (Pure _ _ _) <- fSpec, v < Fortran95 = tooOld v "Pure function" Fortran90
       | functionIsRecursive fSpec, v < Fortran90 = tooOld v "Recursive function" Fortran90
       | isJust mRes, v < Fortran90 = tooOld v "Function result" Fortran90
       | isJust mSubs, v < Fortran90 = tooOld v "Function subprogram" Fortran90
@@ -140,8 +140,8 @@ instance IndentablePretty (ProgramUnit a) where
         indent curI
           (pprint' v mRetType <+>
           (case fSpec of
-            (Elemental _) -> "elemental"
-            (Pure _ _) -> "pure"
+            (Elemental _ _) -> "elemental"
+            (Pure _ _ _) -> "pure"
             otherwise -> empty) <+>
           (if functionIsRecursive fSpec then "recursive" else empty) <+>
           "function" <+> text name <>

--- a/test/Language/Fortran/Analysis/RenamingSpec.hs
+++ b/test/Language/Fortran/Analysis/RenamingSpec.hs
@@ -113,7 +113,7 @@ spec = do
 --------------------------------------------------
 
 ex1 = ProgramFile mi77 [ ex1pu1 ]
-ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" Nothing Nothing [] Nothing
+ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" Nothing Nothing [] Nothing
 
 ex2 = ProgramFile mi77 [ ex2pu1 ]
 ex2pu1 = PUMain () u (Just "main") ex2pu1bs Nothing
@@ -154,7 +154,7 @@ ex3pu1bs =
       (ExpSubscript () u (varGen "c") (AList () u [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
       (varGen "d") (ExpBinary () u Addition (varGen "d") (intGen 1))) ]
-ex3pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" (Just $ AList () u [ varGen "d", varGen "b"]) Nothing (ex3pu1bs ++ [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "d")) ]) Nothing
+ex3pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "d", varGen "b"]) Nothing (ex3pu1bs ++ [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "d")) ]) Nothing
 
 ex4 = ProgramFile mi77 [ ex4pu1, ex4pu2 ]
 ex4pu1 = PUMain () u (Just "main") ex4pu1bs Nothing
@@ -166,14 +166,14 @@ ex4pu1bs =
       (ExpValue () u (ValVariable "r"))
       (ExpFunctionCall () u (ExpValue () u (ValVariable "f1"))
                             (Just $ AList () u [ Argument () u Nothing $ intGen 1 ]))) ]
-ex4pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
+ex4pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
 
 ex5 = ProgramFile mi77 [ ex5pu1, ex5pu2 ]
 ex5pu1 = PUMain () u (Just "main") ex5pu1bs Nothing
 ex5pu1bs = []
 ex5pu2 = PUModule () u "ex5mod" ex5pu2bs (Just [ex5pu2pu1])
 ex5pu2bs = []
-ex5pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
+ex5pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
 
 
 ex6 = ProgramFile mi77 [ ex6pu1, ex6pu2 ]
@@ -181,7 +181,7 @@ ex6pu1 = PUMain () u (Just "main") ex6pu1bs Nothing
 ex6pu1bs = []
 ex6pu2 = PUModule () u "ex6mod" ex6pu2bs (Just [ex6pu2pu1])
 ex6pu2bs = []
-ex6pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (ExpFunctionCall () u (ExpValue () u (ValVariable "f1")) (Just $ AList () u [Argument () u Nothing (varGen "x")]))) ] (Just [ex5pu2pu1])
+ex6pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (ExpFunctionCall () u (ExpValue () u (ValVariable "f1")) (Just $ AList () u [Argument () u Nothing (varGen "x")]))) ] (Just [ex5pu2pu1])
 
 parseF90 = resetSrcSpan . flip fortran90Parser "" . unlines
 
@@ -242,7 +242,7 @@ ex10pu1bs =
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e3")) Nothing Nothing) ]
 
 ex11 = ProgramFile mi77 [ ex11pu1 ]
-ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) False "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
+ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
 ex11pu1bs =
   [ BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e1")) Nothing Nothing)
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e2")) Nothing Nothing)

--- a/test/Language/Fortran/Analysis/RenamingSpec.hs
+++ b/test/Language/Fortran/Analysis/RenamingSpec.hs
@@ -113,7 +113,7 @@ spec = do
 --------------------------------------------------
 
 ex1 = ProgramFile mi77 [ ex1pu1 ]
-ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" Nothing Nothing [] Nothing
+ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" Nothing Nothing [] Nothing
 
 ex2 = ProgramFile mi77 [ ex2pu1 ]
 ex2pu1 = PUMain () u (Just "main") ex2pu1bs Nothing
@@ -154,7 +154,7 @@ ex3pu1bs =
       (ExpSubscript () u (varGen "c") (AList () u [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
       (varGen "d") (ExpBinary () u Addition (varGen "d") (intGen 1))) ]
-ex3pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "d", varGen "b"]) Nothing (ex3pu1bs ++ [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "d")) ]) Nothing
+ex3pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" (Just $ AList () u [ varGen "d", varGen "b"]) Nothing (ex3pu1bs ++ [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "d")) ]) Nothing
 
 ex4 = ProgramFile mi77 [ ex4pu1, ex4pu2 ]
 ex4pu1 = PUMain () u (Just "main") ex4pu1bs Nothing
@@ -166,14 +166,14 @@ ex4pu1bs =
       (ExpValue () u (ValVariable "r"))
       (ExpFunctionCall () u (ExpValue () u (ValVariable "f1"))
                             (Just $ AList () u [ Argument () u Nothing $ intGen 1 ]))) ]
-ex4pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
+ex4pu2 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
 
 ex5 = ProgramFile mi77 [ ex5pu1, ex5pu2 ]
 ex5pu1 = PUMain () u (Just "main") ex5pu1bs Nothing
 ex5pu1bs = []
 ex5pu2 = PUModule () u "ex5mod" ex5pu2bs (Just [ex5pu2pu1])
 ex5pu2bs = []
-ex5pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
+ex5pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (varGen "x")) ] Nothing
 
 
 ex6 = ProgramFile mi77 [ ex6pu1, ex6pu2 ]
@@ -181,7 +181,7 @@ ex6pu1 = PUMain () u (Just "main") ex6pu1bs Nothing
 ex6pu1bs = []
 ex6pu2 = PUModule () u "ex6mod" ex6pu2bs (Just [ex6pu2pu1])
 ex6pu2bs = []
-ex6pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (ExpFunctionCall () u (ExpValue () u (ValVariable "f1")) (Just $ AList () u [Argument () u Nothing (varGen "x")]))) ] (Just [ex5pu2pu1])
+ex6pu2pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" (Just $ AList () u [ varGen "x"]) Nothing [ BlStatement () u Nothing (StExpressionAssign () u (varGen "f1") (ExpFunctionCall () u (ExpValue () u (ValVariable "f1")) (Just $ AList () u [Argument () u Nothing (varGen "x")]))) ] (Just [ex5pu2pu1])
 
 parseF90 = resetSrcSpan . flip fortran90Parser "" . unlines
 
@@ -242,7 +242,7 @@ ex10pu1bs =
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e3")) Nothing Nothing) ]
 
 ex11 = ProgramFile mi77 [ ex11pu1 ]
-ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
+ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () u False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
 ex11pu1bs =
   [ BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e1")) Nothing Nothing)
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e2")) Nothing Nothing)

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -68,7 +68,7 @@ spec = do
         idCType (mapping ! "cabs") `shouldBe` Just CTArray
 
 ex1 = ProgramFile mi77 [ ex1pu1 ]
-ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" Nothing Nothing [] Nothing
+ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () u False) "f1" Nothing Nothing [] Nothing
 
 ex2 = ProgramFile mi77 [ ex2pu1, ex1pu1 ]
 ex2pu1 = PUSubroutine () u False "s1" Nothing [] Nothing
@@ -129,7 +129,7 @@ ex6pu1bs =
       (ExpSubscript () u (varGen "d") (fromList () [ ixSinGen 1 ])) (intGen 1)) ]
 
 ex11 = ProgramFile mi77 [ ex11pu1 ]
-ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
+ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () u False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
 ex11pu1bs =
   [ BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e1")) Nothing Nothing)
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e2")) Nothing Nothing)

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -68,7 +68,7 @@ spec = do
         idCType (mapping ! "cabs") `shouldBe` Just CTArray
 
 ex1 = ProgramFile mi77 [ ex1pu1 ]
-ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) False "f1" Nothing Nothing [] Nothing
+ex1pu1 = PUFunction () u (Just $ TypeSpec () u TypeInteger Nothing) (None () False) "f1" Nothing Nothing [] Nothing
 
 ex2 = ProgramFile mi77 [ ex2pu1, ex1pu1 ]
 ex2pu1 = PUSubroutine () u False "s1" Nothing [] Nothing
@@ -129,7 +129,7 @@ ex6pu1bs =
       (ExpSubscript () u (varGen "d") (fromList () [ ixSinGen 1 ])) (intGen 1)) ]
 
 ex11 = ProgramFile mi77 [ ex11pu1 ]
-ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) False "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
+ex11pu1 = PUFunction () u (Just (TypeSpec () u TypeInteger Nothing)) (None () False) "f1" Nothing (Just (varGen "r1")) ex11pu1bs Nothing
 ex11pu1bs =
   [ BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e1")) Nothing Nothing)
   , BlStatement () u Nothing (StEntry () u (ExpValue () u (ValVariable "e2")) Nothing Nothing)

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -33,7 +33,7 @@ spec =
     describe "Function" $ do
       it "parses basic functions" $ do
         let stType = Just $ TypeSpec () u TypeInteger Nothing
-        let stOpt = None () False
+        let stOpt = None () u False
         let stArgs = Just $ AList () u [ varGen "x", varGen "y", varGen "z" ]                                                     
         let stRes = Just $ varGen "i"                                                                                      
         let decrementRHS = ExpBinary () u Subtraction (varGen "i") (intGen 1)

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -73,6 +73,16 @@ spec =
         let st = StExpressionAssign () u lhs (intGen 1)
         sParser "x(1) % y = 1" `shouldBe'` st
 
+      it "parses pause statements" $ do
+        let stPause = StPause () u Nothing
+        let stStr = "PAUSE"
+        sParser stStr `shouldBe'` stPause
+        
+      it "parses pause statements with expression" $ do
+        let stPause = StPause () u (Just (strGen "MESSAGE"))
+        let stStr = "PAUSE \"MESSAGE\""
+        sParser stStr `shouldBe'` stPause
+
       it "parses declaration with attributes" $ do
         let typeSpec = TypeSpec () u TypeReal Nothing
         let attrs = AList () u [ AttrExternal () u

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -24,9 +24,36 @@ sParser :: String -> Statement ()
 sParser sourceCode =
   evalParse statementParser $ initParseState (B.pack sourceCode) Fortran95 "<unknown>"
 
+fParser :: String -> ProgramUnit ()
+fParser sourceCode =
+  evalParse functionParser $ initParseState (B.pack sourceCode) Fortran95 "<unknown>"
+
+{- Useful for parser debugging; Lexes the given source code.
+ - fTok :: String -> [Token]
+ - fTok sourceCode = collectFreeTokens Fortran95 $ B.pack sourceCode
+ -}
+
 spec :: Spec
 spec =
   describe "Fortran 95 Parser" $ do
+    describe "Function" $ do
+      it "parses basic functions" $ do
+        let stType = Just $ TypeSpec () u TypeInteger Nothing
+        let stOpt = None () False
+        let stArgs = Just $ AList () u [ varGen "x", varGen "y", varGen "z" ]                                                     
+        let stRes = Just $ varGen "i"                                                                                      
+        let decrementRHS = ExpBinary () u Subtraction (varGen "i") (intGen 1)
+        let st1 = StPrint () u starVal (Just $ AList () u [ varGen "i" ])                                                      
+        let st2 = StExpressionAssign () u (varGen "i") decrementRHS
+        let stBody = [ BlStatement () u Nothing st1 , BlStatement () u Nothing st2 ]
+        let stSub = Nothing
+        let expected = PUFunction () u stType stOpt "f" stArgs stRes stBody stSub
+        let stStr = init $ unlines [ "integer function f(x, y, z) result(i)"                                                 
+                             , "  print *, i"                                                                          
+                             , "  i = (i - 1)"                                                                         
+                             , "end function f" ]                                                                      
+        fParser stStr `shouldBe'` expected
+
     describe "Expression" $ do
       it "parses logial literals with kind" $ do
         let expected = ExpValue () u (ValLogical ".true._kind")

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -33,7 +33,7 @@ fParser sourceCode =
 {- Useful for parser debugging; Lexes the given source code.
 fTok :: String -> [Token]
 fTok sourceCode = collectFreeTokens Fortran95 $ B.pack sourceCode
- -}
+-}
 
 {-
  - Given a list of values, find every combination of those values:
@@ -93,11 +93,11 @@ spec =
           let fStr = str ++ (init $ unlines ["function f()", "end"])
           let opt = buildPUFunctionOpts opts
           let expected = puFunction fType 
-          it (show fStr) $ do
-            case opt of
-              Left _ -> evaluate (fParser fStr) `shouldThrow` anyIOException
-              Right fOpt ->
-                let expected = puFunction fType fOpt fName fArgs fRes fBody fSub in
+          case opt of
+            Left _ -> it ("Shouldn't parse: " ++ show fStr ++ ": " ++ show opt) $ evaluate (fParser fStr) `shouldThrow` anyIOException
+            Right fOpt ->
+              it ("Should parse: " ++ show fStr ++ ": " ++ show opt) $ do
+                let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
                 fParser fStr `shouldBe'` expected
           )
 

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -1,0 +1,426 @@
+module Language.Fortran.Parser.Fortran95ExperimentalSpec (spec) where
+
+import Prelude hiding (GT)
+
+import TestUtil
+import Test.Hspec
+
+import Language.Fortran.AST
+import Language.Fortran.ParserMonad
+import Language.Fortran.Lexer.FreeForm
+import Language.Fortran.Parser.Fortran95Experimental
+import qualified Data.ByteString.Char8 as B
+
+eParser :: String -> Expression ()
+eParser sourceCode =
+  case evalParse statementParser parseState of
+    (StExpressionAssign _ _ _ e) -> e
+  where
+    paddedSourceCode = B.pack $ "      a = " ++ sourceCode
+    parseState =  initParseState paddedSourceCode Fortran95 "<unknown>"
+
+sParser :: String -> Statement ()
+sParser sourceCode =
+  evalParse statementParser $ initParseState (B.pack sourceCode) Fortran95 "<unknown>"
+
+spec :: Spec
+spec =
+  describe "Fortran 95 Parser" $ do
+    describe "Expression" $ do
+      it "parses logial literals with kind" $ do
+        let expected = ExpValue () u (ValLogical ".true._kind")
+        eParser ".true._kind" `shouldBe'` expected
+
+      it "parses array initialisation exp" $ do
+        let list = AList () u [ intGen 1, intGen 2, intGen 3, intGen 4 ]
+        eParser "(/ 1, 2, 3, 4 /)" `shouldBe'` ExpInitialisation () u list
+
+      describe "Custom operator" $ do
+        let unOp = UnCustom ".inverse."
+        let unExp = ExpUnary () u unOp $ intGen 42
+
+        it "parses unary custom operator" $
+          eParser ".inverse. 42" `shouldBe'` unExp
+
+        let binOp = BinCustom ".xor."
+        it "parses binary custom operator" $ do
+          let expected = ExpBinary () u binOp (intGen 24) (intGen 42)
+          eParser "24 .xor. 42" `shouldBe'` expected
+
+        it "parses mixed unary custom operator" $ do
+          let binExp = ExpBinary () u binOp unExp (intGen 24)
+          eParser ".inverse. 42 .xor. 24" `shouldBe'` binExp
+
+        it "parses data ref" $ do
+          let range = fromList () [ IxSingle () u Nothing $ intGen 10 ]
+          let sub = ExpSubscript () u (varGen "y") range
+          let innerRefExp = ExpDataRef () u (varGen "x") sub
+          let exp = ExpDataRef () u innerRefExp (varGen "z")
+          eParser "x % y(10) % z" `shouldBe'` exp
+
+        it "parses section subscript" $ do
+          let range = [ IxSingle () u Nothing $ intGen 10
+                      , IxRange () u Nothing (Just $ intGen 1) (Just $ intGen 2)
+                      , IxSingle () u Nothing $ varGen "y" ]
+          let exp = ExpSubscript () u (varGen "x") (fromList () range)
+          eParser "x (10, : 1 : 2, y)" `shouldBe'` exp
+
+    describe "Statement" $ do
+      it "data ref assignment" $ do
+        let indicies = AList () u [ IxSingle () u Nothing (intGen 1) ]
+        let subs = ExpSubscript () u (varGen "x") indicies
+        let lhs = ExpDataRef () u subs (varGen "y")
+        let st = StExpressionAssign () u lhs (intGen 1)
+        sParser "x(1) % y = 1" `shouldBe'` st
+
+      it "parses declaration with attributes" $ do
+        let typeSpec = TypeSpec () u TypeReal Nothing
+        let attrs = AList () u [ AttrExternal () u
+                               , AttrIntent () u Out
+                               , AttrDimension () u $ AList () u
+                                  [ DimensionDeclarator () u
+                                      (Just $ intGen 3) (Just $ intGen 10)
+                                  ]
+                               ]
+        let declarators = AList () u
+              [ DeclVariable () u (varGen "x") Nothing Nothing
+              , DeclVariable () u (varGen "y") Nothing Nothing ]
+        let expected = StDeclaration () u typeSpec (Just attrs) declarators
+        let stStr = "real, external, intent (out), dimension (3:10) :: x, y"
+        sParser stStr `shouldBe'` expected
+
+      it "parses declaration with old syntax" $ do
+        let typeSpec = TypeSpec () u TypeLogical Nothing
+        let declarators = AList () u
+              [ DeclVariable () u (varGen "x") Nothing Nothing
+              , DeclVariable () u (varGen "y") Nothing Nothing ]
+        let expected = StDeclaration () u typeSpec Nothing declarators
+        let stStr = "logical x, y"
+        sParser stStr `shouldBe'` expected
+
+      it "parses declaration with initialisation" $ do
+        let typeSpec = TypeSpec () u TypeComplex Nothing
+        let init = ExpValue () u (ValComplex (intGen 24) (realGen 42.0))
+        let declarators = AList () u
+              [ DeclVariable () u (varGen "x") Nothing (Just init) ]
+        let expected = StDeclaration () u typeSpec Nothing declarators
+        let stStr = "complex :: x = (24, 42.0)"
+        sParser stStr `shouldBe'` expected
+
+      it "parses declaration of custom type" $ do
+        let typeSpec = TypeSpec () u (TypeCustom "meinetype") Nothing
+        let declarators = AList () u
+              [ DeclVariable () u (varGen "x") Nothing Nothing ]
+        let expected = StDeclaration () u typeSpec Nothing declarators
+        let stStr = "type (MeineType) :: x"
+        sParser stStr `shouldBe'` expected
+
+      it "parses declaration type with kind selector" $ do
+        let selector = Selector () u Nothing (Just $ varGen "hello")
+        let typeSpec = TypeSpec () u TypeInteger (Just selector)
+        let declarators = AList () u
+              [ DeclVariable () u (varGen "x") Nothing Nothing ]
+        let expected = StDeclaration () u typeSpec Nothing declarators
+        let stStr = "integer (hello) :: x"
+        sParser stStr `shouldBe'` expected
+
+      it "parses intent statement" $ do
+        let stStr = "intent (inout) :: a"
+        let expected = StIntent () u InOut (fromList () [ varGen "a" ])
+        sParser stStr `shouldBe'` expected
+
+      it "parses optional statement" $ do
+        let stStr = "optional x"
+        let expected = StOptional () u (fromList () [ varGen "x" ])
+        sParser stStr `shouldBe'` expected
+
+      it "parses public statement" $ do
+        let stStr = "public :: x"
+        let expected = StPublic () u (Just $ fromList () [ varGen "x" ])
+        sParser stStr `shouldBe'` expected
+
+      it "parses public assignment" $ do
+        let expected = StPublic () u (Just $ fromList () [ assVal ])
+        sParser "public :: assignment (=)" `shouldBe'` expected
+
+      it "parses private statement" $
+        sParser "private" `shouldBe'` StPrivate () u Nothing
+
+      it "parses private operator" $ do
+        let expected = StPrivate () u (Just $ fromList () [ opGen "*" ])
+        sParser "private operator ( * )" `shouldBe'` expected
+
+      it "parses save statement" $ do
+        let list = [ varGen "hello", varGen "bye" ]
+        let expected = StSave () u (Just $ fromList () list)
+        let stStr = "save /hello/, bye"
+        sParser stStr `shouldBe'` expected
+
+      it "parses parameter statement" $ do
+        let ass1 = DeclVariable () u (varGen "x") Nothing (Just $ intGen 10)
+        let ass2 = DeclVariable () u (varGen "y") Nothing (Just $ intGen 20)
+        let expected = StParameter () u (fromList () [ ass1, ass2 ])
+        sParser "parameter (x = 10, y = 20)" `shouldBe'` expected
+
+      describe "Implicit" $ do
+        it "parses implicit none" $ do
+          let st = StImplicit () u Nothing
+          sParser "implicit none" `shouldBe'` st
+
+        it "parses implicit with single" $ do
+          let typeSpec = TypeSpec () u TypeCharacter Nothing
+          let impEls = [ ImpCharacter () u "k" ]
+          let impLists = [ ImpList () u typeSpec (fromList () impEls) ]
+          let st = StImplicit () u (Just $ fromList () impLists)
+          sParser "implicit character (k)" `shouldBe'` st
+
+        it "parses implicit with range" $ do
+          let typeSpec = TypeSpec () u TypeLogical Nothing
+          let impEls = [ ImpRange () u "x" "z" ]
+          let impLists = [ ImpList () u typeSpec (fromList () impEls) ]
+          let st = StImplicit () u (Just $ fromList () impLists)
+          sParser "implicit logical (x-z)" `shouldBe'` st
+
+        it "parses implicit statement" $ do
+          let typeSpec1 = TypeSpec () u TypeCharacter Nothing
+          let typeSpec2 = TypeSpec () u TypeInteger Nothing
+          let impEls1 = [ ImpCharacter () u "s", ImpCharacter () u "a" ]
+          let impEls2 = [ ImpRange () u "x" "z" ]
+          let impLists = [ ImpList () u typeSpec1 (fromList () impEls1)
+                         , ImpList () u typeSpec2 (fromList () impEls2) ]
+          let st = StImplicit () u (Just $ fromList () impLists)
+          sParser "implicit character (s, a), integer (x-z)" `shouldBe'` st
+
+      describe "Data" $ do
+        it "parses vanilla" $ do
+          let nlist = fromList () [ varGen "x", varGen "y" ]
+          let vlist = fromList () [ intGen 1, intGen 2 ]
+          let list = [ DataGroup () u nlist vlist ]
+          let expected = StData () u (fromList () list)
+          let stStr = "data x,y/1,2/"
+          sParser stStr `shouldBe'` expected
+
+        describe "Delimeter" $ do
+          let [ nlist1, vlist1 ] =
+                map (fromList () . return) [ varGen "x", intGen 1 ]
+          let [ nlist2, vlist2 ] =
+                map (fromList () . return) [ varGen "y", intGen 2 ]
+          let list = [ DataGroup () u nlist1 vlist1
+                     , DataGroup () u nlist2 vlist2 ]
+          let expected = StData () u (fromList () list)
+
+          it "parses comma delimited init groups" $
+            sParser "data x/1/, y/2/" `shouldBe'` expected
+
+          it "parses non-comma delimited init groups" $
+            sParser "data x/1/ y/2/" `shouldBe'` expected
+
+      describe "Namelist" $ do
+        let groupNames = [ ExpValue () u (ValVariable "something")
+                         , ExpValue () u (ValVariable "other") ]
+        let itemss = [ fromList () [ varGen "a", varGen "b", varGen "c" ]
+                     , fromList () [ varGen "y" ] ]
+        let st = StNamelist () u $
+              fromList () [ Namelist () u (head groupNames) (head itemss)
+                          , Namelist () u (last groupNames) (last itemss) ]
+
+        it "parses namelist statement (comma delimited) (1)" $
+          sParser "namelist /something/a,b,c,/other/y" `shouldBe'` st
+
+        it "parses namelist statement (2)" $
+          sParser "namelist /something/a,b,c/other/y" `shouldBe'` st
+
+      describe "Common" $ do
+        let commonNames = [ ExpValue () u (ValVariable "something")
+                          , ExpValue () u (ValVariable "other") ]
+        let itemss = [ fromList () [ varGen "a", varGen "b", varGen "c" ]
+                     , fromList () [ varGen "y" ] ]
+        let st = StCommon () u $ fromList ()
+              [ CommonGroup () u Nothing (fromList () [ varGen "q" ])
+              , CommonGroup () u (Just $ head commonNames) (head itemss)
+              , CommonGroup () u (Just $ last commonNames) (last itemss) ]
+
+        it "parses common statement (comma delimited) (1)" $
+          sParser "common q /something/a,b,c, /other/y" `shouldBe'` st
+
+        it "parses common statement (2)" $
+          sParser "common q /something/a,b,c /other/y" `shouldBe'` st
+
+      it "parses equivalence statement" $ do
+        let eqALists = fromList ()
+              [ fromList ()
+                  [ let indicies = fromList () [ IxSingle () u Nothing (intGen 1) ]
+                    in ExpSubscript () u (varGen "a") indicies
+                  , varGen "x"
+                  ]
+              , fromList ()
+                  [ varGen "y"
+                  , varGen "z"
+                  , let indicies = fromList () [ IxRange () u (Just $ intGen 1)
+                                                              (Just $ intGen 42)
+                                                              Nothing ]
+                    in ExpSubscript () u (varGen "d") indicies
+                  ]
+              ]
+        let st = StEquivalence () u eqALists
+        sParser "equivalence (a(1), x), (y, z, d(1:42))" `shouldBe'` st
+
+      describe "Dynamic allocation" $ do
+        it "parses allocate statement" $ do
+          let controlPair = ControlPair () u (Just "stat") (varGen "a")
+          let allocs = fromList ()
+                [ varGen "x"
+                , ExpDataRef () u (varGen "st") (varGen "part")
+                ]
+          let s = StAllocate () u allocs (Just controlPair)
+          sParser "allocate (x, st % part, STAT = a)" `shouldBe'` s
+
+        it "parses deallocate statement" $ do
+          let allocs = fromList ()
+                [ let indicies = fromList () [ IxSingle () u Nothing (intGen 20) ]
+                  in ExpSubscript () u (varGen "smt") indicies
+                ]
+          let s = StDeallocate () u allocs Nothing
+          sParser "deallocate (smt ( 20 ))" `shouldBe'` s
+
+        it "parses nullify statement" $ do
+          let s = StNullify () u (fromList () [ varGen "x" ])
+          sParser "nullify (x)" `shouldBe'` s
+
+      it "parses pointer assignment" $ do
+        let src = ExpDataRef () u (varGen "x") (varGen "y")
+        let st = StPointerAssign () u src (varGen "exp")
+        sParser "x % y => exp" `shouldBe'` st
+
+      describe "Where" $ do
+        it "parses where statement" $ do
+          let exp = ExpBinary () u Subtraction (varGen "temp") (varGen "r_temp")
+          let pred = ExpBinary () u GT (varGen "temp") (intGen 100)
+          let assignment = StExpressionAssign () u (varGen "temp") exp
+          let st = StWhere () u pred assignment
+          sParser "where (temp > 100) temp = temp - r_temp"`shouldBe'` st
+
+        describe "Where block" $ do
+          it "parses where construct statement" $
+            sParser "where (.true.)" `shouldBe'` StWhereConstruct () u valTrue
+
+          it "parses elsewhere statement" $
+            sParser "elsewhere" `shouldBe'` StElsewhere () u
+
+          it "parses endwhere statement" $
+            sParser "endwhere" `shouldBe'` StEndWhere () u
+
+    describe "If" $ do
+      it "parses if-then statement" $
+        sParser "if (.false.) then" `shouldBe'` StIfThen () u Nothing valFalse
+
+      it "parses if-then statement with construct name" $ do
+        let st = StIfThen () u (Just "my_if") valFalse
+        sParser "my_if: if (.false.) then" `shouldBe'` st
+
+      it "parses else statement" $
+        sParser "else" `shouldBe'` StElse () u Nothing
+
+      it "parses else-if statement" $
+        sParser "else if (.true.) then" `shouldBe'` StElsif () u Nothing valTrue
+
+      it "parses end if statement" $
+        sParser "end if" `shouldBe'` StEndif () u Nothing
+
+      it "parses logical if statement" $ do
+        let assignment = StExpressionAssign () u (varGen "a") (varGen "b")
+        let stIf = StIfLogical () u valTrue assignment
+        sParser "if (.true.) a = b" `shouldBe'` stIf
+
+      it "parses arithmetic if statement" $ do
+        let stIf = StIfArithmetic () u (varGen "x") (intGen 1)
+                                                    (intGen 2)
+                                                    (intGen 3)
+        sParser "if (x) 1, 2, 3" `shouldBe'` stIf
+
+    describe "Case" $ do
+      it "parses select case statement" $ do
+        let st = StSelectCase () u Nothing (varGen "n")
+        sParser "select case (n)" `shouldBe'` st
+
+      it "parses select case statement with construct name" $ do
+        let st = StSelectCase () u (Just "case") (varGen "n")
+        sParser "case: select case (n)" `shouldBe'` st
+
+      it "parses case statement" $ do
+        let ranges = AList () u [ IxRange () u (Just $ intGen 42) Nothing Nothing ]
+        sParser "case (42:)" `shouldBe'` StCase () u Nothing (Just ranges)
+
+      it "parses case statement" $
+        sParser "case default" `shouldBe'` StCase () u Nothing Nothing
+
+      it "parses end select statement" $ do
+        let st = StEndcase () u (Just "name")
+        sParser "end select name" `shouldBe'` st
+
+    describe "Do" $ do
+      it "parses do statement with label" $ do
+        let assign = StExpressionAssign () u (varGen "i") (intGen 0)
+        let doSpec = DoSpecification () u assign (intGen 42) Nothing
+        let st = StDo () u Nothing (Just $ intGen 24) (Just doSpec)
+        sParser "do 24, i = 0, 42" `shouldBe'` st
+
+      it "parses do statement without label" $ do
+        let assign = StExpressionAssign () u (varGen "i") (intGen 0)
+        let doSpec = DoSpecification () u assign (intGen 42) Nothing
+        let st = StDo () u Nothing Nothing (Just doSpec)
+        sParser "do i = 0, 42" `shouldBe'` st
+
+      it "parses infinite do" $ do
+        let st = StDo () u Nothing Nothing Nothing
+        sParser "do" `shouldBe'` st
+
+      it "parses end do statement" $ do
+        let st = StEnddo () u (Just "constructor")
+        sParser "end do constructor" `shouldBe'` st
+
+      it "parses end do while statement" $ do
+        let st = StDoWhile () u (Just "name") Nothing valTrue
+        sParser "name: do while (.true.)" `shouldBe'` st
+
+    describe "Goto" $ do
+      it "parses vanilla goto" $ do
+        let st = StGotoUnconditional () u (intGen 999)
+        sParser "goto 999" `shouldBe'` st
+
+      it "parses computed goto" $ do
+        let list = fromList () [ intGen 10, intGen 20, intGen 30 ]
+        let st = StGotoComputed () u list (intGen 20)
+        sParser "goto (10, 20, 30) 20" `shouldBe'` st
+
+      it "parses assigned goto" $ do
+        let list = fromList () [ intGen 10, intGen 20, intGen 30 ]
+        let st = StGotoAssigned () u (varGen "i") list
+        sParser "goto i, (10, 20, 30)" `shouldBe'` st
+
+      it "parses label assignment" $ do
+        let st = StLabelAssign () u (intGen 20) (varGen "l")
+        sParser "assign 20 to l" `shouldBe'` st
+
+    describe "IO" $ do
+      it "parses vanilla print" $ do
+        let st = StPrint () u starVal (Just $ fromList () [ varGen "hex" ])
+        sParser "print *, hex" `shouldBe'` st
+
+      it "parses write with implied do" $ do
+        let cp1 = ControlPair () u Nothing (intGen 10)
+        let cp2 = ControlPair () u (Just "format") (varGen "x")
+        let ciList = fromList () [ cp1, cp2 ]
+        let assign = StExpressionAssign () u (varGen "i") (intGen 1)
+        let doSpec = DoSpecification () u assign (intGen 42) (Just $ intGen 2)
+        let alist = fromList () [ varGen "i", varGen "j" ]
+        let outList = fromList () [ ExpImpliedDo () u alist doSpec ]
+        let st = StWrite () u ciList (Just outList)
+        sParser "write (10, FORMAT = x) (i, j,  i = 1, 42, 2)" `shouldBe'` st
+
+    it "parses use statement" $ do
+      let renames = fromList ()
+            [ UseRename () u (varGen "sprod") (varGen "prod")
+            , UseRename () u (varGen "a") (varGen "b") ]
+      let st = StUse () u (varGen "stats_lib") Permissive (Just renames)
+      sParser "use stats_lib, sprod => prod, a => b" `shouldBe'` st

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -29,30 +29,90 @@ fParser sourceCode =
   evalParse functionParser $ initParseState (B.pack sourceCode) Fortran95 "<unknown>"
 
 {- Useful for parser debugging; Lexes the given source code.
- - fTok :: String -> [Token]
- - fTok sourceCode = collectFreeTokens Fortran95 $ B.pack sourceCode
+fTok :: String -> [Token]
+fTok sourceCode = collectFreeTokens Fortran95 $ B.pack sourceCode
  -}
 
 spec :: Spec
 spec =
   describe "Fortran 95 Parser" $ do
     describe "Function" $ do
-      it "parses basic functions" $ do
-        let stType = Just $ TypeSpec () u TypeInteger Nothing
-        let stOpt = None () False
-        let stArgs = Just $ AList () u [ varGen "x", varGen "y", varGen "z" ]                                                     
-        let stRes = Just $ varGen "i"                                                                                      
+      let puFunction = PUFunction () u
+      let fType = Nothing
+      let fOpt = None () False
+      let fName = "f"
+      let fArgs = Nothing
+      let fRes = Nothing
+      let fBody = []
+      let fSub = Nothing
+
+      describe "End" $ do
+        it "parses simple functions ending with \"end function [function name]\"" $ do
+          let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+          let fStr = init $ unlines ["function f()"
+                               , "end function f" ]
+          fParser fStr `shouldBe'` expected
+
+        it "parses simple functions ending with \"end\"" $ do
+          let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+          let fStr = init $ unlines ["function f()"
+                               , "end" ]
+          fParser fStr `shouldBe'` expected
+
+        it "parses simple functions ending with \"end function\"" $ do
+          let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+          let fStr = init $ unlines ["function f()"
+                               , "end function" ]
+          fParser fStr `shouldBe'` expected
+
+
+        it "parses functions with return type specs" $ do
+          let fType = Just $ TypeSpec () u TypeInteger Nothing
+          let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+          let fStr = init $ unlines ["integer function f()"
+                               , "end function f" ]
+          fParser fStr `shouldBe'` expected
+
+      it "parses functions with a list of arguments" $ do
+        let fArgs = Just $ AList () u [ varGen "x", varGen "y", varGen "z" ]                                                     
+        let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+        let fStr = init $ unlines ["function f(x, y, z)"
+                             , "end function f" ]
+        fParser fStr `shouldBe'` expected
+
+      it "parses functions with a result variable" $ do
+        let fRes = Just $ varGen "i"
+        let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+        let fStr = init $ unlines ["function f() result(i)"
+                             , "end function f" ]
+        fParser fStr `shouldBe'` expected
+
+      it "parses functions with function bodies" $ do
         let decrementRHS = ExpBinary () u Subtraction (varGen "i") (intGen 1)
-        let st1 = StPrint () u starVal (Just $ AList () u [ varGen "i" ])                                                      
-        let st2 = StExpressionAssign () u (varGen "i") decrementRHS
-        let stBody = [ BlStatement () u Nothing st1 , BlStatement () u Nothing st2 ]
-        let stSub = Nothing
-        let expected = PUFunction () u stType stOpt "f" stArgs stRes stBody stSub
-        let stStr = init $ unlines [ "integer function f(x, y, z) result(i)"                                                 
+        let f1 = StPrint () u starVal (Just $ AList () u [ varGen "i" ])                                                      
+        let f2 = StExpressionAssign () u (varGen "i") decrementRHS
+        let fBody = [ BlStatement () u Nothing f1 , BlStatement () u Nothing f2 ]
+        let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+        let fStr = init $ unlines ["function f()"
+                             , "  print *, i"                                                                          
+                             , "  i = (i - 1)"                                                                         
+                             , "end function f" ]
+        fParser fStr `shouldBe'` expected
+
+      it "parses complex functions" $ do
+        let fType = Just $ TypeSpec () u TypeInteger Nothing
+        let fArgs = Just $ AList () u [ varGen "x", varGen "y", varGen "z" ]                                                     
+        let fRes = Just $ varGen "i"                                                                                      
+        let decrementRHS = ExpBinary () u Subtraction (varGen "i") (intGen 1)
+        let f1 = StPrint () u starVal (Just $ AList () u [ varGen "i" ])                                                      
+        let f2 = StExpressionAssign () u (varGen "i") decrementRHS
+        let fBody = [ BlStatement () u Nothing f1 , BlStatement () u Nothing f2 ]
+        let expected = puFunction fType fOpt fName fArgs fRes fBody fSub
+        let fStr = init $ unlines [ "integer function f(x, y, z) result(i)"                                                 
                              , "  print *, i"                                                                          
                              , "  i = (i - 1)"                                                                         
                              , "end function f" ]                                                                      
-        fParser stStr `shouldBe'` expected
+        fParser fStr `shouldBe'` expected
 
     describe "Expression" $ do
       it "parses logial literals with kind" $ do

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -82,7 +82,7 @@ spec =
                                , "end function f" ]
           fParser fStr `shouldBe'` expected
 
-      it "parses function options (recursive, pure, elemental)" $ do
+      describe "parses function options (recursive, pure, elemental)" $ do
         let options_list = map unzip $ combination
                                         [ ("recursive ", None () True)
                                         , ("pure ", Pure () False)
@@ -90,14 +90,15 @@ spec =
 
         forM_ options_list (\(strs, opts) -> do
           let str = foldr (++) "" strs
-          let fStr = str ++ "function f()\nend"
+          let fStr = str ++ (init $ unlines ["function f()", "end"])
           let opt = buildPUFunctionOpts opts
           let expected = puFunction fType 
-          case opt of
-            Left _ -> evaluate (fParser fStr) `shouldThrow` anyIOException
-            Right fOpt ->
-              let expected = puFunction fType fOpt fName fArgs fRes fBody fSub in
-              fParser fStr `shouldBe'` expected
+          it (show fStr) $ do
+            case opt of
+              Left _ -> evaluate (fParser fStr) `shouldThrow` anyIOException
+              Right fOpt ->
+                let expected = puFunction fType fOpt fName fArgs fRes fBody fSub in
+                fParser fStr `shouldBe'` expected
           )
 
       it "parses functions with a list of arguments" $ do

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -74,6 +74,10 @@ spec =
         let st = StExpressionAssign () u lhs (intGen 1)
         sParser "x(1) % y = 1" `shouldBe'` st
 
+      it "doesn't parse assign statements" $ do
+        let stStr = "ASSIGN 1 \"LABEL\""
+        evaluate (sParser stStr) `shouldThrow` anyIOException
+
       it "doesn't parse pause statements" $ do
         let stStr = "PAUSE"
         evaluate (sParser stStr) `shouldThrow` anyIOException
@@ -402,14 +406,11 @@ spec =
         let st = StGotoComputed () u list (intGen 20)
         sParser "goto (10, 20, 30) 20" `shouldBe'` st
 
-      it "parses assigned goto" $ do
-        let list = fromList () [ intGen 10, intGen 20, intGen 30 ]
-        let st = StGotoAssigned () u (varGen "i") list
-        sParser "goto i, (10, 20, 30)" `shouldBe'` st
+      it "doesn't parse assigned goto" $ do
+        evaluate (sParser "goto i, (10, 20, 30)") `shouldThrow` anyIOException
 
-      it "parses label assignment" $ do
-        let st = StLabelAssign () u (intGen 20) (varGen "l")
-        sParser "assign 20 to l" `shouldBe'` st
+      it "doesn't parse label assignment" $ do
+        evaluate (sParser "assign 20 to l") `shouldThrow` anyIOException
 
     describe "IO" $ do
       it "parses vanilla print" $ do

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -4,6 +4,7 @@ import Prelude hiding (GT)
 
 import TestUtil
 import Test.Hspec
+import Control.Exception (evaluate)
 
 import Language.Fortran.AST
 import Language.Fortran.ParserMonad
@@ -72,6 +73,14 @@ spec =
         let lhs = ExpDataRef () u subs (varGen "y")
         let st = StExpressionAssign () u lhs (intGen 1)
         sParser "x(1) % y = 1" `shouldBe'` st
+
+      it "parses pause statements" $ do
+        let stStr = "PAUSE"
+        evaluate (sParser stStr) `shouldThrow` anyIOException
+        
+      it "parses pause statements with expression" $ do
+        let stStr = "PAUSE \"MESSAGE\""
+        evaluate (sParser stStr) `shouldThrow` anyIOException
 
       it "parses declaration with attributes" $ do
         let typeSpec = TypeSpec () u TypeReal Nothing

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -48,7 +48,7 @@ spec =
     describe "Function" $ do
       let puFunction = PUFunction () u
       let fType = Nothing
-      let fOpt = None () False
+      let fOpt = None () u False
       let fName = "f"
       let fArgs = Nothing
       let fRes = Nothing
@@ -84,9 +84,9 @@ spec =
 
       describe "parses function options (recursive, pure, elemental)" $ do
         let options_list = map unzip $ combination
-                                        [ ("recursive ", None () True)
-                                        , ("pure ", Pure () False)
-                                        , ("elemental ", Elemental ()) ]
+                                        [ ("recursive ", None () u True)
+                                        , ("pure ", Pure () u False)
+                                        , ("elemental ", Elemental () u) ]
 
         forM_ options_list (\(strs, opts) -> do
           let str = foldr (++) "" strs

--- a/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran95ExperimentalSpec.hs
@@ -74,11 +74,11 @@ spec =
         let st = StExpressionAssign () u lhs (intGen 1)
         sParser "x(1) % y = 1" `shouldBe'` st
 
-      it "parses pause statements" $ do
+      it "doesn't parse pause statements" $ do
         let stStr = "PAUSE"
         evaluate (sParser stStr) `shouldThrow` anyIOException
         
-      it "parses pause statements with expression" $ do
+      it "doesn't parse pause statements with expression" $ do
         let stStr = "PAUSE \"MESSAGE\""
         evaluate (sParser stStr) `shouldThrow` anyIOException
 

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -448,7 +448,7 @@ spec =
         it "prints function with args with result without sub programs" $ do
           let args = AList () u [ varGen "x", varGen "y", varGen "z" ]
           let res = Just $ varGen "i"
-          let fun = PUFunction () u tSpec (None () False) "f" (Just args) res body Nothing
+          let fun = PUFunction () u tSpec (None () u False) "f" (Just args) res body Nothing
           let expect = unlines [ "  integer function f(x, y, z) result(i)"
                                , "    print *, i"
                                , "    i = (i - 1)"

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -448,7 +448,7 @@ spec =
         it "prints function with args with result without sub programs" $ do
           let args = AList () u [ varGen "x", varGen "y", varGen "z" ]
           let res = Just $ varGen "i"
-          let fun = PUFunction () u tSpec False "f" (Just args) res body Nothing
+          let fun = PUFunction () u tSpec (None () False) "f" (Just args) res body Nothing
           let expect = unlines [ "  integer function f(x, y, z) result(i)"
                                , "    print *, i"
                                , "    i = (i - 1)"

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -90,7 +90,7 @@ expectedEx1pu1bs =
 -}
 ex2 = ProgramFile mi77 [ ex2pu1, ex2pu2 ]
 ex2pu1 = PUMain () u Nothing ex2pu1bs Nothing
-ex2pu2 = PUFunction () u Nothing (None () False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
+ex2pu2 = PUFunction () u Nothing (None () u False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
 ex2pu1bs =
   [ BlStatement () u Nothing
       (StFunction () u
@@ -124,7 +124,7 @@ expectedEx2pu1bs =
 
 ex3 = ProgramFile mi77 [ ex3pu1, ex3pu2 ]
 ex3pu1 = PUMain () u Nothing ex3pu1bs Nothing
-ex3pu2 = PUFunction () u Nothing (None () False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
+ex3pu2 = PUFunction () u Nothing (None () u False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
 ex3pu1bs =
   [ BlStatement () u Nothing
       (StFunction () u

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -90,7 +90,7 @@ expectedEx1pu1bs =
 -}
 ex2 = ProgramFile mi77 [ ex2pu1, ex2pu2 ]
 ex2pu1 = PUMain () u Nothing ex2pu1bs Nothing
-ex2pu2 = PUFunction () u Nothing False "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
+ex2pu2 = PUFunction () u Nothing (None () False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
 ex2pu1bs =
   [ BlStatement () u Nothing
       (StFunction () u
@@ -124,7 +124,7 @@ expectedEx2pu1bs =
 
 ex3 = ProgramFile mi77 [ ex3pu1, ex3pu2 ]
 ex3pu1 = PUMain () u Nothing ex3pu1bs Nothing
-ex3pu2 = PUFunction () u Nothing False "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
+ex3pu2 = PUFunction () u Nothing (None () False) "y" (Just $ AList () u [ varGen "i", varGen "j" ]) Nothing [ ] Nothing
 ex3pu1bs =
   [ BlStatement () u Nothing
       (StFunction () u


### PR DESCRIPTION
@harry-clarke Just specified that we have (after this is complete) support for Fortran 95 in readme.