### PR TITLE
Allow selection of post-parse AST transformations

### DIFF
--- a/src/Language/Fortran/Analysis/ModGraph.hs
+++ b/src/Language/Fortran/Analysis/ModGraph.hs
@@ -86,7 +86,7 @@ genModGraph mversion includeDirs paths = do
       iter path = do
         contents <- liftIO $ flexReadFile path
         let version = fromMaybe (deduceFortranVersion path) mversion
-        let (Just parserF0) = lookup version parserWithModFilesVersions
+        let parserF0 = parserWithModFilesVersions version
         let parserF m b s = fromRight (parserF0 m b s)
         fileMods <- liftIO $ decodeModFiles includeDirs
         let mods = map snd fileMods

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -68,3 +68,7 @@ fortranParserWithModFilesAndVersion :: FortranVersion -> ParserWithModFiles
 fortranParserWithModFilesAndVersion v mods contents filename = do
    let Just parserF = lookup v parserWithModFilesVersions
    parserF mods contents filename
+
+-- | TODO. Base helper function.
+--fortranParserWithModFilesAndVersionAndTrans
+--    :: FortranVersion -> ModFiles

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -72,7 +72,3 @@ fortranParserWithModFilesAndVersion :: FortranVersion -> ParserWithModFiles
 fortranParserWithModFilesAndVersion v mods contents filename =
    let parserF = parserWithModFilesVersions v
     in parserF mods contents filename
-
--- | TODO. Base helper function.
---fortranParserWithModFilesAndVersionAndTrans
---    :: FortranVersion -> ModFiles

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -15,6 +15,7 @@ import Language.Fortran.Parser.Fortran2003 ( fortran2003Parser, fortran2003Parse
 
 import qualified Data.ByteString.Char8 as B
 
+-- TODO: rewrite in lambda case style?
 type Parser = B.ByteString -> String -> Either ParseErrorSimple (ProgramFile A0)
 parserVersions :: [(FortranVersion, Parser)]
 parserVersions =
@@ -26,6 +27,7 @@ parserVersions =
   , (Fortran95, fromParseResult `after` fortran95Parser)
   , (Fortran2003, fromParseResult `after` fortran2003Parser) ]
 
+-- TODO: rewrite in lambda case style?
 type ParserWithModFiles = ModFiles -> B.ByteString -> String -> Either ParseErrorSimple (ProgramFile A0)
 parserWithModFilesVersions :: [(FortranVersion, ParserWithModFiles)]
 parserWithModFilesVersions =

--- a/src/Language/Fortran/Parser/Any.hs
+++ b/src/Language/Fortran/Parser/Any.hs
@@ -1,5 +1,17 @@
 {-# LANGUAGE LambdaCase #-}
 
+-- | = Note on these parsers
+--
+-- Seperate parsers are provided for different Fortran versions. A few parsers
+-- are provided for each version, offering built-in defaults or allowing you to
+-- configure them yourself. They can be identified by their suffix:
+--
+--   * @parser@: all defaults (without mod files, default transformations)
+--   * @parserWithModFiles@: select mod files, default transformations
+--   * @parserWithTransforms@: without mod files, select transformations
+--   * @parserWithModFilesWithTransforms@: select mod files, select transformations
+--
+
 module Language.Fortran.Parser.Any where
 
 import Language.Fortran.AST
@@ -28,6 +40,9 @@ parserVersions = \case
   Fortran95         -> fromParseResult `after` fortran95Parser
   Fortran2003       -> fromParseResult `after` fortran2003Parser
   _                 -> error "no parser available for requested Fortran version"
+  where
+    after :: (b -> c) -> (t -> a -> b) -> t -> a -> c
+    after g f x = g . f x
 
 type ParserWithModFiles = ModFiles -> B.ByteString -> String -> Either ParseErrorSimple (ProgramFile A0)
 parserWithModFilesVersions :: FortranVersion -> ParserWithModFiles
@@ -42,9 +57,6 @@ parserWithModFilesVersions = \case
   _                 -> error "no parser available for requested Fortran version"
   where
     helper parser m s = fromParseResult . parser m s
-
-after :: (b -> c) -> (t -> a -> b) -> t -> a -> c
-after g f x = g . f x
 
 -- | Deduce the type of parser from the filename and parse the
 -- contents of the file.

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1287,14 +1287,7 @@ unitNameCheck _ _ = return ()
 
 parse = runParse programParser
 
-transformations2003 =
-  [ GroupLabeledDo
-  , GroupDo
-  , GroupIf
-  , GroupCase
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
+transformations2003 = defaultTransformations Fortran2003
 
 fortran2003Parser ::
      B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -1067,7 +1067,7 @@ makeReal i1 dot i2 exp =
 
 parse = runParse programParser
 
-defTransforms77 = defaultTransformations Fortran77
+defTransforms77  = defaultTransformations Fortran77
 defTransforms77e = defaultTransformations Fortran77Extended
 defTransforms77l = defaultTransformations Fortran77Legacy
 

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -1059,12 +1059,6 @@ makeReal i1 dot i2 exp =
 
 parse = runParse programParser
 
-transformations77 =
-  [ GroupLabeledDo
-  , GroupIf
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
 fortran77Parser ::
     B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)
 fortran77Parser = fortran77ParserWithModFiles emptyModFiles
@@ -1074,17 +1068,9 @@ fortran77ParserWithModFiles ::
 fortran77ParserWithModFiles mods sourceCode filename =
     fmap (pfSetFilename filename . transform) $ parse parseState
   where
-    transform  = transformWithModFiles mods transformations77
+    transform  = transformWithModFiles mods (defaultTransformations Fortran77)
     parseState = initParseState sourceCode Fortran77Extended filename
 
-transformations77Extended =
-  [ GroupLabeledDo
-  , GroupDo
-  , GroupIf
-  , GroupCase
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
 extended77Parser ::
     B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)
 extended77Parser = extended77ParserWithModFiles emptyModFiles
@@ -1094,16 +1080,9 @@ extended77ParserWithModFiles ::
 extended77ParserWithModFiles mods sourceCode filename =
     fmap (pfSetFilename filename . transform) $ parse parseState
   where
-    transform = transformWithModFiles mods transformations77Extended
+    transform = transformWithModFiles mods (defaultTransformations Fortran77Extended)
     parseState = initParseState sourceCode Fortran77Extended filename
 
-transformations77Legacy =
-  [ GroupLabeledDo
-  , GroupDo
-  , GroupIf
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
 legacy77Parser ::
     B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)
 legacy77Parser = legacy77ParserWithModFiles emptyModFiles
@@ -1113,7 +1092,7 @@ legacy77ParserWithModFiles ::
 legacy77ParserWithModFiles mods sourceCode filename =
     fmap (pfSetFilename filename . transform) $ parse parseState
   where
-    transform = transformWithModFiles mods transformations77Legacy
+    transform = transformWithModFiles mods (defaultTransformations Fortran77Legacy)
     parseState = initParseState sourceCode Fortran77Legacy filename
 
 legacy77ParserWithIncludes ::
@@ -1126,7 +1105,7 @@ legacy77ParserWithIncludes incs sourceCode filename =
       ParseOk p x -> do
         p' <- descendBiM (inlineInclude Fortran77Legacy incs []) p
         return (ParseOk p' x)
-    transform = transformWithModFiles emptyModFiles transformations77Legacy
+    transform = transformWithModFiles emptyModFiles (defaultTransformations Fortran77Legacy)
     parseState = initParseState sourceCode Fortran77Legacy filename
 
 includeParser ::

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -1080,14 +1080,7 @@ unitNameCheck _ _ = return ()
 
 parse = runParse programParser
 
-transformations90 =
-  [ GroupLabeledDo
-  , GroupDo
-  , GroupIf
-  , GroupCase
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
+transformations90 = defaultTransformations Fortran90
 
 fortran90Parser ::
     B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -1147,14 +1147,7 @@ unitNameCheck _ _ = return ()
 
 parse = runParse programParser
 
-transformations95 =
-  [ GroupLabeledDo
-  , GroupDo
-  , GroupIf
-  , GroupCase
-  , DisambiguateIntrinsic
-  , DisambiguateFunction
-  ]
+transformations95 = defaultTransformations Fortran95
 
 fortran95Parser ::
      B.ByteString -> String -> ParseResult AlexInput Token (ProgramFile A0)

--- a/src/Language/Fortran/Transformer.hs
+++ b/src/Language/Fortran/Transformer.hs
@@ -48,7 +48,7 @@ transform trs = runTransform empty empty trans
   where
     trans = mapM_ transformationMapping trs
 
--- TODO: explicit, or concise?
+-- | The default post-parse AST transformations for each Fortran version.
 defaultTransformations :: FortranVersion -> [Transformation]
 defaultTransformations = \case
   Fortran66 ->
@@ -56,27 +56,9 @@ defaultTransformations = \case
     , DisambiguateIntrinsic
     , DisambiguateFunction
     ]
-  Fortran77 -> -- GroupIf : defaultTransformations Fortran66
-    [ GroupLabeledDo
-    , GroupIf
-    , DisambiguateIntrinsic
-    , DisambiguateFunction
-    ]
-  Fortran77Legacy -> -- GroupDo : defaultTransformations Fortran77
-    [ GroupLabeledDo
-    , GroupDo
-    , GroupIf
-    , DisambiguateIntrinsic
-    , DisambiguateFunction
-    ]
-  Fortran77Extended -> -- GroupCase : defaultTransformations Fortran77Legacy
-    [ GroupLabeledDo
-    , GroupDo
-    , GroupIf
-    , GroupCase
-    , DisambiguateIntrinsic
-    , DisambiguateFunction
-    ]
+  Fortran77         -> GroupIf   : defaultTransformations Fortran66
+  Fortran77Legacy   -> GroupDo   : defaultTransformations Fortran77
+  Fortran77Extended -> GroupCase : defaultTransformations Fortran77Legacy
   Fortran90   -> defaultTransformations Fortran77Extended
   Fortran95   -> defaultTransformations Fortran77Extended
   Fortran2003 -> defaultTransformations Fortran77Extended

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -105,7 +105,7 @@ main = do
     (path:_, actionOpt) -> do
       contents <- flexReadFile path
       let version = fromMaybe (deduceFortranVersion path) (fortranVersion opts)
-      let (Just parserF0) = lookup version parserWithModFilesVersions
+      let parserF0 = parserWithModFilesVersions version
       let parserF m b s = fromRight (parserF0 m b s)
       let outfmt = outputFormat opts
       mods <- decodeModFiles $ includeDirs opts
@@ -244,7 +244,7 @@ compileFileToMod :: Maybe FortranVersion -> ModFiles -> FilePath -> Maybe FilePa
 compileFileToMod mvers mods path moutfile = do
   contents <- flexReadFile path
   let version = fromMaybe (deduceFortranVersion path) mvers
-  let (Just parserF0) = lookup version parserWithModFilesVersions
+  let parserF0 = parserWithModFilesVersions version
   let parserF m b s = fromRight (parserF0 m b s)
   let mmap = combinedModuleMap mods
   let tenv = combinedTypeEnv mods


### PR DESCRIPTION
Centralize default transformations and export more parsers (currently for Fortran 66 only).