### PR TITLE
Handle leading-zero labels in BBlocks

### DIFF
--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -268,10 +268,9 @@ isFinalBlockExceptionalCtrlXfer bs@(_:_)
 isFinalBlockExceptionalCtrlXfer _                   = False
 
 -- Drop any '0' that appear at the beginning of a label since
--- labels like "40" and "040" are equivalent.
+-- labels like "40" and "040" are considered equivalent.
 dropLeadingZeroes :: String -> String
-dropLeadingZeroes ('0' : xs) = dropLeadingZeroes xs
-dropLeadingZeroes xs = xs
+dropLeadingZeroes = dropWhile (== '0')
 
 lookupBBlock :: Num a1 => M.Map String a1 -> Expression a2 -> a1
 lookupBBlock lm a =

--- a/test/Language/Fortran/Analysis/BBlocksSpec.hs
+++ b/test/Language/Fortran/Analysis/BBlocksSpec.hs
@@ -93,6 +93,23 @@ spec =
       it "all terminate" $ do
         let reached = IS.fromList $ rdfs [-1] gr
         reached `shouldBe` nodeSet
+    describe "Leading zero labels" $ do
+      let pf = pParser programZeroLabels
+          gr = fromJust . M.lookup (Named "zero_labels") $ genBBlockMap pf
+          ns = nodes gr
+          es = edges gr
+          nodeSet = IS.fromList ns
+      it "nodes and edges length" $ do
+        (length ns, length es) `shouldBe` (13, 15)
+      it "branching nodes" $ do
+        let succs l = IS.size $ findSuccsBB gr [l]
+        (succs 10, succs 20, succs 40, succs 60, succs 80) `shouldBe` (4, 1, 1, 1, 1)
+      it "all reachable" $ do
+        let reached = IS.fromList $ dfs [0] gr
+        reached `shouldBe` nodeSet
+      it "all terminate" $ do
+        let reached = IS.fromList $ rdfs [-1] gr
+        reached `shouldBe` nodeSet
 
 --------------------------------------------------
 -- Label-finding helper functions to help write tests that are
@@ -180,6 +197,22 @@ programRead = unlines [
   , " 60    goto 70"
   , " 70    print *, 'done'"
   , "       print *, i"
+  , "      end" ]
+
+programZeroLabels :: String
+programZeroLabels = unlines [
+    "      program zero_labels"
+  , "       integer i"
+  , "  10   goto (30, 50, 70) i"
+  , "  20   goto 999"
+  , "  30   print *, '30'"
+  , "  40   goto 900"
+  , " 050   print *, '050'"
+  , "  60   goto 900"
+  , " 070   print *, '070'"
+  , "  80   goto 0900"
+  , " 0900  print *, '0900'"
+  , "  999  continue"
   , "      end" ]
 
 


### PR DESCRIPTION
FORTRAN considers labels with leading zeroes to be the same as those without them, for instance the following program still has a valid `goto`
```fortran
      program foobar
      goto 400
      print *, 'unreachable'
      goto 900
 0400 print *, '0400'
  900 continue
      end
```
However, `fortran-src` is not picking up on this in `BBlocks`, so in the preceding example the basic block containing `0400` would end up being unreachable.

This PR fixes this issue by simply removing the leading zeroes from the strings used as keys in the label map. It is done this way as opposed to simply converting the strings to their numerical representation because it seems the label map also contains variables as keys in the case of the F77 `ASSIGN` statement. Since variables cannot start with numbers, this should not affect this code path.

@ruoso