### PR TITLE
Remove empty fields in project config and don't save creds

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
 resolver: lts-11.9
 packages:
 - '.'
-extra-deps: []
-flags: {}
-extra-package-dbs: []
+save-hackage-creds: false


### PR DESCRIPTION
This removes some empty fields from the config and bypasses the prompt to save credentials in the local dist config