### PR TITLE
Disambiguate function call

### DIFF
--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -36,14 +36,12 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
       | Just (IDType _ (Just CTFunction)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-    expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
       | Just (IDType _ (Just CTExternal)) <- idType a
+      , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
+      | Just (IDType _ (Just CTVariable)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
       | Just (IDType _ (Just CTIntrinsic)) <- idType a
-      , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-    expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
-      | Just (IDType _ (Just CTVariable)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression e                                      = e
 

--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -42,6 +42,9 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
       | Just (IDType _ (Just CTIntrinsic)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
+    expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
+      | Just (IDType _ (Just CTVariable)) <- idType a
+      , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression e                                      = e
 
 -- BEGIN: TODO STRICTLY TO BE REMOVED LATER TODO

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -27,6 +27,10 @@ spec = do
       let pf = disambiguateFunction $ resetSrcSpan ex3
       pf `shouldBe'` expectedEx3
 
+  describe "Function call / Variable disambiguation" $
+    it "disambiguates function calls in example 4" $ do
+      let pf = disambiguateFunction $ resetSrcSpan ex4
+      pf `shouldBe'` expectedEx4
 {-
 - program Main
 - integer a, b(1), c, e
@@ -173,6 +177,41 @@ expectedEx3pu1bs =
           (Just $ AList () u [ Argument () u Nothing
             (ExpFunctionCall () u (ExpValue () u $ ValVariable "f")
                                   (Just $ AList () u [ Argument () u Nothing (intGen 1) ])) ]))) ]
+
+
+{-
+- program Main
+- integer a, f
+- a = f(1)
+- end
+-}
+
+ex4 :: ProgramFile ()
+ex4 = ProgramFile mi77 [ ex4pu1 ]
+ex4pu1 :: ProgramUnit ()
+ex4pu1 = PUMain () u (Just "main") ex4pu1bs Nothing
+ex4pu1bs :: [Block ()]
+ex4pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing
+      , DeclVariable () u (varGen "f") Nothing Nothing ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
+
+expectedEx4 :: ProgramFile ()
+expectedEx4 = ProgramFile mi77 [ expectedEx4pu1 ]
+expectedEx4pu1 :: ProgramUnit ()
+expectedEx4pu1 = PUMain () u (Just "main") expectedEx4pu1bs Nothing
+
+expectedEx4pu1bs :: [Block ()]
+expectedEx4pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing
+      , DeclVariable () u (varGen "f") Nothing Nothing ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a")
+       (ExpFunctionCall () u (ExpValue () u $ ValVariable "f")
+                                  (Just $ AList () u [ Argument () u Nothing (intGen 1) ] ))) ]
 
 -- Local variables:
 -- mode: haskell


### PR DESCRIPTION
In the following code `foo` is a function defined in other compilation unit. It is declared as a variable however is being used as an array in this compilation unit. With this knowledge we shall be able to resolve `foo` as a function.

```
      program main 
      integer a
      integer foo
      a = foo (1, 2)
      end
```
