### PR TITLE
CI via GitHub Actions

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    types:
+    - opened
+    - synchronized
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: cache Stack downloaded packages
+      uses: actions/cache@v2
+      with:
+        path: $HOME/.stack
+      key: ${{ runner.os }}
+    - name: install latest Stack and add to path
+      run: |
+        mkdir -p ~/.local/bin
+        export PATH="$HOME/.local/bin:$PATH"
+        # for GitHub Actions
+        echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH
+        curl -sSL https://get.haskellstack.org/ | sh
+    - name: install project dependencies
+      run: stack --no-terminal test --only-dependencies
+    - name: build and run tests
+      run: stack --no-terminal haddock --test --no-haddock-deps


### PR DESCRIPTION
The old, free Travis CI site travis-ci.org is [closing down](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom) and merging with travis-ci.com. Actually, it should have happened last week, so we'll want to migrate CI soon.

However, they're also changing the free plan, and I've only heard [negative things](https://travis-ci.community/t/org-com-migration-unexpectedly-comes-with-a-plan-change-for-oss-what-exactly-is-the-new-deal/10567). So I'm trying out GitHub Actions instead.