### PR TITLE
Fix SrcSpan of "if" to include "endif"

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -76,3 +76,4 @@ tests:
     - deepseq
     - hspec >=2.2 && <3
     - fortran-src
+    - raw-strings-qq >= 1.1

--- a/test/Language/Fortran/Transformation/GroupingSpec.hs
+++ b/test/Language/Fortran/Transformation/GroupingSpec.hs
@@ -6,7 +6,6 @@ import Test.Hspec hiding (Selector)
 import TestUtil
 import Control.Exception (evaluate)
 import Control.DeepSeq (force, NFData)
-import qualified Data.ByteString as B
 import Data.ByteString.Char8 (pack)
 import Text.RawString.QQ
 


### PR DESCRIPTION
Fixes the issue mentioned here https://github.com/camfort/fortran-src/issues/46#issuecomment-438057635

Copying here:

There is a ***big*** problem for `SrcSpan`s related to `BlIf` (i.e. if blocks).

As a trivial example, consider the following:

```fortran
      subroutine foo
      if (.TRUE.) then
      print *, 'I print'
      endif
      end
```

The `SrcSpan` for this block shows that its end is the the last character (`'`) in the `print` line.

Ok, so maybe this isn't so bad, we can *probably* assume that the real end to the `BlIf` is one additional line down and `6 + 5` characters over (6 for indentation).

On the other hand the problem is *much much* worse for if the if blocks are *nested*.

```fortran
      subroutine bar
      if (.TRUE.) then
      if (.TRUE.) then
      if (.TRUE.) then
      if (.TRUE.) then
      print *, 'I print'
      endif
      endif
      endif
      endif
      end
```

For ***every*** `BlIf` in the above code, the corresponding `SrcSpan`'s end is the last character (`'`) in the `print` line.

This means that in order to even think about determining the span of any if statement anywhere using `fortran-src` we need to traverse the tree all the way down and pull up the (possibly different) end of the span on the way up. *And this may not even be able to be done correctly if the `endif`s are not all the way to the left (i.e. 6 characters from the left).*

I have a very hard time thinking of any reasons why the current system would be useful given the nesting problem.

---

This PR fixes this issue, by changing the `SrcSpan` to include the `StEndif`, which previously was just thrown away in the grouping step.

@ruoso