### PR TITLE
Add missing edges for READ in BBlocks

### DIFF
--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -212,7 +212,7 @@ insExitEdges :: (Data a, DynGraph gr) => ProgramUnit (Analysis a) -> M.Map Strin
 insExitEdges pu lm gr = flip insEdges (insNode (-1, bs) gr) $ do
   n <- nodes gr
   bs' <- maybeToList $ lab gr n
-  guard $ null (out gr n) || isFinalBlockNonStrictCtrlXfer bs'
+  guard $ null (out gr n) || isFinalBlockExceptionalCtrlXfer bs'
   n' <- examineFinalBlock lm bs'
   return (n, n', ())
   where
@@ -259,13 +259,13 @@ isFinalBlockCtrlXfer bs@(_:_)
   -- it acts as a StContinue
 isFinalBlockCtrlXfer _                                 = False
 
--- True iff the final block in the list is a non-strict
--- control transfer, like a StGotoComputed or a StRead
-isFinalBlockNonStrictCtrlXfer :: [Block a] -> Bool
-isFinalBlockNonStrictCtrlXfer bs@(_:_)
+-- True iff the final block in the list has an control transfer
+-- with exceptional circumstances, like a StGotoComputed or a StRead
+isFinalBlockExceptionalCtrlXfer :: [Block a] -> Bool
+isFinalBlockExceptionalCtrlXfer bs@(_:_)
   | BlStatement _ _ _ StGotoComputed{} <- last bs = True
   | BlStatement _ _ _ StRead{}         <- last bs = True
-isFinalBlockNonStrictCtrlXfer _                   = False
+isFinalBlockExceptionalCtrlXfer _                   = False
 
 lookupBBlock :: Num a1 => M.Map String a1 -> Expression a2 -> a1
 lookupBBlock lm a =

--- a/test/Language/Fortran/Analysis/BBlocksSpec.hs
+++ b/test/Language/Fortran/Analysis/BBlocksSpec.hs
@@ -76,6 +76,23 @@ spec =
       it "all terminate" $ do
         let reached = IS.fromList $ rdfs [-1] gr
         reached `shouldBe` nodeSet
+    describe "READ" $ do
+      let pf = pParser programRead
+          gr = fromJust . M.lookup (Named "reading_time") $ genBBlockMap pf
+          ns = nodes gr
+          es = edges gr
+          nodeSet = IS.fromList ns
+      it "nodes and edges length" $ do
+        (length ns, length es) `shouldBe` (10, 11)
+      it "branching nodes" $ do
+        let succs l = IS.size $ findSuccsBB gr [l]
+        (succs 10, succs 20, succs 40, succs 60) `shouldBe` (3, 1, 1, 1)
+      it "all reachable" $ do
+        let reached = IS.fromList $ dfs [0] gr
+        reached `shouldBe` nodeSet
+      it "all terminate" $ do
+        let reached = IS.fromList $ rdfs [-1] gr
+        reached `shouldBe` nodeSet
 
 --------------------------------------------------
 -- Label-finding helper functions to help write tests that are
@@ -149,6 +166,20 @@ programGotos = unlines [
   , "       endif"
   , " 40    continue"
   , "999    print *, 'all done'"
+  , "      end" ]
+
+programRead :: String
+programRead = unlines [
+    "      program reading_time"
+  , "       integer i"
+  , " 10    read(*, *, END=30, ERR=50) i"
+  , " 20    goto 70"
+  , " 30    print *, 'end'"
+  , " 40    goto 70"
+  , " 50    print *, 'err'"
+  , " 60    goto 70"
+  , " 70    print *, 'done'"
+  , "       print *, i"
   , "      end" ]
 
 


### PR DESCRIPTION
[According to the standard](https://docs.oracle.com/cd/E19957-01/805-4939/6j4m0vnat/index.html), the `READ` function has two optional labeled arguments, `END` and `ERR`, that allow the programmer to specify labels where control should continue when the end of file or some error occurs during the processing of the `READ`, respectively.

Currently these edges are not added into the basic blocks, which can lead to large paths being absent from the generated basic block graph.

This PR adds in the edges when these arguments are present.

@ruoso