### PR TITLE
Fix missing edge in StComputedGotos

### DIFF
--- a/test/Language/Fortran/Analysis/BBlocksSpec.hs
+++ b/test/Language/Fortran/Analysis/BBlocksSpec.hs
@@ -26,7 +26,7 @@ spec =
           gr = fromJust . M.lookup (Named "loop4") $ genBBlockMap pf
           ns = nodes gr
           es = edges gr
-          nodeSet = IS.fromList $ nodes gr
+          nodeSet = IS.fromList ns
       it "nodes and edges length" $
         (length ns, length es) `shouldBe` (11, 12)
       it "branching nodes" $
@@ -59,6 +59,22 @@ spec =
         let gr = fromJust . M.lookup (Named "arithif") $ genBBlockMap pf
         let reached = IS.fromList $ rdfs [-1] gr
         let nodeSet = IS.fromList $ nodes gr
+        reached `shouldBe` nodeSet
+    describe "gotos" $ do
+      let pf = pParser programGotos
+          gr = fromJust . M.lookup (Named "_gotos1") $ genBBlockMap pf
+          ns = nodes gr
+          es = edges gr
+          nodeSet = IS.fromList ns
+      it "nodes and edges length" $ do
+        (length ns, length es) `shouldBe` (10, 12)
+      it "branching nodes" $
+        (IS.size (findSuccsBB gr [10]), IS.size (findSuccsBB gr [20])) `shouldBe` (3, 1)
+      it "all reachable" $ do
+        let reached = IS.fromList $ dfs [0] gr
+        reached `shouldBe` nodeSet
+      it "all terminate" $ do
+        let reached = IS.fromList $ rdfs [-1] gr
         reached `shouldBe` nodeSet
 
 --------------------------------------------------
@@ -118,6 +134,22 @@ programArithIf = unlines [
   , " 20   write (*,*) 20"
   , " 30   write (*,*) 30"
   , "      end"]
+
+programGotos :: String
+programGotos = unlines [
+    "      subroutine gotos(s)"
+  , "       integer s"
+  , "       character a"
+  , "       a = 'H'"
+  , " 10    goto (30, 40) s"
+  , " 20    goto 999"
+  , " 30    continue"
+  , "       if (a .eq. 'G') then"
+  , "        print *, 'almost there'"
+  , "       endif"
+  , " 40    continue"
+  , "999    print *, 'all done'"
+  , "      end" ]
 
 
 -- Local variables:


### PR DESCRIPTION
As it stands in `master` at the moment, `StComputedGoto`s are missing an edge out in the produced `BBlock`s.

[According to the standard](https://www.fortran.com/F77_std/rjcnf0001-sh-11.html#sh-11.2), if the expression supplied to a computed goto does not index into the supplied list of labels then the statement should act as if it were a `continue`. However, in the current implementation the `StGotoComputed` is handled as if it were a final block with an explicit control transfer, and adds only the edges that point to the supplied labels. This means that entire swaths of code can be missing from basic blocks if the path to that code is hit only in the case of the `goto` acting as a `continue`.

The issue in practice can be seen in the supplied test case where the lines
```fortran
 10    goto (30, 40) s
 20    goto 999
```
where `10` has only 2 edges going from it in the original basic block graph produced while `20` has  none, as they are pruned out as "unreachable".

This PR fixes this issue by adding an edge to the next block in the `perBlock` handling step, while also adding the control transfer edges as before.

@ruoso