### PR TITLE
Don't truncate lines after 72 but skip in the lexer

### DIFF
--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -929,6 +929,9 @@ alexGetByte ai
   -- Ignore inline comments
   | aiFortranVersion ai == Fortran77Legacy &&
     _isWhiteInsensitive && not _inFormat && _curChar == '!' = skip Comment ai
+  -- Ignore comments after column 72 in fortran77
+  | aiFortranVersion ai == Fortran77Legacy && posColumn _position > 72 && _curChar /= '\n'
+  = skip Comment ai
   -- Read genuine character and advance. Also covers white sensitivity.
   | otherwise =
       let (_b:_bs) = utf8Encode _curChar in

--- a/test/Language/Fortran/Lexer/FixedFormSpec.hs
+++ b/test/Language/Fortran/Lexer/FixedFormSpec.hs
@@ -255,6 +255,29 @@ spec =
                                   , TEndStructure u, TNewline u
                                   , TEOF u ]
 
+      it "lexes but skips comments after 72" $ do
+        let src  = unlines [ "       l = r" <> replicate 65 ' ' <> "! comment after 72"
+                           , "       r = l"
+                           , replicate 72 ' ' <> "blank line with comment"]
+        resetSrcSpan (collectFixedTokens' Fortran77Legacy src) `shouldBe`
+          resetSrcSpan [ TId u "l", TOpAssign u, TId u "r", TNewline u
+                       , TId u "r", TOpAssign u, TId u "l", TNewline u
+                       , TNewline u, TEOF u]
+      it "lexes comment overflow" $ do
+        let src = unlines
+              [ "      l = r" <> replicate 65 ' ' <>  "Comment overflowing 72 limit"
+              , "      r = l"
+              ]
+        resetSrcSpan (collectFixedTokens' Fortran77Legacy src) `shouldBe`
+          resetSrcSpan [ TId u "l", TOpAssign u, TId u "r", TNewline u
+                       , TId u "r", TOpAssign u, TId u "l", TNewline u, TEOF u]
+      it "lexel comment line overflow" $ do
+        let src = unlines [ replicate 80 'c'
+                          , "      l = r" ]
+        resetSrcSpan (collectFixedTokens' Fortran77Legacy src) `shouldBe`
+          resetSrcSpan [ TComment u (replicate 71 'c'), TNewline u
+                       , TId u "l", TOpAssign u, TId u "r", TNewline u, TEOF u]
+
 example1 :: String
 example1 = unlines [
   "      intEGerix",


### PR DESCRIPTION
Previously fortran-src just truncated lines for legacy 77 mode before any lexing, and this meant `PosAbsoluteOffset` didn't correspond to the position in the file for anything following characters after column 72.