### PR TITLE
Update lts

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -15,7 +15,6 @@ import Data.Data
 import Data.Generics.Uniplate.Data ()
 import Data.Typeable ()
 import Data.Binary
-import GHC.Generics (Generic)
 import Control.DeepSeq
 import Text.PrettyPrint.GenericPretty
 import Language.Fortran.ParserMonad (FortranVersion(..))

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -22,7 +22,6 @@ import Language.Fortran.AST
 import Language.Fortran.LValue
 import Data.Graph.Inductive (Node, empty)
 import Data.Graph.Inductive.PatriciaTree (Gr)
-import GHC.Generics (Generic)
 import Text.PrettyPrint.GenericPretty
 import Text.PrettyPrint hiding (empty, isEmpty)
 import qualified Data.Map.Strict as M

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -21,7 +21,6 @@ import Language.Fortran.Util.Position
 import qualified Data.Map as M
 import qualified Data.IntMap as IM
 import Data.Graph.Inductive
-import Data.Graph.Inductive.PatriciaTree (Gr)
 import Data.List (intercalate)
 import Data.Maybe
 import Data.Functor.Identity

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -40,7 +40,6 @@ import qualified Data.IntMap.Strict as IMS
 import qualified Data.Set as S
 import qualified Data.IntSet as IS
 import Data.Graph.Inductive hiding (trc, dom, order, inn, out, rc)
-import Data.Graph.Inductive.PatriciaTree (Gr)
 import Data.Maybe
 import Data.List (foldl', foldl1', (\\), union, intersect)
 import Control.Monad.Writer hiding (fix)

--- a/src/Language/Fortran/Analysis/ModGraph.hs
+++ b/src/Language/Fortran/Analysis/ModGraph.hs
@@ -11,7 +11,6 @@ import Control.Monad.State.Strict
 import Data.Data
 import Data.Generics.Uniplate.Data
 import Data.Graph.Inductive hiding (version)
-import Data.Graph.Inductive.PatriciaTree (Gr)
 import Data.Maybe
 import Data.Text.Encoding (encodeUtf8, decodeUtf8With)
 import Data.Text.Encoding.Error (replace)

--- a/src/Language/Fortran/Analysis/Renaming.hs
+++ b/src/Language/Fortran/Analysis/Renaming.hs
@@ -17,11 +17,10 @@ import Language.Fortran.Analysis
 import Language.Fortran.ParserMonad (FortranVersion(..))
 
 import Prelude hiding (lookup)
-import Data.Maybe (mapMaybe, maybe, fromMaybe)
+import Data.Maybe (mapMaybe, fromMaybe)
 import qualified Data.List as L
 import Data.Map (insert, empty, lookup, Map)
 import qualified Data.Map.Strict as M
-import Control.Monad (void)
 import Control.Monad.State.Strict
 import Data.Generics.Uniplate.Data
 import Data.Data

--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -15,7 +15,7 @@ module Language.Fortran.Lexer.FixedForm
 
 import Data.Word (Word8)
 import Data.Char (toLower, ord, isDigit)
-import Data.List (isPrefixOf, any)
+import Data.List (isPrefixOf)
 import Data.Maybe (fromJust, isNothing, isJust)
 import Data.Data
 import qualified Data.Bits

--- a/src/Language/Fortran/ParserMonad.hs
+++ b/src/Language/Fortran/ParserMonad.hs
@@ -147,6 +147,7 @@ instance (Loc b, LastToken b c, Show c) => Monad (Parse b c) where
       ParseOk a s' -> unParse (f a) s'
       ParseFailed e -> ParseFailed e
 
+instance (Loc b, LastToken b c, Show c) => MonadFail (Parse b c) where
   fail msg = Parse $ \s -> ParseFailed ParseError
     { errPos        = (getPos . psAlexInput) s
     , errLastToken  = (getLastToken . psAlexInput) s

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -996,9 +996,9 @@ instance Pretty (Declarator a) where
         case mInit of
           Nothing -> pprint' v e <>
                      char '*' <?> pprint' v mLen
-          Just init -> pprint' v e <>
+          Just initial -> pprint' v e <>
                        char '*' <?> pprint' v mLen <>
-                       char '/' <> pprint' v init <> char '/'
+                       char '/' <> pprint' v initial <> char '/'
 
     pprint' v (DeclVariable _ _ e mLen mInit)
       | Nothing <- mLen
@@ -1017,11 +1017,11 @@ instance Pretty (Declarator a) where
         case mInit of
           Nothing -> pprint' v e <> parens (pprint' v dims) <>
                      "*" <?> pprint' v mLen
-          Just init ->
-            let initDoc = case init of
+          Just initial ->
+            let initDoc = case initial of
                   ExpInitialisation _ _ es ->
                     char '/' <> pprint' v es <> char '/'
-                  e -> pprint' v e
+                  e' -> pprint' v e'
             in pprint' v e <> parens (pprint' v dims) <>
                "*" <?> pprint' v mLen <> initDoc
 

--- a/src/Language/Fortran/Util/Position.hs
+++ b/src/Language/Fortran/Util/Position.hs
@@ -9,7 +9,6 @@ import Data.Data
 import Text.PrettyPrint.GenericPretty
 import Text.PrettyPrint
 import Data.Binary
-import GHC.Generics (Generic)
 import Control.DeepSeq
 
 import Language.Fortran.Util.SecondParameter

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.1
+resolver: lts-16.7
 packages:
 - '.'
 save-hackage-creds: false


### PR DESCRIPTION
We're hoping to use ghc 8.8 soon so this moves the fail definition out of Monad into MonadFail, as well as updating various pedantic warnings introduced by changes to libraries.