### PR TITLE
Pretty printer fixes

### DIFF
--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -386,9 +386,9 @@ instance Pretty (Selector a) where
     | v < Fortran90 =
       case (mLenSel, mKindSel) of
         (Just lenSel, Nothing) ->
-          char '*' <+> parens (pprint' Fortran77Extended lenSel)
+          char '*' <> noParensLit lenSel
         (Nothing, Just kindSel) ->
-          char '*' <+> parens (pprint' Fortran77Extended kindSel)
+          char '*' <> noParensLit kindSel
         _ -> error "Kind and length selectors can be active one at a time in\
                    \Fortran 77."
 
@@ -404,6 +404,8 @@ instance Pretty (Selector a) where
     where
       len e  = "len=" <> pprint' v e
       kind e = "kind=" <> pprint' v e
+      noParensLit e@(ExpValue _ _ (ValInteger _))  = pprint' v e
+      noParensLit e = parens $ pprint' v e
 
 instance Pretty (Statement a) where
     pprint' v (StDeclaration _ _ typeSpec mAttrList declList)

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -996,7 +996,9 @@ instance Pretty (Declarator a) where
         case mInit of
           Nothing -> pprint' v e <>
                      char '*' <?> pprint' v mLen
-          _ -> tooOld v "Variable initialisation" Fortran90
+          Just init -> pprint' v e <>
+                       char '*' <?> pprint' v mLen <>
+                       char '/' <> pprint' v init <> char '/'
 
     pprint' v (DeclVariable _ _ e mLen mInit)
       | Nothing <- mLen
@@ -1015,7 +1017,14 @@ instance Pretty (Declarator a) where
         case mInit of
           Nothing -> pprint' v e <> parens (pprint' v dims) <>
                      "*" <?> pprint' v mLen
-          _ -> tooOld v "Variable initialisation" Fortran90
+          Just init ->
+            let initDoc = case init of
+                  ExpInitialisation _ _ es ->
+                    char '/' <> pprint' v es <> char '/'
+                  e -> pprint' v e
+            in pprint' v e <> parens (pprint' v dims) <>
+               "*" <?> pprint' v mLen <> initDoc
+
     pprint' v (DeclArray _ _ e dims mLen mInit)
       | Nothing <- mLen
       , Nothing <- mInit = pprint' v e <> parens (pprint' v dims)

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -54,7 +54,11 @@ spec =
     describe "Selector" $ do
       it "prints Fortran 77 selector" $ do
         let sel = Selector () u (Just $ intGen 42) Nothing
-        pprint Fortran77 sel Nothing `shouldBe` "* (42)"
+        pprint Fortran77 sel Nothing `shouldBe` "*42"
+        let ksel = Selector () u Nothing (Just $ intGen 4)
+        pprint Fortran77 ksel Nothing `shouldBe` "*4"
+        let vsel = Selector () u (Just $ varGen "v") Nothing
+        pprint Fortran77 vsel Nothing `shouldBe` "*(v)"
 
       it "prints Fortran 90 selector" $ do
         let sel = Selector () u (Just $ intGen 42) (Just $ intGen 24)

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -122,11 +122,13 @@ spec =
 
         it "prints 77 style" $ do
           let typeSpec = TypeSpec () u TypeInteger Nothing
-          let dds = [ DimensionDeclarator () u Nothing (Just $ intGen 10) ]
+          let dds = [ DimensionDeclarator () u Nothing (Just $ intGen 5) ]
           let declList =
-                [ DeclArray () u (varGen "x") (AList () u dds) Nothing Nothing ]
+                [ DeclArray () u (varGen "x") (AList () u dds) Nothing
+                            (Just . initGen $ map intGen [1..5])
+                ]
           let st = StDeclaration () u typeSpec Nothing (AList () u declList)
-          pprint Fortran77 st Nothing `shouldBe` "integer x(10)"
+          pprint Fortran77 st Nothing `shouldBe` "integer x(5)/1, 2, 3, 4, 5/"
 
       describe "Intent" $
         it "prints intent statement" $ do

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -35,6 +35,9 @@ varGen str = ExpValue () u $ ValVariable str
 intGen :: Integer -> Expression ()
 intGen i = ExpValue () u $ ValInteger $ show i
 
+initGen :: [Expression ()] -> Expression ()
+initGen es = ExpInitialisation () u $ fromList () es
+
 realGen :: (Fractional a, Show a) => a -> Expression ()
 realGen i = ExpValue () u $ ValReal $ show i
 


### PR DESCRIPTION
Two small fixes to the pretty printer which resulted in either failures or invalid code.
* Avoid parenthesis for integer literals in the kind and length selectors, for example GFortran wont compile the declaration `integer*(4) i`.
* Pretty print old style initialisers. Previously it failed saying that variable initialisation wasn't in fortran 77, despite the fact the parser accepts it.