### PR TITLE
Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - echo $TRAVIS_TAG
 - "GHC_OPTIONS=\"--ghc-options=\"$(ruby -e 'print (ENV[%q|TRAVIS_TAG|] =~ /v/ ? %q|-O3| : %q|-O0|)')\"\""
 - echo $GHC_OPTIONS
-- stack --no-terminal haddock --test --no-haddock-deps --pedantic --ghc-options='-Wno-orphans' -j 4 $GHC_OPTIONS
+- stack --no-terminal haddock --test --no-haddock-deps --pedantic -j 4 $GHC_OPTIONS
 deploy:
 - provider: releases
   api_key:

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
+-- orphans are instances of package-natives
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fortran.AST where
 

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, StandaloneDeriving, DeriveGeneric, TupleSections #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
 -- Common data structures and functions supporting analysis of the AST.

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fortran.PrettyPrint where
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -21,7 +21,6 @@ import Data.List (intercalate, (\\), isSuffixOf)
 import Data.Char (toLower)
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Data
-import Data.Binary
 import Data.Generics.Uniplate.Data
 
 import Language.Fortran.ParserMonad (selectFortranVersion, FortranVersion(..), fromRight)

--- a/test/Language/Fortran/Analysis/BBlocksSpec.hs
+++ b/test/Language/Fortran/Analysis/BBlocksSpec.hs
@@ -22,27 +22,20 @@ spec :: Spec
 spec =
   describe "Basic Blocks" $ do
     describe "loop4" $ do
-      it "nodes and edges length" $ do
-        let pf = pParser programLoop4
-        let gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
-        let ns = nodes gr
-        let es = edges gr
+      let pf = pParser programLoop4
+          gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
+          ns = nodes gr
+          es = edges gr
+          nodeSet = IS.fromList $ nodes gr
+      it "nodes and edges length" $
         (length ns, length es) `shouldBe` (11, 12)
-      it "branching nodes" $ do
-        let pf = pParser programLoop4
-        let gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
+      it "branching nodes" $
         (IS.size (findSuccsBB gr [10]), IS.size (findSuccsBB gr [20])) `shouldBe` (2, 2)
       it "all reachable" $ do
-        let pf = pParser programLoop4
-        let gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
         let reached = IS.fromList $ dfs [0] gr
-        let nodeSet = IS.fromList $ nodes gr
         reached `shouldBe` nodeSet
       it "all terminate" $ do
-        let pf = pParser programLoop4
-        let gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
         let reached = IS.fromList $ rdfs [-1] gr
-        let nodeSet = IS.fromList $ nodes gr
         reached `shouldBe` nodeSet
     describe "if arith" $ do
       it "nodes and edges length" $ do

--- a/test/Language/Fortran/Analysis/DataFlowSpec.hs
+++ b/test/Language/Fortran/Analysis/DataFlowSpec.hs
@@ -25,6 +25,8 @@ import Data.Generics.Uniplate.Operations
 import qualified Data.ByteString.Char8 as B
 import Control.Arrow ((&&&))
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+
 data F77 = F77
 data F90 = F90
 

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -10,6 +10,8 @@ import Language.Fortran.ParserMonad (FortranVersion(..), evalParse, fromParseRes
 import Language.Fortran.AST
 import qualified Data.ByteString.Char8 as B
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+
 eParser :: String -> Expression ()
 eParser sourceCode =
   case evalParse statementParser parseState of

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -12,6 +12,8 @@ import Language.Fortran.Parser.Fortran90
 --import qualified Data.List as List
 import qualified Data.ByteString.Char8 as B
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+
 eParser :: String -> Expression ()
 eParser sourceCode =
   case evalParse statementParser parseState of

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -14,6 +14,8 @@ import qualified Data.List as List
 import Data.Foldable(forM_)
 import qualified Data.ByteString.Char8 as B
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+
 eParser :: String -> Expression ()
 eParser sourceCode =
   case evalParse statementParser parseState of

--- a/test/Language/Fortran/ParserMonadSpec.hs
+++ b/test/Language/Fortran/ParserMonadSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fortran.ParserMonadSpec where
 

--- a/test/Language/Fortran/Transformation/GroupingSpec.hs
+++ b/test/Language/Fortran/Transformation/GroupingSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Language.Fortran.Transformation.GroupingSpec where
 
 import Test.Hspec hiding (Selector)


### PR DESCRIPTION
#76 

I eventually concluded that 'fixing' these last cases of orphans and duplication would have introduced some pretty horrible things into the code and that it was actually better not to fix them: Duplication in the test specs is fine, there's no rebinding, it just has some explicit steps that potentially could be marshalled into a monad but really doesn't provide any benefit. The remaining orphans are mostly package natives and in either case typename abuse doesn't really offer anything aside from fooling the compiler into not warning about them since it still won't provide type safety