### PR TITLE
disambiguates nullary statement function

### DIFF
--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -24,6 +24,9 @@ disambiguateFunctionStatements = modifyProgramFile (trans statement)
     statement (StExpressionAssign a1 s (ExpSubscript _ _ v@(ExpValue a _ (ValVariable _)) indicies) e2)
       | Just (IDType _ (Just CTFunction)) <- idType a
       , indiciesRangeFree indicies = StFunction a1 s v (aMap fromIndex indicies) e2
+    -- nullary statement function
+    statement (StExpressionAssign a1 s1 (ExpFunctionCall _ _ v@(ExpValue a s (ValVariable _)) Nothing) e2)
+      = StFunction a1 s1 v (AList a s []) e2
     statement st                                      = st
 
 disambiguateFunctionCalls :: Data a => Transform a ()

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -29,12 +29,13 @@ spec = do
 
 {-
 - program Main
-- integer a, b(1), c
+- integer a, b(1), c, e
 - dimension a(1)
 - a(1) = 1
 - b(1) = 1
 - c(x) = 1
 - d(x) = 1
+- e() = 1
 - end
 -}
 ex1 :: ProgramFile ()
@@ -56,7 +57,9 @@ ex1pu1bs =
   , BlStatement () u Nothing (StExpressionAssign () u
       (ExpSubscript () u (varGen "c") (AList () u [ IxSingle () u Nothing $ varGen "x" ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
-      (ExpSubscript () u (varGen "d") (AList () u [ IxSingle () u Nothing $ varGen "x" ])) (intGen 1)) ]
+      (ExpSubscript () u (varGen "d") (AList () u [ IxSingle () u Nothing $ varGen "x" ])) (intGen 1))
+  , BlStatement () u Nothing (StExpressionAssign () u
+      (ExpFunctionCall () u (varGen "e") Nothing) (intGen 1)) ]
 
 expectedEx1 :: ProgramFile ()
 expectedEx1 = ProgramFile mi77 [ expectedEx1pu1 ]
@@ -77,7 +80,9 @@ expectedEx1pu1bs =
   , BlStatement () u Nothing (StFunction () u
       (ExpValue () u $ ValVariable "c") (AList () u [ varGen "x" ]) (intGen 1))
   , BlStatement () u Nothing (StFunction () u
-      (ExpValue () u $ ValVariable "d") (AList () u [ varGen "x" ]) (intGen 1)) ]
+      (ExpValue () u $ ValVariable "d") (AList () u [ varGen "x" ]) (intGen 1))
+  , BlStatement () u Nothing (StFunction () u
+      (ExpValue () u $ ValVariable "e") (AList () u []) (intGen 1)) ]
 
 {-
 - program


### PR DESCRIPTION
While we were using fortran-src to do data flow analysis on our internal code, we have seen similar errors as reported in https://github.com/camfort/fortran-src/issues/43

Currently fortran-src treats statement function with no argument as an assignment with its LHS being a function call. So code like
```
func0 () = 42
```
is parsed as
```
StExpressionAssign ()
                                                     (4:7)-(4:19)
                                                     (ExpFunctionCall ()
                                                                      (4:7)-(4:14)
                                                                      (ExpValue ()
                                                                                (4:7)-(4:11)
                                                                                (ValVariable "func0"))
                                                                      Nothing)
                                                     (ExpValue ()
                                                               (4:18)-(4:19)
                                                               (ValInteger "42"))
```
