### PR TITLE
Add missing signature for isDo in Transformation.Grouping

### DIFF
--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -227,6 +227,7 @@ collectNonDoBlocks blocks mNameTarget =
       in (b : bs', rest, mLabel, stEnd)
     _ -> error "Premature file ending while parsing structured do block."
 
+isDo :: Statement a -> Bool
 isDo s = case s of
   StDo _ _ _ Nothing _      -> True
   StDoWhile _ _ _ Nothing _ -> True


### PR DESCRIPTION
Fixes the issue that causes CI to fail (in #103 for instance).