### PR TITLE
Add subscript to ARITHMETIC_CONSTANT_EXPRESSION

### DIFF
--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -882,6 +882,7 @@ ARITHMETIC_CONSTANT_EXPRESSION
 | NUMERIC_LITERAL               { $1 }
 | '(' ARITHMETIC_CONSTANT_EXPRESSION ',' ARITHMETIC_CONSTANT_EXPRESSION ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
 | VARIABLE                     { $1 }
+| SUBSCRIPT                    { $1 }
 
 RELATIONAL_OPERATOR :: { BinaryOp }
 RELATIONAL_OPERATOR

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -206,6 +206,14 @@ spec =
           st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
       sParser "      character a*8" `shouldBe'` st
 
+    it "parses 'character c*(ichar('A'))" $ do
+      let args = AList () u [ IxSingle () u Nothing (ExpValue () u (ValString "A")) ]
+          lenExpr = ExpSubscript () u (ExpValue () u (ValVariable "ichar")) args
+          decl = DeclVariable () u (varGen "c") (Just $ lenExpr) Nothing
+          typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
+      sParser "      character c*(ichar('A'))" `shouldBe'` st
+
     it "parses included files" $ do
       let decl = DeclVariable () u (varGen "a") Nothing Nothing
           typeSpec = TypeSpec () u TypeInteger Nothing


### PR DESCRIPTION
Fortran intrinsics are allowed in these types of expressions, so the parser needs to be able to parse functions here. For example in setting the length of a character variable, the following is valid: `character*(len(d)) c`.

There might be a better solution as this allows a lot of non-valid expressions, but given function calls need to be disambiguated from other subscript expressions maybe this isn't possible in the parser.