### PR TITLE
Add static statement to legacy parser and AST

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -299,6 +299,7 @@ data Statement a  =
   | StVolatile            a SrcSpan (AList Declarator a)
   | StData                a SrcSpan (AList DataGroup a)
   | StAutomatic           a SrcSpan (AList Declarator a)
+  | StStatic              a SrcSpan (AList Declarator a)
   | StNamelist            a SrcSpan (AList Namelist a)
   | StParameter           a SrcSpan (AList Declarator a)
   | StExternal            a SrcSpan (AList Expression a)

--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -196,6 +196,7 @@ tokens :-
   -- Tokens related to data initalization statement
   <keyword> "data"                            { toSC st >> addSpan TData  }
   <keyword> "automatic" / { legacy77P }       { toSC st >> addSpan TAutomatic  }
+  <keyword> "static" / { legacy77P }          { toSC st >> addSpan TStatic }
 
   -- Tokens related to format statement
   <keyword> "format"                          { toSC fmt >> enterFormat >> addSpan TFormat  }
@@ -793,6 +794,7 @@ data Token = TLeftPar             SrcSpan
            | TNone                SrcSpan
            | TParameter           SrcSpan
            | TData                SrcSpan
+           | TStatic              SrcSpan
            | TAutomatic           SrcSpan
            | TFormat              SrcSpan
            | TBlob                SrcSpan String

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -121,6 +121,7 @@ import Control.Exception
   none                  { TNone _ }
   data                  { TData _ }
   automatic             { TAutomatic _ }
+  static                { TStatic _ }
   format                { TFormat _ }
   blob                  { TBlob _ _ }
   int                   { TInt _ _ }
@@ -492,6 +493,7 @@ NONEXECUTABLE_STATEMENT
 | pointer POINTER_LIST { StPointer () (getTransSpan $1 $2) (fromReverseList $2) }
 | data DATA_GROUPS { StData () (getTransSpan $1 $2) (fromReverseList $2) }
 | automatic DECLARATORS { StAutomatic () (getTransSpan $1 $2) (aReverse $2) }
+| static DECLARATORS { StStatic () (getTransSpan $1 $2) (aReverse $2) }
 -- Following is a fake node to make arbitrary FORMAT statements parsable.
 -- Must be fixed in the future. TODO
 | format blob

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -486,6 +486,10 @@ instance Pretty (Statement a) where
       | v == Fortran77Extended = "automatic" <+> pprint' v decls
       | otherwise = tooOld v "Automatic statement" Fortran90
 
+    pprint' v (StStatic _ _ decls)
+      | v == Fortran77Extended = "static" <+> pprint' v decls
+      | otherwise = tooOld v "Static statement" Fortran90
+
     pprint' v (StNamelist _ _ namelist)
       | v >= Fortran90 = "namelist" <+> pprint' v namelist
       | otherwise = tooOld v "Namelist statement" Fortran90

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -348,6 +348,14 @@ spec =
             tgt3 = ExpSubscript () u (ExpDataRef () u (ExpValue () u (ValVariable "x")) (ExpValue () u (ValVariable "foo"))) (AList () u [mkIdx "0"])
             st3 = StExpressionAssign () u tgt3 (ExpValue () u (ValInteger "0"))
         resetSrcSpan (slParser src3) `shouldBe` st3
+      it "parses automatic and static statements" $ do
+        let decl = DeclVariable () u (varGen "x") Nothing Nothing
+            autoStmt = StAutomatic () u (AList () u [decl])
+            staticStmt = StStatic () u (AList () u [decl])
+            autoSrc =  "      automatic x"
+            staticSrc = "      static x"
+        resetSrcSpan (slParser autoSrc) `shouldBe` autoStmt
+        resetSrcSpan (slParser staticSrc) `shouldBe` staticStmt
 
 exampleProgram1 :: String
 exampleProgram1 = unlines


### PR DESCRIPTION
Pretty much identical to automatic statement equivalent.

I guess we never encountered it before because it's the default behaviour for legacy fortran, but it has popped up now.