### PR TITLE
Fix SrcSpan end issue for BlDo and BlDoWhile

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -76,4 +76,3 @@ tests:
     - deepseq
     - hspec >=2.2 && <3
     - fortran-src
-    - raw-strings-qq >= 1.1


### PR DESCRIPTION
This fixes the issue that `BlDo` and `BlDoWhile` do not have the correct end in their respective `SrcSpan`s after the grouping transformation. This is similar to how the [`BlIf` was previously fixed](https://github.com/camfort/fortran-src/pull/88).

As far as I can tell this fixes all of the post-grouping spans for FORTRAN 77 standard constructs.

Since it was rather unnecessary, I also removed the test suite's dependency on `raw-strings-qq` in favor of `unlines` as well.

@ruoso