### PR TITLE
Promote FortranVersion to own separate module

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ library:
   - Language.Fortran.Analysis.BBlocks
   - Language.Fortran.Analysis.DataFlow
   - Language.Fortran.AST
+  - Language.Fortran.Version
   - Language.Fortran.LValue
   - Language.Fortran.Intrinsics
   - Language.Fortran.Lexer.FixedForm

--- a/src/Language/Fortran/Analysis/ModGraph.hs
+++ b/src/Language/Fortran/Analysis/ModGraph.hs
@@ -15,7 +15,8 @@ import Data.Maybe
 import Data.Text.Encoding (encodeUtf8, decodeUtf8With)
 import Data.Text.Encoding.Error (replace)
 import Language.Fortran.AST hiding (setName)
-import Language.Fortran.Parser.Any
+import Language.Fortran.Version (FortranVersion(..), deduceFortranVersion)
+import Language.Fortran.Parser.Any (parserWithModFilesVersions)
 import Language.Fortran.ParserMonad (FortranVersion(..), fromRight)
 import Language.Fortran.Util.ModFile
 import qualified Data.ByteString.Char8 as B
@@ -87,7 +88,7 @@ genModGraph mversion includeDirs paths = do
   let iter :: FilePath -> ModGrapher ()
       iter path = do
         contents <- liftIO $ flexReadFile path
-        let version = fromMaybe (deduceVersion path) mversion
+        let version = fromMaybe (deduceFortranVersion path) mversion
         let (Just parserF0) = lookup version parserWithModFilesVersions
         let parserF m b s = fromRight (parserF0 m b s)
         fileMods <- liftIO $ decodeModFiles includeDirs

--- a/src/Language/Fortran/Analysis/ModGraph.hs
+++ b/src/Language/Fortran/Analysis/ModGraph.hs
@@ -17,7 +17,7 @@ import Data.Text.Encoding.Error (replace)
 import Language.Fortran.AST hiding (setName)
 import Language.Fortran.Version (FortranVersion(..), deduceFortranVersion)
 import Language.Fortran.Parser.Any (parserWithModFilesVersions)
-import Language.Fortran.ParserMonad (FortranVersion(..), fromRight)
+import Language.Fortran.ParserMonad (fromRight)
 import Language.Fortran.Util.ModFile
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as LB

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -2,7 +2,8 @@ module Language.Fortran.Parser.Any where
 
 import Language.Fortran.AST
 import Language.Fortran.Util.ModFile
-import Language.Fortran.ParserMonad (FortranVersion(..), ParseErrorSimple(..), fromParseResult)
+import Language.Fortran.Version (FortranVersion(..), deduceFortranVersion)
+import Language.Fortran.ParserMonad (ParseErrorSimple(..), fromParseResult)
 
 import Language.Fortran.Parser.Fortran66 ( fortran66Parser, fortran66ParserWithModFiles )
 import Language.Fortran.Parser.Fortran77 ( fortran77Parser, fortran77ParserWithModFiles
@@ -13,24 +14,6 @@ import Language.Fortran.Parser.Fortran95 ( fortran95Parser, fortran95ParserWithM
 import Language.Fortran.Parser.Fortran2003 ( fortran2003Parser, fortran2003ParserWithModFiles )
 
 import qualified Data.ByteString.Char8 as B
-import Data.Char (toLower)
-import Data.List (isSuffixOf)
-
-deduceVersion :: String -> FortranVersion
-deduceVersion path
-  | isExtensionOf ".f"      = Fortran77Extended
-  | isExtensionOf ".for"    = Fortran77
-  | isExtensionOf ".fpp"    = Fortran77
-  | isExtensionOf ".ftn"    = Fortran77
-  | isExtensionOf ".f90"    = Fortran90
-  | isExtensionOf ".f95"    = Fortran95
-  | isExtensionOf ".f03"    = Fortran2003
-  | isExtensionOf ".f2003"  = Fortran2003
-  | isExtensionOf ".f08"    = Fortran2008
-  | isExtensionOf ".f2008"  = Fortran2008
-  | otherwise               = Fortran90 -- default
-  where
-    isExtensionOf = flip isSuffixOf $ map toLower path
 
 type Parser = B.ByteString -> String -> Either ParseErrorSimple (ProgramFile A0)
 parserVersions :: [(FortranVersion, Parser)]
@@ -61,14 +44,14 @@ after g f x = g . f x
 -- contents of the file.
 fortranParser :: Parser
 fortranParser contents filename = do
-   let Just parserF = lookup (deduceVersion filename) parserVersions
+   let Just parserF = lookup (deduceFortranVersion filename) parserVersions
    parserF contents filename
 
 -- | Deduce the type of parser from the filename and parse the
 -- contents of the file, within the context of given "mod files".
 fortranParserWithModFiles :: ParserWithModFiles
 fortranParserWithModFiles mods contents filename = do
-   let Just parserF = lookup (deduceVersion filename) parserWithModFilesVersions
+   let Just parserF = lookup (deduceFortranVersion filename) parserWithModFilesVersions
    parserF mods contents filename
 
 -- | Given a FortranVersion, parse the contents of the file.

--- a/src/Language/Fortran/ParserMonad.hs
+++ b/src/Language/Fortran/ParserMonad.hs
@@ -6,7 +6,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FunctionalDependencies #-}
 
-module Language.Fortran.ParserMonad where
+module Language.Fortran.ParserMonad
+  ( module Language.Fortran.ParserMonad
+  , module Language.Fortran.Version -- TODO: temporary plug to avoid API change
+  ) where
+
+import Language.Fortran.Version
 
 import GHC.IO.Exception
 import Control.Exception
@@ -24,39 +29,6 @@ import Data.List (isInfixOf, find)
 -------------------------------------------------------------------------------
 -- Helper datatype definitions
 -------------------------------------------------------------------------------
-
-data FortranVersion = Fortran66
-                    | Fortran77
-                    | Fortran77Extended
-                    | Fortran77Legacy
-                    | Fortran90
-                    | Fortran95
-                    | Fortran2003
-                    | Fortran2008
-                    deriving (Ord, Eq, Data, Typeable, Generic)
-
-instance Show FortranVersion where
-  show Fortran66 = "Fortran 66"
-  show Fortran77 = "Fortran 77"
-  show Fortran77Extended = "Fortran 77 Extended"
-  show Fortran77Legacy = "Fortran 77 Legacy"
-  show Fortran90 = "Fortran 90"
-  show Fortran95 = "Fortran 95"
-  show Fortran2003 = "Fortran 2003"
-  show Fortran2008 = "Fortran 2008"
-
-fortranVersionAliases :: [(String, FortranVersion)]
-fortranVersionAliases = [ ("66" , Fortran66)
-                        , ("77e", Fortran77Extended)
-                        , ("77l", Fortran77Legacy)
-                        , ("77" , Fortran77)
-                        , ("90" , Fortran90)
-                        , ("95" , Fortran95)
-                        , ("03" , Fortran2003)
-                        , ("08" , Fortran2008) ]
-
-selectFortranVersion :: String -> Maybe FortranVersion
-selectFortranVersion alias = snd <$> find (\ entry -> fst entry `isInfixOf` map toLower alias) fortranVersionAliases
 
 data ParanthesesCount = ParanthesesCount
   { pcActual :: Integer

--- a/src/Language/Fortran/ParserMonad.hs
+++ b/src/Language/Fortran/ParserMonad.hs
@@ -20,11 +20,7 @@ import Control.Monad.State hiding (state)
 import Control.Monad.Except
 
 import Data.Typeable
-import Data.Data
-import GHC.Generics (Generic)
 import Language.Fortran.Util.Position
-import Data.Char (toLower)
-import Data.List (isInfixOf, find)
 
 -------------------------------------------------------------------------------
 -- Helper datatype definitions

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Language.Fortran.Version
+  ( FortranVersion(..)
+  , fortranVersionAliases
+  , selectFortranVersion
+  ) where
+
+import           Data.Char (toLower)
+import           Data.List (isInfixOf, find)
+
+import Data.Data (Data, Typeable)
+import GHC.Generics (Generic)
+
+data FortranVersion = Fortran66
+                    | Fortran77
+                    | Fortran77Extended
+                    | Fortran77Legacy
+                    | Fortran90
+                    | Fortran95
+                    | Fortran2003
+                    | Fortran2008
+                    deriving (Ord, Eq, Data, Typeable, Generic)
+
+instance Show FortranVersion where
+  show Fortran66         = "Fortran 66"
+  show Fortran77         = "Fortran 77"
+  show Fortran77Extended = "Fortran 77 Extended"
+  show Fortran77Legacy   = "Fortran 77 Legacy"
+  show Fortran90         = "Fortran 90"
+  show Fortran95         = "Fortran 95"
+  show Fortran2003       = "Fortran 2003"
+  show Fortran2008       = "Fortran 2008"
+
+fortranVersionAliases :: [(String, FortranVersion)]
+fortranVersionAliases = [ ("66" , Fortran66)
+                        , ("77e", Fortran77Extended)
+                        , ("77l", Fortran77Legacy)
+                        , ("77" , Fortran77)
+                        , ("90" , Fortran90)
+                        , ("95" , Fortran95)
+                        , ("03" , Fortran2003)
+                        , ("08" , Fortran2008) ]
+
+selectFortranVersion :: String -> Maybe FortranVersion
+selectFortranVersion alias = snd <$> find (\ entry -> fst entry `isInfixOf` map toLower alias) fortranVersionAliases

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -1,14 +1,17 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
+-- | Fortran version enum and tools for selecting version for a given file.
+
 module Language.Fortran.Version
   ( FortranVersion(..)
   , fortranVersionAliases
   , selectFortranVersion
+  , deduceFortranVersion
   ) where
 
 import           Data.Char (toLower)
-import           Data.List (isInfixOf, find)
+import           Data.List (isInfixOf, isSuffixOf, find)
 
 import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)
@@ -45,3 +48,22 @@ fortranVersionAliases = [ ("66" , Fortran66)
 
 selectFortranVersion :: String -> Maybe FortranVersion
 selectFortranVersion alias = snd <$> find (\ entry -> fst entry `isInfixOf` map toLower alias) fortranVersionAliases
+
+-- | Deduce the 'FortranVersion' from a 'FilePath' using extension.
+--
+-- Defaults to Fortran 90 if suffix is unrecognized.
+deduceFortranVersion :: FilePath -> FortranVersion
+deduceFortranVersion path
+  | isExtensionOf ".f"      = Fortran77Extended
+  | isExtensionOf ".for"    = Fortran77
+  | isExtensionOf ".fpp"    = Fortran77
+  | isExtensionOf ".ftn"    = Fortran77
+  | isExtensionOf ".f90"    = Fortran90
+  | isExtensionOf ".f95"    = Fortran95
+  | isExtensionOf ".f03"    = Fortran2003
+  | isExtensionOf ".f2003"  = Fortran2003
+  | isExtensionOf ".f08"    = Fortran2008
+  | isExtensionOf ".f2008"  = Fortran2008
+  | otherwise               = Fortran90         -- unrecognized, default to F90
+  where
+    isExtensionOf = flip isSuffixOf $ map toLower path

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,11 +25,12 @@ import Data.Maybe (listToMaybe, fromMaybe, maybeToList)
 import Data.Data
 import Data.Generics.Uniplate.Data
 
-import Language.Fortran.ParserMonad (selectFortranVersion, FortranVersion(..), fromRight)
+import Language.Fortran.Version (FortranVersion(..), selectFortranVersion, deduceFortranVersion)
+import Language.Fortran.ParserMonad (fromRight)
 import qualified Language.Fortran.Lexer.FixedForm as FixedForm (collectFixedTokens, Token(..))
 import qualified Language.Fortran.Lexer.FreeForm as FreeForm (collectFreeTokens, Token(..))
 
-import Language.Fortran.Parser.Any
+import Language.Fortran.Parser.Any (parserWithModFilesVersions)
 
 import Language.Fortran.Util.ModFile
 import Language.Fortran.Util.Position
@@ -104,7 +105,7 @@ main = do
       mapM_ (\ p -> compileFileToMod (fortranVersion opts) mods p (outputFile opts)) paths
     (path:_, actionOpt) -> do
       contents <- flexReadFile path
-      let version = fromMaybe (deduceVersion path) (fortranVersion opts)
+      let version = fromMaybe (deduceFortranVersion path) (fortranVersion opts)
       let (Just parserF0) = lookup version parserWithModFilesVersions
       let parserF m b s = fromRight (parserF0 m b s)
       let outfmt = outputFormat opts
@@ -238,7 +239,7 @@ listDirectoryRecursively dir = listDirectoryRec dir ""
 compileFileToMod :: Maybe FortranVersion -> ModFiles -> FilePath -> Maybe FilePath -> IO ModFile
 compileFileToMod mvers mods path moutfile = do
   contents <- flexReadFile path
-  let version = fromMaybe (deduceVersion path) mvers
+  let version = fromMaybe (deduceFortranVersion path) mvers
   let (Just parserF0) = lookup version parserWithModFilesVersions
   let parserF m b s = fromRight (parserF0 m b s)
   let mmap = combinedModuleMap mods


### PR DESCRIPTION
`FortranVersion` is used by various parts of the project and by fortran-src users, so placed into its own top-level module.

For now, `ParserMonad` continues to export it in order to keep API from breaking. That is, `import Language.Fortran.ParserMonad ( FortranVersion(..) )` will continue to work, but should probably be consider deprecated.