### PR TITLE
rewriter: temporary files via a temp sys dir

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2d18bd343f3cdb0783b1a174c15e83a2e3c26b2dcb261dde4e72fb3eb5a4946f
+-- hash: 48e669c2672cd1dc959b18b2b9b123b9372dfeafe821647b66bab38a32c3f8cb
 
 name:           fortran-src
 version:        0.4.1
@@ -76,9 +76,10 @@ library
     , deepseq
     , directory >=1.2 && <2
     , fgl >=5 && <6
-    , filepath >=1.4 && <2
+    , filepath
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , temporary
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
   default-language: Haskell2010
@@ -98,10 +99,11 @@ executable fortran-src
     , deepseq
     , directory >=1.2 && <2
     , fgl >=5 && <6
-    , filepath >=1.4 && <2
+    , filepath
     , fortran-src
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , temporary
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
   default-language: Haskell2010
@@ -148,11 +150,12 @@ test-suite spec
     , deepseq
     , directory >=1.2 && <2
     , fgl >=5 && <6
-    , filepath >=1.4 && <2
+    , filepath
     , fortran-src
     , hspec >=2.2 && <3
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , temporary
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,8 @@ dependencies:
 - directory >=1.2 && <2
 - fgl >=5 && <6
 - deepseq
+- filepath
+- temporary
 
 # --pedantic for building (not used for stack ghci)
 ghc-options:

--- a/test/Language/Fortran/RewriterSpec.hs
+++ b/test/Language/Fortran/RewriterSpec.hs
@@ -11,15 +11,12 @@ import           Control.Exception.Base         ( try
                                                 )
 import           Control.Monad                  ( foldM
                                                 , unless
-                                                , when
                                                 )
 import qualified Data.Map                      as M
 import           System.Directory               ( copyFile
                                                 , createDirectory
                                                 , getCurrentDirectory
                                                 , doesDirectoryExist
-                                                , doesFileExist
-                                                , removeFile
                                                 )
 import           Language.Fortran.Rewriter
 import qualified Data.ByteString.Lazy.Char8    as BC
@@ -297,24 +294,6 @@ spec = do
         , "005_removals.f"
         , "006_linewrap_heuristic.f"
         ]
-
-  describe "Error handling" $
-    it "Removes *.temp files in the event of an error" $ do
-      let failureFile = "test/Language/Fortran/samples/rewriter/temp-failure/fail.f"
-          temp = failureFile ++ ".temp"
-          replacements = M.singleton failureFile
-            [ Replacement
-                (SourceRange (SourceLocation (-1) (-1)) (SourceLocation 0 (-43)))
-                ""
-            ]
-      exists <- doesFileExist temp
-      when exists $ removeFile temp
-      result <-
-        try $ processReplacements replacements :: IO
-          (Either ReplacementError ())
-      result `shouldBe` Left InvalidRangeError
-      exists' <- doesFileExist temp
-      exists' `shouldBe` False
 
   describe "Filtering overlapping replacements" $ do
     it "Simple overlap" $ do


### PR DESCRIPTION
Temporary file names when applying rewrite replacements are no longer
deterministic, so the respective test has been removed.