### PR TITLE
extend Fortran77 lexer/parser with support for legacy extensions

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -123,6 +123,7 @@ test-suite spec
     Language.Fortran.Parser.Fortran66Spec
     Language.Fortran.Parser.Fortran77Spec
     Language.Fortran.Parser.Fortran90Spec
+    Language.Fortran.Parser.Fortran95Spec
     Language.Fortran.Parser.UtilsSpec
     Language.Fortran.ParserMonadSpec
     Language.Fortran.PrettyPrintSpec

--- a/src/Language/Fortran/Intrinsics.hs
+++ b/src/Language/Fortran/Intrinsics.hs
@@ -143,6 +143,10 @@ fortran77intrinsics = M.fromList
   , ("lgt"     , mkIEntry ITLogical func2)
   , ("lle"     , mkIEntry ITLogical func2)
   , ("llt"     , mkIEntry ITLogical func2)
+  -- https://gcc.gnu.org/onlinedocs/gfortran/Argument-list-functions.html
+  , ("%loc", mkIEntry (ITParam 1) func1)
+  , ("%ref", mkIEntry (ITParam 1) func1)
+  , ("%val", mkIEntry (ITParam 1) func1)
   ]
 
 fortran90intrinisics :: IntrinsicsTable

--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -1,5 +1,6 @@
 -- -*- Mode: Haskell -*-
 {
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -7,12 +8,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Language.Fortran.Lexer.FixedForm where
+module Language.Fortran.Lexer.FixedForm
+  ( lexer, initParseState, collectFixedTokens, collectFixedTokensSafe
+  , Token(..), LexAction, AlexInput(..), lexemeMatch, lexN
+  ) where
 
 import Data.Word (Word8)
-import Data.Char (toLower, ord)
+import Data.Char (toLower, ord, isDigit)
 import Data.List (isPrefixOf, any)
-import Data.Maybe (fromJust, isNothing)
+import Data.Maybe (fromJust, isNothing, isJust)
 import Data.Data
 import qualified Data.Bits
 import qualified Data.ByteString.Char8 as B
@@ -29,6 +33,14 @@ import Language.Fortran.Util.Position
 }
 
 $digit = [0-9]
+$octalDigit = 0-7
+$hexDigit = [a-f $digit]
+$bit = 0-1
+
+@binary = b\'$bit+\' | \'$bit+\'b
+@octal = o\'$octalDigit+\' | \'$octalDigit+\'o
+@hex = x\'$hexDigit+\' | \'$hexDigit+\'x | z\'$hexDigit+\' | \'$hexDigit+\'z
+
 $letter = [a-z]
 $alphanumeric = [$letter $digit]
 $alphanumericExtended = [$letter $digit \_]
@@ -38,13 +50,18 @@ $special = [\ \=\+\-\*\/\(\)\,\.\$]
 -- programs out there.
 @idExtended = $letter $alphanumericExtended{0,9} $alphanumericExtended{0,9} $alphanumericExtended{0,9} $alphanumericExtended?
 @id = $letter $alphanumeric{0,5}
-@label = [1-9] $digit{0,4}
+@label = $digit{1,5}
+
+@idLegacy = [$letter \_ \%] [$alphanumericExtended \$]*
 
 @datatype = "integer" | "real" | "doubleprecision" | "complex" | "logical"
+          -- legacy extensions
+          | "byte"
 
 -- Numbers
 @integerConst = $digit+ -- Integer constant
 @posIntegerConst = [1-9] $digit*
+@bozLiteralConst = (@binary|@octal|@hex)
 
 -- For reals
 @exponent = [ed] [\+\-]? @integerConst
@@ -56,44 +73,63 @@ $special = [\ \=\+\-\*\/\(\)\,\.\$]
 tokens :-
 
   <0> [c!\*d] / { commentP }                  { lexComment Nothing }
+  "!" / { bangCommentP &&& legacy77P }        { lexComment Nothing }
   <0> @label / { withinLabelColsP }           { addSpanAndMatch TLabel }
   <0> . / { \_ ai _ _ -> atColP 6 ai }        { toSC keyword }
   <0> " "                                     ;
 
-  <0,st,keyword,iif> \n                       { resetPar >> toSC 0 >> addSpan TNewline }
-  <0,st,keyword,iif> \r                       ;
+  <0,st,keyword,iif,assn,doo> \n              { resetPar >> toSC 0 >> addSpan TNewline }
+  <0,st,keyword,iif,assn,doo> \r              ;
+  <0,st,keyword,iif,assn,doo> ";"             { resetPar >> toSC 0 >> addSpan TNewline }
 
   <st> "("                                    { addSpan TLeftPar }
+  <keyword> "(" / { legacy77P }               { addSpan TLeftPar }
   <iif> "("                                   { incPar >> addSpan TLeftPar }
   <st> ")"                                    { addSpan TRightPar }
+  <keyword> ")" / { legacy77P }               { typeSCChange >> addSpan TRightPar }
   <iif> ")"                                   { maybeToKeyword >> addSpan TRightPar }
   <st,iif> "(/" / { formatExtendedP }         { addSpan TLeftArrayPar }
   <st,iif> "/)" / { formatExtendedP }         { addSpan TRightArrayPar }
-  <st,iif,keyword> ","                        { addSpan TComma }
-  <st,iif> "."                                { addSpan TDot }
+  <st,iif,doo,keyword> ","                    { addSpan TComma }
+  <st,iif,keyword> "."                        { addSpan TDot }
+  <keyword> "." / { legacy77P }               { addSpan TDot }
   <st,iif> ":" / { fortran77P }               { addSpan TColon }
 
   <keyword> @id / { idP }                     { toSC st >> addSpanAndMatch TId }
   <keyword> @idExtended / { extendedIdP }     { toSC st >> addSpanAndMatch TId }
+  <keyword> @idLegacy / { legacyIdP }         { toSC st >> addSpanAndMatch TId }
 
   <keyword> "include" / { extended77P }       { toSC st >> addSpan TInclude }
 
   -- Tokens related to procedures and subprograms
   <keyword> "program"                         { toSC st >> addSpan TProgram }
-  <keyword> "function"                        { toSC st >> addSpan TFunction  }
+  <keyword> "function" / { functionP }        { toSC st >> addSpan TFunction  }
   <keyword> "subroutine"                      { toSC st >> addSpan TSubroutine  }
   <keyword> "blockdata"                       { toSC st >> addSpan TBlockData  }
+  <keyword> "structure"    / { legacy77P }    { toSC st >> addSpan TStructure  }
+  <keyword> "union"        / { legacy77P }    { toSC st >> addSpan TUnion  }
+  <keyword> "map"          / { legacy77P }    { toSC st >> addSpan TMap  }
+  <keyword> "endstructure" / { legacy77P }    { toSC st >> addSpan TEndStructure  }
+  <keyword> "endunion"     / { legacy77P }    { toSC st >> addSpan TEndUnion  }
+  <keyword> "endmap"       / { legacy77P }    { toSC st >> addSpan TEndMap  }
+  <keyword> "record"       / { legacy77P }    { toSC st >> addSpan TRecord  }
   <keyword> "end"                             { toSC st >> addSpan TEnd  }
+  <keyword> "endprogram"    / { legacy77P }   { toSC st >> addSpan TEndProgram  }
+  <keyword> "endfunction"   / { legacy77P }   { toSC st >> addSpan TEndFunction  }
+  <keyword> "endsubroutine" / { legacy77P }   { toSC st >> addSpan TEndSubroutine  }
 
   -- Tokens related to assignment statements
-  <keyword> "assign"                          { toSC st >> addSpan TAssign  }
+  <keyword> "assign"                          { toSC assn >> addSpan TAssign  }
+  <assn> @integerConst                        { addSpanAndMatch TInt }
+  <assn> "to"                                 { addSpan TTo  }
+  <assn> @id / { notToP }             { addSpanAndMatch TId }
+  <assn> @idExtended / { notToP &&& extended77P } { addSpanAndMatch TId }
+  <assn> @idLegacy / { notToP &&& legacy77P } { addSpanAndMatch TId }
   <st,iif> "="                                { addSpan TOpAssign  }
-  <st> "to"                                   { addSpan TTo  }
 
   -- Tokens related to control statements
   <keyword> "goto"                            { toSC st >> addSpan TGoto  }
-  <keyword> "if"                              { toSC iif >> addSpan TIf  }
-  <st> "if" / { fortran77P }                  { toSC iif >> addSpan TIf  }
+  <keyword> "if" / { ifP }                    { toSC iif >> addSpan TIf  }
   <st,keyword> "then" / { fortran77P }        { toSC keyword >> addSpan TThen  }
   <keyword> "else" / {fortran77P }            { addSpan TElse  }
   <keyword> "elseif" / {fortran77P }          { toSC st >> addSpan TElsif  }
@@ -104,10 +140,20 @@ tokens :-
   <keyword> "continue"                        { toSC st >> addSpan TContinue  }
   <keyword> "stop"                            { toSC st >> addSpan TStop  }
   <keyword> "exit" / { extended77P }          { toSC st >> addSpan TExit  }
+  <keyword> "cycle" / { legacy77P }           { toSC st >> addSpan TCycle  }
+  <keyword> "case" / { legacy77P }            { toSC st >> addSpan TCase  }
+  <keyword> "casedefault" / { legacy77P }     { toSC st >> addSpan TCaseDefault  }
+  <keyword> "selectcase" / { legacy77P }      { toSC st >> addSpan TSelectCase  }
+  <keyword> "endselect" / { legacy77P }       { toSC st >> addSpan TEndSelect  }
   <keyword> "pause"                           { toSC st >> addSpan TPause  }
-  <keyword> "do"                              { toSC st >> addSpan TDo }
   <keyword> "dowhile" / { extended77P }       { toSC st >> addSpan TDoWhile }
   <keyword> "enddo" / { extended77P }         { toSC st >> addSpan TEndDo  }
+  <keyword> "do"                              { toSC doo >> addSpan TDo }
+  <doo> @integerConst                         { addSpanAndMatch TInt }
+  <doo> "while" / { extended77P }             { toSC st >> addSpan TWhile }
+  <doo> @id                                   { toSC st >> addSpanAndMatch TId }
+  <doo> @idExtended / { extended77P }         { toSC st >> addSpanAndMatch TId }
+  <doo> @idLegacy / { legacy77P }             { toSC st >> addSpanAndMatch TId }
 
   -- Tokens related to I/O statements
   <keyword> "read"                            { toSC st >> addSpan TRead  }
@@ -119,6 +165,7 @@ tokens :-
   <keyword> "open" / { fortran77P }           { toSC st >> addSpan TOpen  }
   <keyword> "close" / { fortran77P }          { toSC st >> addSpan TClose  }
   <keyword> "print" / { fortran77P }          { toSC st >> addSpan TPrint  }
+  <keyword> "type" / { legacy77P }            { toSC st >> addSpan TTypePrint  }
 
   -- Tokens related to non-executable statements
 
@@ -130,29 +177,36 @@ tokens :-
   <keyword> "intrinsic" / { fortran77P }      { toSC st >> addSpan TIntrinsic  }
   <keyword> @datatype                         { typeSCChange >> addSpanAndMatch TType }
   <st> @datatype / { implicitStP }            { addSpanAndMatch TType }
+
   <keyword> "doublecomplex" / { extended77P } { typeSCChange >> addSpanAndMatch TType }
   <st> "doublecomplex" / { implicitTypeExtendedP }  { addSpanAndMatch TType }
-  <keyword> "character" / { fortran77P }      { toSC st >> addSpanAndMatch TType }
+  <keyword> "character" / { fortran77P }      { typeSCChange >> addSpanAndMatch TType }
   <st> "character" / { implicitType77P }      { addSpanAndMatch TType }
   <keyword> "implicit" / { fortran77P }       { toSC st >> addSpan TImplicit  }
-  <st> "none" / { fortran77P }                { addSpan TNone  }
+  <st> "none" / { implicitType77P }           { addSpan TNone  }
   <keyword> "parameter" / { fortran77P }      { toSC st >> addSpan TParameter  }
   <keyword> "entry" / { fortran77P }          { toSC st >> addSpan TEntry  }
+  <keyword> "pointer" / { legacy77P }         { toSC st >> addSpan TPointer  }
 
   -- Tokens related to data initalization statement
   <keyword> "data"                            { toSC st >> addSpan TData  }
+  <keyword> "automatic" / { legacy77P }       { toSC st >> addSpan TAutomatic  }
 
   -- Tokens related to format statement
-  <keyword> "format"                          { toSC st >> addSpan TFormat  }
-  <st> "(".*")" / { formatP }                 { addSpanAndMatch TBlob }
+  <keyword> "format"                          { toSC fmt >> enterFormat >> addSpan TFormat  }
+  <fmt> "(".*")"                              { toSC st >> exitFormat >> addSpanAndMatch TBlob }
 
   -- Tokens needed to parse integers, reals, double precision and complex
   -- constants
   <st,iif> @exponent / { exponentP }          { addSpanAndMatch TExponent }
-  <st,iif,keyword> @integerConst              { addSpanAndMatch TInt }
+  <st,iif> @integerConst                      { addSpanAndMatch TInt }
+    -- can be part (end) of function type declaration
+  <keyword> @integerConst                     { typeSCChange >> addSpanAndMatch TInt }
+  <st,iif,keyword> @bozLiteralConst / { legacy77P } { addSpanAndMatch TBozInt }
 
   -- String
-  <st,iif> \' / { fortran77P }                { strAutomaton 0 }
+  <st,iif> \' / { fortran77P }                { strAutomaton '\'' 0 }
+  <st,iif> \" / { legacy77P }                 { strAutomaton '"'  0 }
 
   -- Logicals
   <st,iif> (".true."|".false.")               { addSpanAndMatch TBool  }
@@ -162,12 +216,16 @@ tokens :-
   <st,iif> "-"                                { addSpan TOpMinus  }
   <st,iif> "**"                               { addSpan TOpExp  }
   <st,iif> "*"                                { addSpan TStar  }
+    -- can be part of function type declaration
+  <keyword> "*" / { legacy77P }               { addSpan TStar  }
   <st,iif> "/"                                { addSpan TSlash  }
+  <st,iif> "&" / { legacy77P }                { addSpan TAmpersand  }
 
   -- Logical operators
   <st,iif> ".or."                             { addSpan TOpOr  }
   <st,iif> ".and."                            { addSpan TOpAnd  }
   <st,iif> ".not."                            { addSpan TOpNot  }
+  <st,iif> ".xor." / { legacy77P }            { addSpan TOpXOr  }
   <st,iif> ".eqv." / { fortran77P }           { addSpan TOpEquivalent  }
   <st,iif> ".neqv." / { fortran77P }          { addSpan TOpNotEquivalent  }
 
@@ -175,7 +233,7 @@ tokens :-
   <st,iif> "<" / { extended77P }              { addSpan TOpLT  }
   <st,iif> "<=" / { extended77P }             { addSpan TOpLE  }
   <st,iif> "==" / { extended77P }             { addSpan TOpEQ  }
-  <st,iif> "!=" / { extended77P }             { addSpan TOpNE  }
+  <st,iif> "/=" / { extended77P }             { addSpan TOpNE  }
   <st,iif> ">" / { extended77P }              { addSpan TOpGT  }
   <st,iif> ">=" / { extended77P }             { addSpan TOpGE  }
   <st,iif> ".lt."                             { addSpan TOpLT  }
@@ -188,9 +246,11 @@ tokens :-
   -- ID
   <st,iif> @id                                { addSpanAndMatch TId }
   <st,iif> @idExtended / { extended77P }      { addSpanAndMatch TId }
+  <st,iif> @idLegacy / { legacy77P }          { addSpanAndMatch TId }
 
   -- Strings
   <st> @posIntegerConst "h" / { fortran66P }  { lexHollerith }
+  <st,iif> @posIntegerConst "h" / { hollerithP &&& legacy77P } { lexHollerith }
 
 {
 
@@ -198,13 +258,13 @@ tokens :-
 -- Predicated lexer helpers
 --------------------------------------------------------------------------------
 
-formatP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-formatP _ _ _ ai
-  | Just TFormat{} <- aiPreviousToken ai = True
-  | otherwise = False
+(&&&) :: (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+      -> (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+      -> (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+f &&& g = \ fv ai1 i ai2 -> f fv ai1 i ai2 && g fv ai1 i ai2
 
 formatExtendedP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-formatExtendedP fv _ _ ai = fv == Fortran77Extended &&
+formatExtendedP fv _ _ ai = fv `elem` [Fortran77Extended, Fortran77Legacy] &&
   case xs of
     [ TFormat _, _ ] -> False
     [ TLabel _ _, TFormat _ ] -> False
@@ -225,13 +285,42 @@ implicitStP fv _ _ ai = checkPreviousTokensInLine f ai
     f _ = False
 
 extendedIdP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-extendedIdP fv a b ai = fv == Fortran77Extended && idP fv a b ai
+extendedIdP fv a b ai = fv `elem` [Fortran77Extended, Fortran77Legacy] && idP fv a b ai
+
+legacyIdP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+legacyIdP fv a b ai = fv == Fortran77Legacy && idP fv a b ai
 
 idP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-idP fv _ _ ai = not (doP fv ai) && equalFollowsP fv ai
+idP fv ao i ai = not (doP fv ai) && not (ifP fv ao i ai)
+             && (equalFollowsP fv ai || rParFollowsP fv ai)
 
 doP :: FortranVersion -> AlexInput -> Bool
 doP fv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
+    case unParse (lexer $ f 0) ps of
+      ParseOk True _ -> True
+      _ -> False
+  where
+    ps = ParseState
+      { psAlexInput = ai { aiStartCode = st}
+      , psVersion = fv
+      , psFilename = "<unknown>"
+      , psParanthesesCount = ParanthesesCount 0 False
+      , psContext = [ ConStart ] }
+    f 0 t =
+      case t of
+        TNewline{} -> return False
+        TEOF{} -> return False
+        TLeftPar{} -> lexer $ f 1
+        TComma{} -> return True
+        _ -> lexer $ f 0
+    f !n t =
+      case t of
+        TLeftPar{} -> lexer $ f (n+1)
+        TRightPar{} -> lexer $ f (n-1)
+        _ -> lexer $ f n
+
+ifP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+ifP fv _ _ ai = "if" == (reverse . lexemeMatch . aiLexeme $ ai) &&
     case unParse (lexer $ f) ps of
       ParseOk True _ -> True
       _ -> False
@@ -244,10 +333,34 @@ doP fv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
       , psContext = [ ConStart ] }
     f t =
       case t of
-        TNewline{} -> return False
-        TEOF{} -> return False
-        TComma{} -> return True
-        _ -> lexer f
+        -- IF is always followed by (
+        TLeftPar{} -> return True
+        _ -> return False
+
+functionP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+functionP fv _ _ ai = "function" == (reverse . lexemeMatch . aiLexeme $ ai) &&
+    case unParse (lexer $ f) ps of
+      ParseOk True _ -> True
+      _ -> False
+  where
+    ps = ParseState
+      { psAlexInput = ai { aiStartCode = st}
+      , psVersion = fv
+      , psFilename = "<unknown>"
+      , psParanthesesCount = ParanthesesCount 0 False
+      , psContext = [ ConStart ] }
+    f t =
+      case t of
+        -- a function keyword should be followed by the name and a left paren
+        TId{} -> lexer f
+        TLeftPar{} -> return True
+        _ -> return False
+
+hollerithP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+hollerithP fv _ _ ai = isDigit (lookBack 2 ai)
+
+notToP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+notToP fv _ _ ai = not $ "to" `isPrefixOf` (reverse . lexemeMatch . aiLexeme $ ai)
 
 equalFollowsP :: FortranVersion -> AlexInput -> Bool
 equalFollowsP fv ai =
@@ -267,10 +380,15 @@ equalFollowsP fv ai =
         TEOF{} -> return False
         TOpAssign{} -> return True
         TLeftPar{} -> lexer $ f True 1
+        TDot{} -> lexer $ f False 0
+        TId{} -> lexer $ f False 0
         _ -> return False
     f True 0 t =
       case t of
         TOpAssign{} -> return True
+        TDot{} -> lexer $ f True 0
+        TId{} -> lexer $ f True 0
+        TLeftPar{} -> lexer $ f True 1
         _ -> return False
     f True n t =
       case t of
@@ -280,8 +398,30 @@ equalFollowsP fv ai =
         TRightPar{} -> lexer $ f True (n - 1)
         _ -> lexer $ f True n
 
+rParFollowsP :: FortranVersion -> AlexInput -> Bool
+rParFollowsP fv ai =
+    case unParse (lexer $ f) ps of
+      ParseOk True _ -> True
+      _ -> False
+  where
+    ps = ParseState
+      { psAlexInput = ai { aiStartCode = st}
+      , psVersion = fv
+      , psFilename = "<unknown>"
+      , psParanthesesCount = ParanthesesCount 0 False
+      , psContext = [ ConStart ] }
+    f t =
+      case t of
+        TRightPar{} -> return True
+        _ -> return False
+
 commentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 commentP _ aiOld _ aiNew = atColP 1 aiOld && _endsWithLine
+  where
+    _endsWithLine = (posColumn . aiPosition) aiNew /= 1
+
+bangCommentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+bangCommentP fv aiOld i aiNew = _endsWithLine
   where
     _endsWithLine = (posColumn . aiPosition) aiNew /= 1
 
@@ -299,19 +439,25 @@ atColP n ai = (posColumn . aiPosition) ai == n
 -- as an exponent token.
 exponentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 exponentP _ _ _ ai =
-  case aiPreviousToken ai of
-    Just (TInt _ _) -> True
-    Just (TDot _) -> True
+  case aiPreviousTokensInLine ai of
+    -- real*8 d8 is not an exponent
+    TInt{} : TStar{} : TType{} : _ -> False
+    TInt{} : _ -> True
+    TDot{} : _ -> True
     _ -> False
 
 fortran66P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 fortran66P fv _ _ _ = fv == Fortran66
 
 fortran77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-fortran77P fv _ _ _ = fv == Fortran77 || fv == Fortran77Extended
+fortran77P fv _ _ _ = fv == Fortran77 || fv == Fortran77Extended || fv == Fortran77Legacy
 
 extended77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-extended77P fv _ _ _ = fv == Fortran77Extended
+extended77P fv _ _ _ = fv == Fortran77Extended || fv == Fortran77Legacy
+
+legacy77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+legacy77P fv _ _ _ = fv == Fortran77Legacy
+
 
 --------------------------------------------------------------------------------
 -- Lexer helpers
@@ -362,6 +508,26 @@ resetWhiteSensitiveCharCount = do
   ai <- getAlex
   putAlex $ ai { aiWhiteSensitiveCharCount = 0 }
 
+setCaseSensitive :: LexAction ()
+setCaseSensitive = do
+  ai <- getAlex
+  putAlex $ ai { aiCaseSensitive = True }
+
+setCaseInsensitive :: LexAction ()
+setCaseInsensitive = do
+  ai <- getAlex
+  putAlex $ ai { aiCaseSensitive = False }
+
+enterFormat :: LexAction ()
+enterFormat = do
+  ai <- getAlex
+  putAlex $ ai { aiInFormat = True }
+
+exitFormat :: LexAction ()
+exitFormat = do
+  ai <- getAlex
+  putAlex $ ai { aiInFormat = False }
+
 instance Spanned Lexeme where
   getSpan lexeme =
     let ms = lexemeStart lexeme
@@ -402,11 +568,18 @@ lexComment mc = do
   m <- getMatch
   s <- getLexemeSpan
   alex <- getAlex
+  version <- getVersion
+  let emitComment = case version of
+                      Fortran77Legacy
+                        -> return Nothing
+                      _ -> return $ Just $ TComment s $ tail m
   let modifiedAlex = alex { aiWhiteSensitiveCharCount = 1 }
   case mc of
-    Just '\n' -> return $ Just $ TComment s $ tail m
+    Just '\n' -> emitComment
     Just _ ->
       case alexGetByte modifiedAlex of
+        Just (w, _) | fromIntegral w == ord '\n' -> do
+          emitComment
         Just (_, newAlex) -> do
           putAlex newAlex
           lexComment Nothing
@@ -414,7 +587,7 @@ lexComment mc = do
     Nothing ->
       case alexGetByte modifiedAlex of
         Just (_, newAlex) -> lexComment (Just $ (head . lexemeMatch . aiLexeme) newAlex)
-        Nothing -> return $ Just $ TComment s $ tail m
+        Nothing -> emitComment
 
 
 {-
@@ -436,37 +609,39 @@ lexComment mc = do
        +-------------+
             Chars
 -}
-strAutomaton :: Int -> LexAction (Maybe Token)
-strAutomaton 0 = do
+strAutomaton :: Char -> Int -> LexAction (Maybe Token)
+strAutomaton c 0 = do
+  setCaseSensitive
   incWhiteSensitiveCharCount
   alex <- getAlex
   case alexGetByte alex of
     Just (_, newAlex) -> do
       putAlex newAlex
       m <- getMatch
-      if last m == '\''
-      then strAutomaton 1
-      else strAutomaton 0
-    Nothing -> strAutomaton 3
-strAutomaton 1 = do
+      if last m == c
+      then strAutomaton c 1
+      else strAutomaton c 0
+    Nothing -> strAutomaton c 3
+strAutomaton c 1 = do
   incWhiteSensitiveCharCount
   alex <- getAlex
   case alexGetByte alex of
     Just (_, newAlex) -> do
       let m = lexemeMatch . aiLexeme $ newAlex
-      if head m == '\''
+      if head m == c
       then do
         putAlex newAlex
         putMatch $ reverse . tail $ m
-        strAutomaton 0
-      else strAutomaton 2
-    Nothing -> strAutomaton 2
-strAutomaton 2 = do
+        strAutomaton c 0
+      else strAutomaton c 2
+    Nothing -> strAutomaton c 2
+strAutomaton c 2 = do
   s <- getLexemeSpan
   m <- getMatch
   resetWhiteSensitiveCharCount
+  setCaseInsensitive
   return $ Just $ TString s $ (init . tail) m
-strAutomaton 3 = fail "Unmatched string."
+strAutomaton c 3 = fail "Unmatched string."
 
 lexHollerith :: LexAction (Maybe Token)
 lexHollerith = do
@@ -490,10 +665,14 @@ lexN n = do
   then return $ Just match'
   else
     case alexGetByte alex of
+      Just (w, newAlex) | fromIntegral w == ord '\n' -> do
+        return . Just $! pad match'
       Just (_, newAlex) -> do
         putAlex newAlex
         lexN n
       Nothing -> return Nothing
+ where
+  pad s = s ++ replicate (n - length s) ' '
 
 maybeToKeyword :: LexAction (Maybe Token)
 maybeToKeyword = do
@@ -513,6 +692,11 @@ typeSCChange = do
   else toSC st
   where
     f TFunction{} = return True
+      -- can be part of function type declaration
+    f TLeftPar{} = lexer f
+    f TRightPar{} = lexer f
+    f TStar{} = lexer f
+    f TInt{} = lexer f
     f _ = return False
 
 toSC :: Int -> LexAction (Maybe Token)
@@ -539,6 +723,16 @@ data Token = TLeftPar             SrcSpan
            | TFunction            SrcSpan
            | TSubroutine          SrcSpan
            | TBlockData           SrcSpan
+           | TStructure           SrcSpan
+           | TRecord              SrcSpan
+           | TUnion               SrcSpan
+           | TMap                 SrcSpan
+           | TEndProgram          SrcSpan
+           | TEndFunction         SrcSpan
+           | TEndSubroutine       SrcSpan
+           | TEndStructure        SrcSpan
+           | TEndUnion            SrcSpan
+           | TEndMap              SrcSpan
            | TEnd                 SrcSpan
            | TAssign              SrcSpan
            | TOpAssign            SrcSpan
@@ -554,10 +748,16 @@ data Token = TLeftPar             SrcSpan
            | TSave                SrcSpan
            | TContinue            SrcSpan
            | TStop                SrcSpan
+           | TCycle               SrcSpan
            | TExit                SrcSpan
+           | TCase                SrcSpan
+           | TCaseDefault         SrcSpan
+           | TSelectCase          SrcSpan
+           | TEndSelect           SrcSpan
            | TPause               SrcSpan
            | TDo                  SrcSpan
            | TDoWhile             SrcSpan
+           | TWhile               SrcSpan
            | TEndDo               SrcSpan
            | TRead                SrcSpan
            | TWrite               SrcSpan
@@ -568,9 +768,11 @@ data Token = TLeftPar             SrcSpan
            | TOpen                SrcSpan
            | TClose               SrcSpan
            | TPrint               SrcSpan
+           | TTypePrint           SrcSpan
            | TDimension           SrcSpan
            | TCommon              SrcSpan
            | TEquivalence         SrcSpan
+           | TPointer             SrcSpan
            | TExternal            SrcSpan
            | TIntrinsic           SrcSpan
            | TType                SrcSpan String
@@ -579,9 +781,11 @@ data Token = TLeftPar             SrcSpan
            | TNone                SrcSpan
            | TParameter           SrcSpan
            | TData                SrcSpan
+           | TAutomatic           SrcSpan
            | TFormat              SrcSpan
            | TBlob                SrcSpan String
            | TInt                 SrcSpan String
+           | TBozInt              SrcSpan String
            | TExponent            SrcSpan String
            | TBool                SrcSpan String
            | TOpPlus              SrcSpan
@@ -589,8 +793,10 @@ data Token = TLeftPar             SrcSpan
            | TOpExp               SrcSpan
            | TStar                SrcSpan
            | TSlash               SrcSpan
+           | TAmpersand           SrcSpan
            | TOpOr                SrcSpan
            | TOpAnd               SrcSpan
+           | TOpXOr               SrcSpan
            | TOpNot               SrcSpan
            | TOpEquivalent        SrcSpan
            | TOpNotEquivalent     SrcSpan
@@ -645,6 +851,9 @@ data AlexInput = AlexInput
   , aiStartCode                 :: Int
   , aiPreviousToken             :: Maybe Token
   , aiPreviousTokensInLine      :: [ Token ]
+  , aiCaseSensitive             :: Bool
+  , aiInFormat                  :: Bool
+  , aiFortranVersion            :: FortranVersion
   } deriving (Show)
 
 instance Loc AlexInput where
@@ -666,7 +875,11 @@ vanillaAlexInput = AlexInput
   , aiWhiteSensitiveCharCount = 6
   , aiStartCode = 0
   , aiPreviousToken = Nothing
-  , aiPreviousTokensInLine = [ ] }
+  , aiPreviousTokensInLine = [ ]
+  , aiCaseSensitive = False
+  , aiInFormat = False
+  , aiFortranVersion = Fortran77
+  }
 
 updateLexeme :: Maybe Char -> Position -> AlexInput -> AlexInput
 updateLexeme maybeChar p ai =
@@ -674,10 +887,11 @@ updateLexeme maybeChar p ai =
       match = lexemeMatch lexeme
       newMatch =
         case maybeChar of
-          Just c -> toLower c : match
+          Just c -> c : match
           Nothing -> match
       start = lexemeStart lexeme
-      newStart = if isNothing start then Just p else start
+                 -- skipping should not start a new lexeme
+      newStart = if isNothing start && isJust maybeChar then Just p else start
       newEnd = Just p in
     ai { aiLexeme = Lexeme newMatch newStart newEnd }
 
@@ -685,7 +899,7 @@ updateLexeme maybeChar p ai =
 -- Definitions needed for alexScanUser
 --------------------------------------------------------------------------------
 
-data Move = Continuation | Char | Newline
+data Move = Continuation | Char | Newline | NewlineComment | Comment
 
 alexGetByte :: AlexInput -> Maybe (Word8, AlexInput)
 alexGetByte ai
@@ -695,17 +909,23 @@ alexGetByte ai
   | posAbsoluteOffset _position == aiEndOffset ai = Nothing
   -- Skip the continuation line altogether
   | isContinuation ai && _isWhiteInsensitive = skip Continuation ai
+  -- Skip the newline before a comment
+  | aiFortranVersion ai == Fortran77Legacy &&
+    _isWhiteInsensitive && isNewlineComment ai = skip NewlineComment ai
   -- If we are not parsing a Hollerith skip whitespace
   | _curChar `elem` [ ' ', '\t' ] && _isWhiteInsensitive = skip Char ai
+  -- Ignore inline comments
+  | aiFortranVersion ai == Fortran77Legacy &&
+    _isWhiteInsensitive && not _inFormat && _curChar == '!' = skip Comment ai
   -- Read genuine character and advance. Also covers white sensitivity.
   | otherwise =
-      let (_b:_bs) = (utf8Encode . toLower) _curChar in
+      let (_b:_bs) = utf8Encode _curChar in
         Just(_b, updateLexeme (Just _curChar) _position
           ai {
             aiPosition =
               case _curChar of
-                '\n'  -> advance Newline _position
-                _     -> advance Char _position,
+                '\n'  -> advance Newline ai
+                _     -> advance Char ai,
             aiBytes = _bs,
             aiPreviousChar = _curChar,
             aiWhiteSensitiveCharCount =
@@ -714,10 +934,11 @@ alexGetByte ai
               else aiWhiteSensitiveCharCount ai - 1
           })
   where
-    _curChar = currentChar ai
+    _curChar = (if aiCaseSensitive ai then id else toLower) $ currentChar ai
     _bytes = aiBytes ai
     _position = aiPosition ai
     _isWhiteInsensitive = aiWhiteSensitiveCharCount ai == 0
+    _inFormat = aiInFormat ai
 
 alexInputPrevChar :: AlexInput -> Char
 alexInputPrevChar ai = aiPreviousChar ai
@@ -731,19 +952,29 @@ takeNChars n ai =
 currentChar :: AlexInput -> Char
 currentChar ai = B.index (aiSourceBytes ai) (fromIntegral . posAbsoluteOffset . aiPosition $ ai)
 
+lookBack :: Int -> AlexInput -> Char
+lookBack n ai = B.index (aiSourceBytes ai) (fromIntegral . subtract n . posAbsoluteOffset . aiPosition $ ai)
+
 isContinuation :: AlexInput -> Bool
 isContinuation ai =
   take 6 _next7 == "\n     " && not (last _next7 `elem` [' ', '0', '\n', '\r'])
   where
     _next7 = takeNChars 7 ai
 
+isNewlineComment :: AlexInput -> Bool
+isNewlineComment ai =
+  _next1 == "\n" && isCommentLine ai p
+  where
+    _next1 = takeNChars 1 ai
+    p = (aiPosition ai) { posAbsoluteOffset = posAbsoluteOffset (aiPosition ai) + 1 }
+
 skip :: Move -> AlexInput -> Maybe (Word8, AlexInput)
 skip move ai =
-  let _newPosition = advance move $ aiPosition ai in
+  let _newPosition = advance move ai in
     alexGetByte $ updateLexeme Nothing _newPosition $ ai { aiPosition = _newPosition }
 
-advance :: Move -> Position -> Position
-advance move position =
+advance :: Move -> AlexInput -> Position
+advance move ai =
   case move of
     Char ->
       position { posAbsoluteOffset = _absl + 1, posColumn = _col + 1 }
@@ -751,10 +982,67 @@ advance move position =
       position { posAbsoluteOffset = _absl + 7, posColumn = 7, posLine = _line + 1 }
     Newline ->
       position { posAbsoluteOffset = _absl + 1, posColumn = 1, posLine = _line + 1 }
+    NewlineComment ->
+      skipComment ai
+        position { posAbsoluteOffset = _absl + 1, posColumn = 1, posLine = _line + 1 }
+    Comment ->
+      skipComment ai position
   where
+    position = aiPosition ai
     _col = posColumn position
     _line = posLine position
     _absl = posAbsoluteOffset position
+
+skipComment :: AlexInput -> Position -> Position
+skipComment ai p =
+  p { posAbsoluteOffset = posAbsoluteOffset p + length line
+    , posColumn = posColumn p + length line
+    }
+  where
+  line = takeLine p ai
+
+skipCommentLines :: AlexInput -> Position -> Position
+skipCommentLines ai p = go p p
+  where
+  go p' p
+    -- eof is not a comment line
+    | not (null line)
+    , isCommentLine ai p
+    = go p p{ posAbsoluteOffset = posAbsoluteOffset p + length line + 1 -- skip the newline
+            , posColumn = 1, posLine = posLine p + 1
+            }
+    | isContinuation ai'
+    = advance Continuation ai'
+    | otherwise
+      -- after skipping comment lines, place cursor right at the last newline
+    = p2
+    where
+    line = takeLine p ai
+    line' = takeLine p' ai
+    p2 = p' { posAbsoluteOffset = posAbsoluteOffset p' + length line'
+            , posColumn = length line' + 1
+            }
+    ai' = ai { aiPosition = p2 }
+
+isCommentLine :: AlexInput -> Position -> Bool
+isCommentLine ai p
+      -- eof is not a comment line
+    | posAbsoluteOffset p == aiEndOffset ai
+    = False
+    | map toLower (take 1 line) `elem` ["c", "d", "!", "*"]
+      || all (`elem` " \t") line
+      || head (dropWhile (`elem` " \t") line) == '!'
+    = True
+    | otherwise
+    = False
+    where
+    line = takeLine p ai
+
+takeLine :: Position -> AlexInput -> String
+takeLine p ai =
+  B.unpack . B.takeWhile (/='\n') . B.drop (fromIntegral _dropN) $ aiSourceBytes ai
+  where
+    _dropN = posAbsoluteOffset p
 
 utf8Encode :: Char -> [Word8]
 utf8Encode = map fromIntegral . _go . ord
@@ -821,7 +1109,8 @@ initParseState srcBytes fortranVersion filename =
       , psContext = [ ConStart ] }
     _vanillaAlexInput = vanillaAlexInput
       { aiSourceBytes = srcBytes
-      , aiEndOffset   = fromIntegral $ B.length srcBytes  }
+      , aiEndOffset   = fromIntegral $ B.length srcBytes
+      , aiFortranVersion = fortranVersion }
 
 collectFixedTokens :: FortranVersion -> B.ByteString -> [Token]
 collectFixedTokens version srcInput =

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -6,7 +6,8 @@ import Language.Fortran.ParserMonad (FortranVersion(..), ParseErrorSimple(..), f
 
 import Language.Fortran.Parser.Fortran66 ( fortran66Parser, fortran66ParserWithModFiles )
 import Language.Fortran.Parser.Fortran77 ( fortran77Parser, fortran77ParserWithModFiles
-                                         , extended77Parser, extended77ParserWithModFiles )
+                                         , extended77Parser, extended77ParserWithModFiles
+                                         , legacy77Parser, legacy77ParserWithModFiles )
 import Language.Fortran.Parser.Fortran90 ( fortran90Parser, fortran90ParserWithModFiles )
 import Language.Fortran.Parser.Fortran95 ( fortran95Parser, fortran95ParserWithModFiles )
 
@@ -36,6 +37,7 @@ parserVersions =
   [ (Fortran66, fromParseResult `after` fortran66Parser)
   , (Fortran77, fromParseResult `after` fortran77Parser)
   , (Fortran77Extended, fromParseResult `after` extended77Parser)
+  , (Fortran77Legacy, fromParseResult `after` legacy77Parser)
   , (Fortran90, fromParseResult `after` fortran90Parser)
   , (Fortran95, fromParseResult `after` fortran95Parser) ]
 
@@ -45,6 +47,7 @@ parserWithModFilesVersions =
   [ (Fortran66, \m s -> fromParseResult . fortran66ParserWithModFiles m s)
   , (Fortran77, \m s -> fromParseResult . fortran77ParserWithModFiles m s)
   , (Fortran77Extended, \m s -> fromParseResult . extended77ParserWithModFiles m s)
+  , (Fortran77Legacy, \m s -> fromParseResult . legacy77ParserWithModFiles m s)
   , (Fortran90, \m s -> fromParseResult . fortran90ParserWithModFiles m s)
   , (Fortran95, \m s -> fromParseResult . fortran95ParserWithModFiles m s) ]
 

--- a/src/Language/Fortran/ParserMonad.hs
+++ b/src/Language/Fortran/ParserMonad.hs
@@ -26,6 +26,7 @@ import Language.Fortran.Util.Position
 data FortranVersion = Fortran66
                     | Fortran77
                     | Fortran77Extended
+                    | Fortran77Legacy
                     | Fortran90
                     | Fortran95
                     | Fortran2003
@@ -36,6 +37,7 @@ instance Show FortranVersion where
   show Fortran66 = "Fortran 66"
   show Fortran77 = "Fortran 77"
   show Fortran77Extended = "Fortran 77 Extended"
+  show Fortran77Legacy = "Fortran 77 Legacy"
   show Fortran90 = "Fortran 90"
   show Fortran95 = "Fortran 95"
   show Fortran2003 = "Fortran 2003"

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -222,6 +222,13 @@ groupLabeledDo' blos@(b:bs) = b' : bs'
               lastLabel = getLastLabel $ last blocks
           in ( BlDo a (getTransSpan s blocks) label mn tl doSpec blocks lastLabel
              , leftOverBlocks )
+      BlStatement a s label
+        (StDoWhile _ _ mn tl@Just{} cond) ->
+          let ( blocks, leftOverBlocks ) =
+                collectNonLabeledDoBlocks tl groupedBlocks
+              lastLabel = getLastLabel $ last blocks
+          in ( BlDoWhile a (getTransSpan s blocks) label mn tl cond blocks lastLabel
+             , leftOverBlocks )
       b | containsGroups b ->
         ( applyGroupingToSubblocks groupLabeledDo' b, groupedBlocks )
       _ -> (b, groupedBlocks)

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -252,8 +252,11 @@ collectNonLabeledDoBlocks targetLabel blocks =
 
 compLabel :: Maybe (Expression a) -> Maybe (Expression a) -> Bool
 compLabel (Just (ExpValue _ _ (ValInteger l1)))
-          (Just (ExpValue _ _ (ValInteger l2))) = l1 == l2
+          (Just (ExpValue _ _ (ValInteger l2))) = strip l1 == strip l2
 compLabel _ _ = False
+
+strip :: String -> String
+strip = dropWhile (=='0')
 
 --------------------------------------------------------------------------------
 -- Grouping case statements

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -84,7 +84,7 @@ main = do
                   sgr = genSuperBBGr bbm
 
       case actionOpt of
-        Lex | version `elem` [ Fortran66, Fortran77, Fortran77Extended ] ->
+        Lex | version `elem` [ Fortran66, Fortran77, Fortran77Extended, Fortran77Legacy ] ->
           print $ FixedForm.collectFixedTokens version contents
         Lex | version `elem` [Fortran90, Fortran2003, Fortran2008] ->
           print $ FreeForm.collectFreeTokens version contents
@@ -263,11 +263,13 @@ instance Read FortranVersion where
   readsPrec _ value =
     let options = [ ("66", Fortran66)
                   , ("77e", Fortran77Extended)
+                  , ("77l", Fortran77Legacy)
                   , ("77", Fortran77)
                   , ("90", Fortran90)
                   , ("95", Fortran95)
                   , ("03", Fortran2003)
-                  , ("08", Fortran2008)] in
+                  , ("08", Fortran2008)
+                  ] in
       tryTypes options
       where
         tryTypes [] = []


### PR DESCRIPTION
- TYPE statement (alias for PRINT)
- STRUCTURE/UNION/MAP statements
- hollerith constants
- BOZ literals
- inline comments (we just throw them away for now)
- CASE statement
- specific widths for type declarations (eg, INTEGER*4)