### PR TITLE
Fix exception for array declaration in common statement

### DIFF
--- a/src/Language/Fortran/Analysis/Renaming.hs
+++ b/src/Language/Fortran/Analysis/Renaming.hs
@@ -253,7 +253,7 @@ initialEnv blocks = do
   let common = M.fromList [ (v, (v', NTVariable))
                           | CommonGroup _ _ me1 alist <- universeBi blocks :: [CommonGroup (Analysis a)]
                           , let prefix = case me1 of Just e1 -> srcName e1; _ -> ""
-                          , e <- aStrip alist
+                          , e@(ExpValue _ _ ValVariable{}) <- universeBi (aStrip alist) :: [Expression (Analysis a)]
                           , let v = srcName e
                           , let v' = prefix ++ "_" ++ v ++ "_common" ]
 

--- a/test/Language/Fortran/Analysis/RenamingSpec.hs
+++ b/test/Language/Fortran/Analysis/RenamingSpec.hs
@@ -116,6 +116,7 @@ spec = do
       let entry = extractNameMap' common1
       length (filter (=="x") (elems entry)) `shouldBe` 2
       M.lookup "c_x_common" entry `shouldBe` Just "x"
+      M.lookup "c_y_common" entry `shouldBe` Just "y"
 
 --------------------------------------------------
 
@@ -413,8 +414,8 @@ common1 :: ProgramFile A0
 common1 = resetSrcSpan . flip fortran90Parser "" $ unlines [
     "program p1"
   , "  implicit none"
-  , "  integer :: x"
-  , "  common /c/ x"
+  , "  integer :: x, y"
+  , "  common /c/ x, y(10)"
   , "contains"
   , "  subroutine s1 ()"
   , "    call s2 (f1(x))"


### PR DESCRIPTION
For the following code which declares an array in the common statement
```
integer a
common /c/ a(10)
```
fortran-src throws exception:
```
uncaught exception: ErrorCall (Use of srcName on non-variable.
       CallStack (from HasCallStack):
         error, called at src/Language/Fortran/Analysis.hs:166:72 in fortran-src-0.2.2.0-3De5L0hl9pcKK2n6AkwMyF:Language.Fortran.Analysis)
```