### PR TITLE
Implicit function calls should be disambiguated

### DIFF
--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -40,6 +40,8 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
       | Just (IDType _ (Just CTVariable)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
+      | Nothing <- idType a
+      , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
       | Just (IDType _ (Just CTIntrinsic)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -31,6 +31,11 @@ spec = do
     it "disambiguates function calls in example 4" $ do
       let pf = disambiguateFunction $ resetSrcSpan ex4
       pf `shouldBe'` expectedEx4
+
+  describe "Implicit Function call / Variable disambiguation" $
+    it "disambiguates function calls in example 5" $ do
+      let pf = disambiguateFunction $ resetSrcSpan ex5
+      pf `shouldBe'` expectedEx5
 {-
 - program Main
 - integer a, b(1), c, e
@@ -208,6 +213,39 @@ expectedEx4pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ DeclVariable () u (varGen "a") Nothing Nothing
       , DeclVariable () u (varGen "f") Nothing Nothing ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a")
+       (ExpFunctionCall () u (ExpValue () u $ ValVariable "f")
+                                  (Just $ AList () u [ Argument () u Nothing (intGen 1) ] ))) ]
+
+{-
+- program Main
+- integer a
+- a = f(1)
+- end
+-}
+
+ex5 :: ProgramFile ()
+ex5 = ProgramFile mi77 [ ex5pu1 ]
+ex5pu1 :: ProgramUnit ()
+ex5pu1 = PUMain () u (Just "main") ex5pu1bs Nothing
+ex5pu1bs :: [Block ()]
+ex5pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing
+      ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
+
+expectedEx5 :: ProgramFile ()
+expectedEx5 = ProgramFile mi77 [ expectedEx5pu1 ]
+expectedEx5pu1 :: ProgramUnit ()
+expectedEx5pu1 = PUMain () u (Just "main") expectedEx5pu1bs Nothing
+
+expectedEx5pu1bs :: [Block ()]
+expectedEx5pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing ]))
   , BlStatement () u Nothing
       (StExpressionAssign () u (varGen "a")
        (ExpFunctionCall () u (ExpValue () u $ ValVariable "f")

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -36,6 +36,12 @@ spec = do
     it "disambiguates function calls in example 5" $ do
       let pf = disambiguateFunction $ resetSrcSpan ex5
       pf `shouldBe'` expectedEx5
+
+  describe "Implicit array declaration with dimension disambiguation" $
+    it "Should not disambiguation to a function call in example 6" $ do
+      let pf = disambiguateFunction $ resetSrcSpan ex6
+      pf `shouldBe'` expectedEx6
+
 {-
 - program Main
 - integer a, b(1), c, e
@@ -250,6 +256,42 @@ expectedEx5pu1bs =
       (StExpressionAssign () u (varGen "a")
        (ExpFunctionCall () u (ExpValue () u $ ValVariable "f")
                                   (Just $ AList () u [ Argument () u Nothing (intGen 1) ] ))) ]
+
+{-
+- program Main
+- integer a
+- dimension f(10)
+- a = f(1)
+- end
+-}
+
+ex6 :: ProgramFile ()
+ex6 = ProgramFile mi77 [ ex6pu1 ]
+ex6pu1 :: ProgramUnit ()
+ex6pu1 = PUMain () u (Just "main") ex6pu1bs Nothing
+ex6pu1bs :: [Block ()]
+ex6pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing
+      ]))
+  , BlStatement () u Nothing (StDimension () u (AList () u
+      [ DeclArray () u (varGen "f") (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10 ) ]) Nothing Nothing ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
+
+expectedEx6 :: ProgramFile ()
+expectedEx6 = ProgramFile mi77 [ expectedEx6pu1 ]
+expectedEx6pu1 :: ProgramUnit ()
+expectedEx6pu1 = PUMain () u (Just "main") expectedEx6pu1bs Nothing
+
+expectedEx6pu1bs :: [Block ()]
+expectedEx6pu1bs =
+  [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
+      [ DeclVariable () u (varGen "a") Nothing Nothing ]))
+  , BlStatement () u Nothing (StDimension () u (AList () u
+      [ DeclArray () u (varGen "f") (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10 ) ]) Nothing Nothing ]))
+  , BlStatement () u Nothing
+      (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
 
 -- Local variables:
 -- mode: haskell


### PR DESCRIPTION
Currently implicit function calls show up as an array index. They
should default to be a function call when no type is declared.