### PR TITLE
Ignore comments in structure declaration

### DIFF
--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -515,28 +515,30 @@ MAYBE_NAME
 STRUCTURE_DECLARATIONS :: { [StructureItem A0] }
 STRUCTURE_DECLARATIONS
 : STRUCTURE_DECLARATIONS STRUCTURE_DECLARATION_STATEMENT
-  { $2 : $1 }
-| STRUCTURE_DECLARATION_STATEMENT { [ $1 ] }
+  { if isNothing $2 then $1 else fromJust $2 : $1 }
+| STRUCTURE_DECLARATION_STATEMENT { if isNothing $1 then [] else [fromJust $1] }
 
-STRUCTURE_DECLARATION_STATEMENT :: { StructureItem A0 }
+STRUCTURE_DECLARATION_STATEMENT :: { Maybe (StructureItem A0) }
 STRUCTURE_DECLARATION_STATEMENT
 : DECLARATION_STATEMENT NEWLINE
   { let StDeclaration () s t attrs decls = $1
-    in StructFields () s t attrs decls }
+    in Just $ StructFields () s t attrs decls }
 | union NEWLINE UNION_MAPS endunion NEWLINE
-  { StructUnion () (getTransSpan $1 $5) (fromReverseList $3) }
+  { Just $ StructUnion () (getTransSpan $1 $5) (fromReverseList $3) }
 | structure MAYBE_NAME NAME NEWLINE STRUCTURE_DECLARATIONS endstructure NEWLINE
-  { StructStructure () (getTransSpan $1 $7) $2 $3 (fromReverseList $5) }
+  { Just $ StructStructure () (getTransSpan $1 $7) $2 $3 (fromReverseList $5) }
+| comment NEWLINE { Nothing }
 
 UNION_MAPS :: { [ UnionMap A0 ] }
 UNION_MAPS
-: UNION_MAPS UNION_MAP { $2 : $1 }
-| UNION_MAP { [ $1 ] }
+: UNION_MAPS UNION_MAP { if isNothing $2 then $1 else fromJust $2 : $1 }
+| UNION_MAP { if isNothing $1 then [] else [fromJust $1] }
 
-UNION_MAP :: { UnionMap A0 }
+UNION_MAP :: { Maybe (UnionMap A0) }
 UNION_MAP
 : map NEWLINE STRUCTURE_DECLARATIONS endmap NEWLINE
-  { UnionMap () (getTransSpan $1 $5) (fromReverseList $3) }
+  { Just $ UnionMap () (getTransSpan $1 $5) (fromReverseList $3) }
+| comment NEWLINE { Nothing }
 
 ENTRY_ARGS :: { AList Expression A0 }
 ENTRY_ARGS

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -236,6 +236,34 @@ spec =
             st = StStructure () u (Just "foo") $ AList () u [StructUnion () u $ AList () u ds]
         resetSrcSpan (slParser src) `shouldBe` st
 
+      it "parses structure/union/map blocks with comments" $ do
+        let src = init
+                $ unlines [ "      structure /foo/"
+                          , "C       comment before union"
+                          , "        union"
+                          , "C         comment inside union, before map"
+                          , "          map"
+                          , "C           comment inside map"
+                          , "            integer i ! more comment"
+                          , "          end map"
+                          , "C         comment between maps"
+                          , "          map"
+                          , "            real r    ! more comment"
+                          , "          end map"
+                          , "C         comment after map"
+                          , "        end union"
+                          , "C       comment after union"
+                          , "      end structure"]
+            ds = [ UnionMap () u $ AList () u
+                   [StructFields () u (TypeSpec () u TypeInteger Nothing) Nothing $
+                    AList () u [DeclVariable () u (varGen "i") Nothing Nothing]]
+                 , UnionMap () u $ AList () u
+                   [StructFields () u (TypeSpec () u TypeReal Nothing) Nothing $
+                    AList () u [DeclVariable () u (varGen "r") Nothing Nothing]]
+                 ]
+            st = StStructure () u (Just "foo") $ AList () u [StructUnion () u $ AList () u ds]
+        resetSrcSpan (slParser src) `shouldBe` st
+
       it "parses nested structure blocks" $ do
         let src = init
                 $ unlines [ "      structure /foo/"


### PR DESCRIPTION
The `Fortran77Legacy` parser supports parsing of the structure, union and map. The following strcuture is parsed as  a single `StStructure` node. 
```fortran
structure /foo/
  integer i
  union 
    map
      integer j
    end map
    map
      real r
   end map
 end union
structure
```
Comments within the structure declaration are tricky to be included in the AST so they shall just be ignored.
Fortran77Legacy lexer used to ignore all comments. Now It passes the comment tokens to the parser for use cases specified in the PR
https://github.com/camfort/fortran-src/pull/103

However, the parsing of structure now fails if there is any comment inside the structure declaration. This PR update the grammar for structure, union, map to ignore the comments within the structure declaration.
