### PR TITLE
Add `filePath` field to `Position` record

### DIFF
--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -1111,7 +1111,8 @@ initParseState srcBytes fortranVersion filename =
     _vanillaAlexInput = vanillaAlexInput
       { aiSourceBytes = srcBytes
       , aiEndOffset   = fromIntegral $ B.length srcBytes
-      , aiFortranVersion = fortranVersion }
+      , aiFortranVersion = fortranVersion
+      , aiPosition = initPosition {filePath = filename} }
 
 collectFixedTokens :: FortranVersion -> B.ByteString -> [Token]
 collectFixedTokens version srcInput =

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -677,7 +677,7 @@ normaliseStartCode = do
 --------------------------------------------------------------------------------
 
 invalidPosition :: Position
-invalidPosition = Position 0 0 0
+invalidPosition = Position 0 0 0 ""
 
 {-# INLINE isValidPosition #-}
 isValidPosition :: Position -> Bool
@@ -1164,7 +1164,8 @@ initParseState srcBytes fortranVersion filename =
       , psContext = [ ConStart ] }
     _vanillaAlexInput = vanillaAlexInput
       { aiSourceBytes = srcBytes
-      , aiEndOffset   = B.length srcBytes }
+      , aiEndOffset   = B.length srcBytes
+      , aiPosition    = initPosition {filePath = filename} }
 
 collectFreeTokens :: FortranVersion -> B.ByteString -> [Token]
 collectFreeTokens version srcInput =

--- a/src/Language/Fortran/Util/Position.hs
+++ b/src/Language/Fortran/Util/Position.hs
@@ -19,18 +19,20 @@ data Position = Position
   { posAbsoluteOffset   :: {-# UNPACK #-} !Int
   , posColumn           :: {-# UNPACK #-} !Int
   , posLine             :: {-# UNPACK #-} !Int
+  , filePath            :: !String
   } deriving (Eq, Ord, Data, Typeable, Generic)
 
 instance Binary Position
 
 instance Show Position where
-  show (Position _ c l) = show l ++ ':' : show c
+  show (Position _ c l f) = show f ++ ':' : show l ++ ':' : show c
 
 initPosition :: Position
 initPosition = Position
   { posAbsoluteOffset = 0
   , posColumn = 1
   , posLine = 1
+  , filePath = ""
   }
 
 lineCol :: Position -> (Int, Int)
@@ -49,11 +51,11 @@ instance Out SrcSpan where
 
 -- Difference between the column of the upper and lower positions in a span
 columnDistance :: SrcSpan -> Int
-columnDistance (SrcSpan (Position _ c1 _) (Position _ c2 _)) = c2 - c1
+columnDistance (SrcSpan (Position _ c1 _ _) (Position _ c2 _ _)) = c2 - c1
 
 -- Difference between the lines of the upper and lower positions in a span
 lineDistance :: SrcSpan -> Int
-lineDistance (SrcSpan (Position _ _ l1) (Position _ _ l2)) = l2 - l1
+lineDistance (SrcSpan (Position _ _ l1 _) (Position _ _ l2 _)) = l2 - l1
 
 initSrcSpan :: SrcSpan
 initSrcSpan = SrcSpan initPosition initPosition

--- a/test/Language/Fortran/Parser/Fortran77/IncludeSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/IncludeSpec.hs
@@ -13,8 +13,8 @@ import Language.Fortran.Util.Position
 iParser :: [String] -> String -> IO (ParseResult AlexInput Token (ProgramFile A0))
 iParser incs src = legacy77ParserWithIncludes incs (B.pack src) "<unknown>"
 
-makeSrcR :: (Int, Int, Int) -> (Int, Int, Int) -> SrcSpan
-makeSrcR (i1, i2, i3) (j1, j2, j3) = SrcSpan (Position i1 i2 i3) (Position j1 j2 j3)
+makeSrcR :: (Int, Int, Int, String) -> (Int, Int, Int, String) -> SrcSpan
+makeSrcR (i1, i2, i3, s) (j1, j2, j3, s') = SrcSpan (Position i1 i2 i3 s) (Position j1 j2 j3 s')
 
 spec :: SpecWith ()
 spec =
@@ -26,16 +26,16 @@ spec =
         incs = ["./test/Language/Fortran/Parser"]
         name = "bar"
         pf = ProgramFile mi77 [pu]
-        puSpan = makeSrcR (6,7,1) (48,9,3)
-        st1Span = makeSrcR (24,7,2) (38,21,2)
-        expSpan = makeSrcR (32,15,2) (38,21,2)
+        puSpan = makeSrcR (6,7,1,"<unknown>") (48,9,3,"<unknown>")
+        st1Span = makeSrcR (24,7,2,"<unknown>") (38,21,2,"<unknown>")
+        expSpan = makeSrcR (32,15,2,"<unknown>") (38,21,2,"<unknown>")
 
         -- the expansion returns the span in the included file
         -- it should return the span at the inclusion
-        st2Span = makeSrcR (6,7,1) (14,15,1)
-        declSpan = makeSrcR (6,7,1) (14,15,1)
-        typeSpan = makeSrcR (6,7,1) (12,13,1)
-        blockSpan = makeSrcR (14,15,1) (14,15,1)
+        st2Span = makeSrcR (6,7,1,"foo.f") (14,15,1,"foo.f")
+        declSpan = makeSrcR (6,7,1,"foo.f") (14,15,1,"foo.f")
+        typeSpan = makeSrcR (6,7,1,"foo.f") (12,13,1,"foo.f")
+        blockSpan = makeSrcR (14,15,1,"foo.f") (14,15,1,"foo.f")
         varGen' str =  ExpValue () blockSpan $ ValVariable str
 
         pu = PUMain () puSpan (Just name) blocks Nothing

--- a/test/Language/Fortran/ParserMonadSpec.hs
+++ b/test/Language/Fortran/ParserMonadSpec.hs
@@ -26,7 +26,7 @@ instance LastToken String String where
 data SomeInput = SomeInput { p :: Position }
 
 initPos :: Position
-initPos = Position 5 1 2
+initPos = Position 5 1 2 ""
 
 initSomeInput :: SomeInput
 initSomeInput = SomeInput { p = initPos }
@@ -59,7 +59,7 @@ spec =
 
       describe "Obtaining locations" $ do
         it "getPosition returns correct location" $
-          let _expPosition = Position 6 2 3
+          let _expPosition = Position 6 2 3 "some.f"
               _exampleM = do
                 _ai <- getAlex
                 putAlex $ _ai { p = _expPosition }
@@ -68,7 +68,7 @@ spec =
             _loc `shouldBe` _expPosition
 
         it "getSrcSpan return correct location span" $
-          let _loc2 = Position 6 2 3
+          let _loc2 = Position 6 2 3 "some.f"
               _exampleM = do
                 _ai <- getAlex
                 _loc1 <- getPosition


### PR DESCRIPTION
PR summary:

Related issue: #79 
```
    * Modify position record to now contain a `filePath` field

    * Update tests and associated functions relying on Position
```

cc: @mrd @madgen @ruoso @burz @traveltissues