### PR TITLE
Replace BaseType in IDType with a semantic type representation

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3eb3f3e8de907d8c4626c9351665c46eb008759e3b74f7459007de21a166fa86
+-- hash: 94796d02b259851a845bd0e2d43eae13767addbada1ac402a731b4056fe31c92
 
 name:           fortran-src
 version:        0.4.3
@@ -28,7 +28,7 @@ source-repository head
 
 library
   exposed-modules:
-      Language.Fortran.Vars.Types
+      Language.Fortran.Analysis.SemanticTypes
       Language.Fortran.Analysis
       Language.Fortran.Analysis.Renaming
       Language.Fortran.Analysis.ModGraph

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f5d7e99716015530592de9c1b2546f0d2ad31a230d0574adb8385118e8bdba1f
+-- hash: 3eb3f3e8de907d8c4626c9351665c46eb008759e3b74f7459007de21a166fa86
 
 name:           fortran-src
 version:        0.4.3
@@ -28,6 +28,7 @@ source-repository head
 
 library
   exposed-modules:
+      Language.Fortran.Vars.Types
       Language.Fortran.Analysis
       Language.Fortran.Analysis.Renaming
       Language.Fortran.Analysis.ModGraph

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ library:
   - happy >=1.19
   other-modules: []
   exposed-modules:
-  - Language.Fortran.Vars.Types
+  - Language.Fortran.Analysis.SemanticTypes
   - Language.Fortran.Analysis
   - Language.Fortran.Analysis.Renaming
   - Language.Fortran.Analysis.ModGraph

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ library:
   - happy >=1.19
   other-modules: []
   exposed-modules:
+  - Language.Fortran.Vars.Types
   - Language.Fortran.Analysis
   - Language.Fortran.Analysis.Renaming
   - Language.Fortran.Analysis.ModGraph

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -85,6 +85,7 @@ module Language.Fortran.AST
   , FlushSpec(..)
   , DoSpecification(..)
   , ProgramUnitName(..)
+  , Kind
 
   -- * Node annotations & related typeclasses
   , A0

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -213,6 +213,8 @@ data Selector a =
   Selector a SrcSpan (Maybe (Expression a)) (Maybe (Expression a))
   deriving (Eq, Show, Data, Typeable, Generic, Functor)
 
+type Kind = Int
+
 data MetaInfo = MetaInfo { miVersion :: FortranVersion, miFilename :: String }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -7,7 +7,7 @@ module Language.Fortran.Analysis
   ( initAnalysis, stripAnalysis, Analysis(..), Constant(..)
   , varName, srcName, lvVarName, lvSrcName, isNamedExpression
   , genVar, puName, puSrcName, blockRhsExprs, rhsExprs
-  , ModEnv, NameType(..), IDType(..), ConstructType(..), SemType(..)
+  , ModEnv, NameType(..), IDType(..), ConstructType(..)
   , lhsExprs, isLExpr, allVars, analyseAllLhsVars, analyseAllLhsVars1, allLhsVars
   , blockVarUses, blockVarDefs
   , BB, BBNode, BBGr(..), bbgrMap, bbgrMapM, bbgrEmpty

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -98,7 +98,7 @@ data ConstructType =
 instance Out ConstructType
 instance Binary ConstructType
 
-type Kind = String
+type Kind = Int
 
 data IDType = IDType
   { idVType :: Maybe BaseType

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -30,6 +30,8 @@ import Data.Binary
 import Language.Fortran.Intrinsics (getIntrinsicDefsUses, allIntrinsics)
 import Data.Bifunctor (first)
 
+import qualified Language.Fortran.Vars.Types as FV
+
 --------------------------------------------------
 
 -- | Basic block
@@ -101,7 +103,8 @@ type Kind = String
 data IDType = IDType
   { idVType :: Maybe BaseType
   , idCType :: Maybe ConstructType
-  , idKind  :: Maybe Kind }
+  , idKind  :: Maybe Kind
+  , idFVType :: Maybe FV.Type }
   deriving (Ord, Eq, Show, Data, Typeable, Generic)
 
 instance Out IDType

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -7,7 +7,7 @@ module Language.Fortran.Analysis
   ( initAnalysis, stripAnalysis, Analysis(..), Constant(..)
   , varName, srcName, lvVarName, lvSrcName, isNamedExpression
   , genVar, puName, puSrcName, blockRhsExprs, rhsExprs
-  , ModEnv, NameType(..), IDType(..), ConstructType(..), BaseType(..), Kind
+  , ModEnv, NameType(..), IDType(..), ConstructType(..), SemType(..)
   , lhsExprs, isLExpr, allVars, analyseAllLhsVars, analyseAllLhsVars1, allLhsVars
   , blockVarUses, blockVarDefs
   , BB, BBNode, BBGr(..), bbgrMap, bbgrMapM, bbgrEmpty
@@ -30,7 +30,7 @@ import Data.Binary
 import Language.Fortran.Intrinsics (getIntrinsicDefsUses, allIntrinsics)
 import Data.Bifunctor (first)
 
-import qualified Language.Fortran.Vars.Types as FV
+import           Language.Fortran.Analysis.SemanticTypes (SemType(..))
 
 --------------------------------------------------
 
@@ -98,13 +98,9 @@ data ConstructType =
 instance Out ConstructType
 instance Binary ConstructType
 
-type Kind = Int
-
 data IDType = IDType
-  { idVType :: Maybe BaseType
-  , idCType :: Maybe ConstructType
-  , idKind  :: Maybe Kind
-  , idFVType :: Maybe FV.Type }
+  { idVType :: Maybe SemType
+  , idCType :: Maybe ConstructType }
   deriving (Ord, Eq, Show, Data, Typeable, Generic)
 
 instance Out IDType
@@ -175,7 +171,7 @@ isNamedExpression (ExpValue _ _ (ValIntrinsic _)) = True
 isNamedExpression _                               = False
 
 -- | Obtain either uniqueName or source name from an ExpValue variable.
-varName :: Expression (Analysis a) -> String
+varName :: Expression (Analysis a) -> Name
 varName (ExpValue Analysis { uniqueName = Just n } _ ValVariable{})  = n
 varName (ExpValue Analysis { sourceName = Just n } _ ValVariable{})  = n
 varName (ExpValue _ _ (ValVariable n))                               = n
@@ -185,7 +181,7 @@ varName (ExpValue _ _ (ValIntrinsic n))                              = n
 varName _                                                            = error "Use of varName on non-variable."
 
 -- | Obtain the source name from an ExpValue variable.
-srcName :: Expression (Analysis a) -> String
+srcName :: Expression (Analysis a) -> Name
 srcName (ExpValue Analysis { sourceName = Just n } _ ValVariable{})  = n
 srcName (ExpValue _ _ (ValVariable n))                               = n
 srcName (ExpValue Analysis { sourceName = Just n } _ ValIntrinsic{}) = n
@@ -193,20 +189,20 @@ srcName (ExpValue _ _ (ValIntrinsic n))                              = n
 srcName _                                                            = error "Use of srcName on non-variable."
 
 -- | Obtain either uniqueName or source name from an LvSimpleVar variable.
-lvVarName :: LValue (Analysis a) -> String
+lvVarName :: LValue (Analysis a) -> Name
 lvVarName (LvSimpleVar Analysis { uniqueName = Just n } _ _)  = n
 lvVarName (LvSimpleVar Analysis { sourceName = Just n } _ _)  = n
 lvVarName (LvSimpleVar _ _ n)                                 = n
 lvVarName _                                                   = error "Use of lvVarName on non-variable."
 
 -- | Obtain the source name from an LvSimpleVar variable.
-lvSrcName :: LValue (Analysis a) -> String
+lvSrcName :: LValue (Analysis a) -> Name
 lvSrcName (LvSimpleVar Analysis { sourceName = Just n } _ _) = n
 lvSrcName (LvSimpleVar _ _ n) = n
 lvSrcName _ = error "Use of lvSrcName on a non-variable"
 
 -- | Generate an ExpValue variable with its source name == to its uniqueName.
-genVar :: Analysis a -> SrcSpan -> String -> Expression (Analysis a)
+genVar :: Analysis a -> SrcSpan -> Name -> Expression (Analysis a)
 genVar a s n = ExpValue (a { uniqueName = Just n, sourceName = Just n }) s v
   where
     v | Just CTIntrinsic <- idCType =<< idType a = ValIntrinsic n

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -7,7 +7,7 @@ module Language.Fortran.Analysis
   ( initAnalysis, stripAnalysis, Analysis(..), Constant(..)
   , varName, srcName, lvVarName, lvSrcName, isNamedExpression
   , genVar, puName, puSrcName, blockRhsExprs, rhsExprs
-  , ModEnv, NameType(..), IDType(..), ConstructType(..), BaseType(..)
+  , ModEnv, NameType(..), IDType(..), ConstructType(..), BaseType(..), Kind
   , lhsExprs, isLExpr, allVars, analyseAllLhsVars, analyseAllLhsVars1, allLhsVars
   , blockVarUses, blockVarDefs
   , BB, BBNode, BBGr(..), bbgrMap, bbgrMapM, bbgrEmpty
@@ -96,9 +96,12 @@ data ConstructType =
 instance Out ConstructType
 instance Binary ConstructType
 
+type Kind = String
+
 data IDType = IDType
   { idVType :: Maybe BaseType
-  , idCType :: Maybe ConstructType }
+  , idCType :: Maybe ConstructType
+  , idKind  :: Maybe Kind }
   deriving (Ord, Eq, Show, Data, Typeable, Generic)
 
 instance Out IDType

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -884,21 +884,11 @@ showBaseType TypeDoublePrecision = "double"
 showBaseType TypeComplex         = "complex"
 showBaseType TypeDoubleComplex   = "doublecomplex"
 showBaseType TypeLogical         = "logical"
-showBaseType (TypeCharacter l k) = case (l, k) of
-  (Just cl, Just ki) -> "character(" ++ showCharLen cl ++ "," ++ ki ++ ")"
-  (Just cl, Nothing) -> "character(" ++ showCharLen cl ++ ")"
-  (Nothing, Just ki) -> "character(kind=" ++ ki ++ ")"
-  (Nothing, Nothing) -> "character"
+showBaseType TypeCharacter       = "character"
 showBaseType (TypeCustom s)      = "type(" ++ s ++ ")"
 showBaseType TypeByte            = "byte"
 showBaseType ClassStar           = "class(*)"
 showBaseType (ClassCustom s)     = "class(" ++ s ++ ")"
-
-showCharLen :: CharacterLen -> String
-showCharLen CharLenStar = "*"
-showCharLen CharLenColon = ":"
-showCharLen CharLenExp  = "*" -- FIXME, possibly, with a more robust const-exp
-showCharLen (CharLenInt i) = show i
 
 showDecl :: Declarator a -> String
 showDecl (DeclArray _ _ e adims length' initial) =

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -83,3 +83,14 @@ setTypeKind st k = case st of
   STyCharacter charLen _ -> STyCharacter charLen k
   STyCustom    _ -> error "can't set kind of STyCustom"
   STyArray _ _   -> error "can't set kind of STyArray"
+
+charLenConcat :: CharacterLen -> CharacterLen -> CharacterLen
+charLenConcat l1 l2 = case (l1, l2) of
+  (CharLenExp    , _             ) -> CharLenExp
+  (_             , CharLenExp    ) -> CharLenExp
+  (CharLenStar   , _             ) -> CharLenStar
+  (_             , CharLenStar   ) -> CharLenStar
+  (CharLenColon  , _             ) -> CharLenColon
+  (_             , CharLenColon  ) -> CharLenColon
+  (CharLenInt i1 , CharLenInt i2 ) -> CharLenInt (i1 + i2)
+

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -16,14 +16,14 @@ import           Text.PrettyPrint.GenericPretty ( Out(..) )
 
 -- | Term type representation.
 data SemType
-  = STInteger Kind
-  | STReal Kind
-  | STComplex Kind
-  | STLogical Kind
-  | STByte Kind
-  | STCharacter (Maybe Kind) -- ^ Nothing denotes dynamic length
-  | STArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
-  | STCustom String          -- use for F77 structures, F90 DDTs
+  = STyInteger Kind
+  | STyReal Kind
+  | STyComplex Kind
+  | STyLogical Kind
+  | STyByte Kind
+  | STyCharacter (Maybe Kind) -- ^ Nothing denotes dynamic length
+  | STyArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
+  | STyCustom String          -- use for F77 structures, F90 DDTs
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
 instance Binary SemType

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -7,7 +7,11 @@ module Language.Fortran.Analysis.SemanticTypes where
 import           Data.Data                      ( Data, Typeable )
 import           Control.DeepSeq                ( NFData )
 import           GHC.Generics                   ( Generic )
-import           Language.Fortran.AST           ( Kind, Expression(..), Value(..), Selector(..) )
+import           Language.Fortran.AST           ( BaseType(..)
+                                                , Kind
+                                                , Expression(..)
+                                                , Value(..)
+                                                , Selector(..) )
 import           Data.Binary                    ( Binary )
 import           Text.PrettyPrint.GenericPretty ( Out(..) )
 
@@ -94,3 +98,56 @@ charLenConcat l1 l2 = case (l1, l2) of
   (_             , CharLenColon  ) -> CharLenColon
   (CharLenInt i1 , CharLenInt i2 ) -> CharLenInt (i1 + i2)
 
+--------------------------------------------------------------------------------
+
+-- | Given a 'BaseType' infer the "default" kind (or size of the
+-- variable in memory).
+--
+-- Useful when you need a default kind, but gives you an unwrapped type.
+-- Consider using Analysis.deriveSemTypeFromBaseType also.
+--
+-- Further documentation:
+-- https://docs.oracle.com/cd/E19957-01/805-4939/c400041360f5/index.html
+kindOfBaseType :: BaseType -> Int
+kindOfBaseType = \case
+  TypeInteger         -> 4
+  TypeReal            -> 4
+  TypeDoublePrecision -> 8
+  TypeComplex         -> 8
+  TypeDoubleComplex   -> 16
+  TypeLogical         -> 4
+  TypeCharacter{}     -> 1
+  TypeByte            -> 1
+
+  -- arbitrary values (>F77 is not tested/used)
+  TypeCustom{}        -> 1
+  ClassStar           -> 1
+  ClassCustom{}       -> 1
+
+getTypeSize :: SemType -> Maybe Int
+getTypeSize = \case
+  TInteger      k   -> Just k
+  TReal         k   -> Just k
+  TComplex      k   -> Just k
+  TLogical      k   -> Just k
+  TByte         k   -> Just k
+  TArray     ty _   -> getTypeSize ty
+  TCustom       _   -> Just 1
+  -- char: treat length as "kind" (but also use recorded kind)
+  TCharacter (CharLenInt l) k -> Just (l * k)
+  TCharacter _              _ -> Nothing
+
+setTypeSize :: SemType -> Maybe Int -> SemType
+setTypeSize ty mk = case (mk, ty) of
+  (Just k, TInteger _  ) -> TInteger k
+  (Just k, TReal _     ) -> TReal k
+  (Just k, TComplex _  ) -> TComplex k
+  (Just k, TLogical _  ) -> TLogical k
+  (Just k, TByte _     ) -> TByte k
+  (_     , TCustom s   ) -> TCustom s
+  -- char: treat length as "kind"
+  (Just l, TCharacter _ k) ->
+    TCharacter (CharLenInt l) k
+  (Nothing, TCharacter _ k) ->
+    TCharacter CharLenStar k
+  _ -> error $ "Tried to set invalid kind for type " <> show ty

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -1,5 +1,3 @@
--- | TODO: copied from fortran-vars (then edited)
-
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
@@ -13,21 +11,25 @@ import           Language.Fortran.AST           ( Kind, Expression(..), Value(..
 import           Data.Binary                    ( Binary )
 import           Text.PrettyPrint.GenericPretty ( Out(..) )
 
--- | Term type representation.
+-- TODO:
+--   * cleaner arrays: separate into scalar & array types?
+--   * how is F77 structure, F90 DDT support really? (F90 likely untested)
 data SemType
   = STyInteger Kind
   | STyReal Kind
   | STyComplex Kind
   | STyLogical Kind
   | STyByte Kind
-  | STyCharacter CharacterLen
+  | STyCharacter CharacterLen Kind
   | STyArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
-  | STyCustom String          -- use for F77 structures, F90 DDTs
+  | STyCustom String                    -- use for F77 structures, F90 DDTs
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
 instance Binary SemType
 instance Out    SemType
 
+-- | The declared dimensions of a staticically typed array variable
+-- type is of the form [(dim1_lower, dim1_upper), (dim2_lower, dim2_upper)]
 type Dimensions = [(Int, Int)]
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -10,7 +10,7 @@ module Language.Fortran.Analysis.SemanticTypes where
 import           Data.Data                      ( Data )
 import           Data.Typeable                  ( Typeable )
 import           GHC.Generics                   ( Generic )
-import           Language.Fortran.AST           ( Kind )
+import           Language.Fortran.AST           ( Kind, CharacterLen(..) )
 import           Data.Binary                    ( Binary )
 import           Text.PrettyPrint.GenericPretty ( Out(..) )
 
@@ -21,7 +21,7 @@ data SemType
   | STyComplex Kind
   | STyLogical Kind
   | STyByte Kind
-  | STyCharacter (Maybe Kind) -- ^ Nothing denotes dynamic length
+  | STyCharacter CharacterLen
   | STyArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
   | STyCustom String          -- use for F77 structures, F90 DDTs
   deriving (Eq, Ord, Show, Data, Typeable, Generic)

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -62,6 +62,17 @@ charLenSelector' = \case
   ExpValue _ _ (ValInteger i) -> CharLenInt (read i)
   _                           -> CharLenExp
 
+getTypeKind :: SemType -> Kind
+getTypeKind = \case
+  STyInteger   k -> k
+  STyReal      k -> k
+  STyComplex   k -> k
+  STyLogical   k -> k
+  STyByte      k -> k
+  STyCharacter _ k -> k
+  STyCustom    _ -> error "STyCustom does not have a kind"
+  STyArray t _   -> getTypeKind t
+
 setTypeKind :: SemType -> Kind -> SemType
 setTypeKind st k = case st of
   STyInteger   _ -> STyInteger   k

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -8,21 +8,11 @@
 module Language.Fortran.Analysis.SemanticTypes where
 
 import           Data.Data                      ( Data )
-import           Data.Map                       ( Map )
 import           Data.Typeable                  ( Typeable )
 import           GHC.Generics                   ( Generic )
-import           Control.DeepSeq                ( NFData )
-import           Language.Fortran.AST           ( Kind
-                                                , Name
-                                                , ProgramUnitName
-                                                , Expression
-                                                )
-import           Language.Fortran.Util.Position ( SrcSpan(..)
-                                                , Position(..)
-                                                )
-
-import           Text.PrettyPrint.GenericPretty (Out(..))
-import           Data.Binary (Binary(..))
+import           Language.Fortran.AST           ( Kind )
+import           Data.Binary                    ( Binary )
+import           Text.PrettyPrint.GenericPretty ( Out(..) )
 
 -- | Term type representation.
 data SemType
@@ -36,96 +26,7 @@ data SemType
   | STCustom String          -- use for F77 structures, F90 DDTs
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
--- | The evaluated value of a FORTRAN expression
-data ExpVal
-  = Int     Int
-  | Real    Double
-  | Str     String
-  | Logical Bool
-  | Boz     String
-  deriving (Eq, Ord, Show, Data, Typeable, Generic, NFData)
-
--- | Memory offset given to a variable in memory
-type Offset = Int
-
--- | The name of block of memory
-type MemoryBlockName = Name
-
--- | The location of a variable, i.e. the 'MemoryBlockName' that
--- contains it as well as the 'Offset' to its location in memory
-type Location = (MemoryBlockName, Offset)
-
--- | The declared lifetimes of the variables in memory
-data StorageClass
-  = Static
-  | Automatic
-  | Constant
-  | Common
-  | Unspecified
-  deriving (Eq, Ord, Show, Data, Typeable, Generic)
-
--- | The declared dimensions of a staticically typed array variable
--- type is of the form [(dim1_lower, dim1_upper), (dim2_lower, dim2_upper)]
-type Dimensions = [(Int, Int)]
-
--- | An entry in the 'SymbolTable' for some variable
-data SymbolTableEntry
-  = SParameter { parType :: SemType , parVal :: ExpVal }
-  | SVariable { varType :: SemType , varLoc :: Location }
-  | SDummy { dumType :: SemType }
-  | SExternal {extType :: SemType }
-  deriving (Eq, Ord, Show, Data, Typeable, Generic)
-
 instance Binary SemType
 instance Out    SemType
 
--- | Symbol table containing all non-intrisic symbols declared in a program
-type SymbolTable = Map Name SymbolTableEntry
-
--- | Structure to hold information about the named blocks of memory
--- in the program
-data MemoryBlock = MemoryBlock
-  { blockSize    :: Maybe Int -- ^ Nothing for when block is dynamically sized
-  , storageClass :: StorageClass
-  , variables    :: [Name]
-  } deriving (Eq, Ord, Show, Data, Typeable, Generic)
-
--- | Map from a structure name to its internal structure, specifying members
--- and their corresponding type. This can then be used to check the type of a
--- data reference expression.
-type StructureTable = Map String Structure
-
--- List of structure fields forming a structure
-type Structure = [StructureTableEntry]
-
--- | Data structurue for a single field of a structure
-data StructureTableEntry
-  = FieldEntry String SemType
-  | UnionEntry [Structure]
-  deriving (Eq, Show, Data)
-
--- | Mapping from the name of a memory block to the information about it
-type StorageTable = Map MemoryBlockName MemoryBlock
-
--- | The model to represent an individual 'Language.Fortran.AST.ProgramUnit'
-type ProgramUnitModel = (SymbolTable, StorageTable)
-
--- | Mapping from the name of a 'Language.Fortran.AST.ProgramUnit' to
--- its 'ProgramUnitModel'
-type ProgramFileModel = Map ProgramUnitName ProgramUnitModel
-
--- | Mapping from name of a program unit to relevant structure table
-type ProgramStructureTables = Map ProgramUnitName StructureTable
-
-data TypeError
-  = TypeError FilePath SrcSpan String
-  | UnknownType SrcSpan
-  | UnboundVariable Name
-  | UnknownField String
-  deriving (Eq, Ord, Show, Generic)
-
--- | Helper method for getting the FilePath out of SrcSpan
-typeError :: SrcSpan -> String -> TypeError
-typeError sp = let SrcSpan p _ = sp in TypeError (filePath p) sp
-
-type TypeOf a = Expression a -> Either TypeError SemType
+type Dimensions = [(Int, Int)]

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -61,3 +61,14 @@ charLenSelector' = \case
   ExpValue _ _ ValColon       -> CharLenColon
   ExpValue _ _ (ValInteger i) -> CharLenInt (read i)
   _                           -> CharLenExp
+
+setTypeKind :: SemType -> Kind -> SemType
+setTypeKind st k = case st of
+  STyInteger   _ -> STyInteger   k
+  STyReal      _ -> STyReal      k
+  STyComplex   _ -> STyComplex   k
+  STyLogical   _ -> STyLogical   k
+  STyByte      _ -> STyByte      k
+  STyCharacter charLen _ -> STyCharacter charLen k
+  STyCustom    _ -> error "can't set kind of STyCustom"
+  STyArray _ _   -> error "can't set kind of STyArray"

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -15,14 +15,14 @@ import           Text.PrettyPrint.GenericPretty ( Out(..) )
 --   * cleaner arrays: separate into scalar & array types?
 --   * how is F77 structure, F90 DDT support really? (F90 likely untested)
 data SemType
-  = STyInteger Kind
-  | STyReal Kind
-  | STyComplex Kind
-  | STyLogical Kind
-  | STyByte Kind
-  | STyCharacter CharacterLen Kind
-  | STyArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
-  | STyCustom String                    -- use for F77 structures, F90 DDTs
+  = TInteger Kind
+  | TReal Kind
+  | TComplex Kind
+  | TLogical Kind
+  | TByte Kind
+  | TCharacter CharacterLen Kind
+  | TArray SemType (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
+  | TCustom String                    -- use for F77 structures, F90 DDTs
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
 instance Binary SemType
@@ -64,25 +64,25 @@ charLenSelector' = \case
 
 getTypeKind :: SemType -> Kind
 getTypeKind = \case
-  STyInteger   k -> k
-  STyReal      k -> k
-  STyComplex   k -> k
-  STyLogical   k -> k
-  STyByte      k -> k
-  STyCharacter _ k -> k
-  STyCustom    _ -> error "STyCustom does not have a kind"
-  STyArray t _   -> getTypeKind t
+  TInteger   k -> k
+  TReal      k -> k
+  TComplex   k -> k
+  TLogical   k -> k
+  TByte      k -> k
+  TCharacter _ k -> k
+  TCustom    _ -> error "TCustom does not have a kind"
+  TArray t _   -> getTypeKind t
 
 setTypeKind :: SemType -> Kind -> SemType
 setTypeKind st k = case st of
-  STyInteger   _ -> STyInteger   k
-  STyReal      _ -> STyReal      k
-  STyComplex   _ -> STyComplex   k
-  STyLogical   _ -> STyLogical   k
-  STyByte      _ -> STyByte      k
-  STyCharacter charLen _ -> STyCharacter charLen k
-  STyCustom    _ -> error "can't set kind of STyCustom"
-  STyArray _ _   -> error "can't set kind of STyArray"
+  TInteger   _ -> TInteger   k
+  TReal      _ -> TReal      k
+  TComplex   _ -> TComplex   k
+  TLogical   _ -> TLogical   k
+  TByte      _ -> TByte      k
+  TCharacter charLen _ -> TCharacter charLen k
+  TCustom    _ -> error "can't set kind of TCustom"
+  TArray _ _   -> error "can't set kind of TArray"
 
 charLenConcat :: CharacterLen -> CharacterLen -> CharacterLen
 charLenConcat l1 l2 = case (l1, l2) of

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -545,9 +545,6 @@ isIxSingle _           = False
 -- If a length was defined on both sides, the declaration length (RHS) is used.
 -- This matches gfortran's behaviour, though even with -Wall they don't warn on
 -- this rather confusing syntax usage. We report a (soft) type error.
---
--- Complicating the matter is that 'TypeCharacter's store a partly-parsed
--- version of the 'Selector'.
 deriveSemTypeFromDeclaration
     :: SrcSpan -> SrcSpan -> TypeSpec a -> Maybe (Expression a) -> Infer SemType
 deriveSemTypeFromDeclaration stmtSs declSs ts@(TypeSpec _ _ bt mSel) mLenExpr =
@@ -637,6 +634,8 @@ deriveSemTypeFromTypeSpec (TypeSpec _ _ bt mSel) =
 
 -- | Attempt to derive a SemType from a 'BaseType' and a 'Selector' (e.g.
 --   extracted from a 'TypeSpec').
+--
+-- TODO needs cleaning up once we put kind in STyCharacter too
 deriveSemTypeFromBaseTypeAndSelector :: BaseType -> Selector a -> Infer SemType
 deriveSemTypeFromBaseTypeAndSelector bt (Selector _ ss mLen mKindExpr) =
     case mLen of
@@ -654,7 +653,7 @@ deriveSemTypeFromBaseTypeAndSelector bt (Selector _ ss mLen mKindExpr) =
       Just len ->
         -- length only makes sense with a CHARACTER (AST does not enforce)
         case bt of
-          TypeCharacter -> defaultSemType -- TODO ????
+          TypeCharacter -> return $ STyCharacter (charLenSelector' len)
           _ -> do
             -- (unreachable code path in correct parser operation)
             typeError "only CHARACTER types can specify length (separate to kind)" ss

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase          #-}
 
 module Language.Fortran.Analysis.Types
-  ( analyseTypes, analyseTypesWithEnv, analyseAndCheckTypesWithEnv, extractTypeEnv, TypeEnv, TypeError )
+  ( analyseTypes, analyseTypesWithEnv, analyseAndCheckTypesWithEnv, extractTypeEnv, TypeEnv, TypeError, deriveSemTypeFromBaseType )
 where
 
 import Language.Fortran.AST

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -403,16 +403,6 @@ functionCallType ss e1 _ = case getIDType e1 of
   Just (IDType (Just st) (Just CTExternal)) -> return $ IDType (Just st) Nothing
   _ -> typeError "non-function invoked by call" ss >> return emptyType
 
-charLenConcat :: CharacterLen -> CharacterLen -> CharacterLen
-charLenConcat l1 l2 = case (l1, l2) of
-  (CharLenExp    , _             ) -> CharLenExp
-  (_             , CharLenExp    ) -> CharLenExp
-  (CharLenStar   , _             ) -> CharLenStar
-  (_             , CharLenStar   ) -> CharLenStar
-  (CharLenColon  , _             ) -> CharLenColon
-  (_             , CharLenColon  ) -> CharLenColon
-  (CharLenInt i1 , CharLenInt i2 ) -> CharLenInt (i1 + i2)
-
 isNumericType :: SemType -> Bool
 isNumericType = \case
   STyComplex{} -> True

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -642,11 +642,11 @@ deriveSemTypeFromBaseType = \case
   -- CHARACTERs default to len=1, kind=1 (non-1 is rare)
   TypeCharacter       -> TCharacter (CharLenInt 1) 1
 
-  -- FIXME: no clue what to do here. SemType maybe doesn't support F90 properly.
-  -- (I think one or two of these map to error in fortran-vars.)
+  -- FIXME: this is where Fortran specs diverge, and fortran-vars doesn't
+  -- support beyond F77e. Sticking with what passes the fortran-vars tests.
   ClassStar           -> TCustom "ClassStar"
-  TypeCustom    str   -> TCustom ("TypeCustom "  <> str)
-  ClassCustom   str   -> TCustom ("ClassCustom " <> str)
+  TypeCustom    str   -> TCustom str
+  ClassCustom   str   -> TCustom str
 
 noKind :: Kind
 noKind = -1

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -11,6 +11,8 @@ module Language.Fortran.Analysis.Types
   , deriveSemTypeFromDeclaration
   , deriveSemTypeFromTypeSpec
   , deriveSemTypeFromBaseType
+  , runInfer
+  , inferState0
   ) where
 
 import Language.Fortran.AST

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -570,11 +570,15 @@ deriveSemTypeFromDeclaration stmtSs declSs ts@(TypeSpec _ _ bt mSel) mLenExpr =
                 _ <- case mSelLenExpr of
                        Just _ -> do
                           -- LHS & RHS lengths: notify user (surprising syntax)
+                          -- Ben has seen this IRL: a high-ranking Fortran
+                          -- tutorial site uses it (2021-04-30):
+                          -- http://web.archive.org/web/20210118202503/https://www.tutorialspoint.com/fortran/fortran_strings.htm
+                          -- TODO: is this actually surprising or just to me lol
                          flip typeError declSs $
                              "warning: CHARACTER variable at declaration "
                           <> show stmtSs
                           <> " has length in LHS type spec and RHS declarator"
-                          <> " -- using declarator length"
+                          <> " -- declarator overrides"
                        _ -> return ()
                 let sel' = Selector selA selSs (Just lenExpr) mKindExpr
                 let (Just charLen, _) = charLenSelector (Just sel')

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -665,17 +665,6 @@ deriveSemTypeFromBaseTypeAndKind :: BaseType -> Kind -> Infer SemType
 deriveSemTypeFromBaseTypeAndKind bt k =
     return $ setTypeKind (deriveSemTypeFromBaseType bt) k
 
-setTypeKind :: SemType -> Kind -> SemType
-setTypeKind st k = case st of
-  STyInteger   _ -> STyInteger   k
-  STyReal      _ -> STyReal      k
-  STyComplex   _ -> STyComplex   k
-  STyLogical   _ -> STyLogical   k
-  STyByte      _ -> STyByte      k
-  STyCharacter charLen _ -> STyCharacter charLen k
-  STyCustom    _ -> error "can't set kind of STyCustom"
-  STyArray _ _   -> error "can't set kind of STyArray"
-
 --------------------------------------------------
 
 -- Local variables:

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -348,9 +348,10 @@ parseRealLiteral r =
     parseRealLitExponent = \case
       l:chs ->
         -- TODO: are we already lowercased perhaps?
-        let expLetter = case toLower l of 'e' -> ExpLetterE
-                                          'd' -> ExpLetterD
-         in Just (expLetter, read (takeWhile isDigit chs))
+        case toLower l of
+          'e' -> Just (ExpLetterE, read (takeWhile isDigit chs))
+          'd' -> Just (ExpLetterD, read (takeWhile isDigit chs))
+          _   -> Nothing
       _ -> Nothing
 
 -- | A REAL literal may have an optional exponent and kind.

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -12,15 +12,12 @@ import Data.Map (insert)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
 import Data.List (find)
-import Data.Char (isDigit, toLower)
-import Text.Read (readMaybe)
 import Control.Monad.State.Strict
 import Data.Generics.Uniplate.Data
 import Data.Data
 import Data.Functor.Identity (Identity ())
 import Control.Applicative (liftA2)
 import Language.Fortran.Analysis
-import Language.Fortran.Analysis.SemanticTypes (SemType(..))
 import Language.Fortran.Intrinsics
 import Language.Fortran.Util.Position
 import Language.Fortran.Version (FortranVersion(..))
@@ -83,7 +80,7 @@ analyseTypesWithEnv' env pf@(ProgramFile mi _) = runInfer (miVersion mi) env $ d
 
   -- Gather types for known entry points.
   eps <- gets (M.toList . entryPoints)
-  _ <- forM eps $ \ (eName, (fName, mRetName)) -> do
+  forM_ eps $ \ (eName, (fName, mRetName)) -> do
     mFType <- getRecordedType fName
     case mFType of
       Just (IDType fVType fCType) -> do
@@ -131,11 +128,12 @@ programUnit pu@(PUFunction _ _ mRetType _ _ _ mRetVar blocks _)
     -- record some type information that we can glean
     recordCType CTFunction n
     case (mRetType, mRetVar) of
-      (Just (TypeSpec _ _ baseType _), Just v) -> do
-        let semType = conjureFVType baseType conjuredKind
+      -- TODO: what exactly is going on here (accessing uniqueName/sourceName)
+      (Just ts@(TypeSpec _ _ baseType _), Just v) -> do
+        semType <- deriveSemTypeFromTypeSpec ts
         recordSemType semType n >> recordSemType semType (varName v)
-      (Just (TypeSpec _ _ baseType _), _)      -> do
-        let semType = conjureFVType baseType conjuredKind
+      (Just ts@(TypeSpec _ _ baseType _), _)      -> do
+        semType <- deriveSemTypeFromTypeSpec ts
         recordSemType semType n
       _                                        -> return ()
     -- record entry points for later annotation
@@ -160,71 +158,8 @@ dimDeclarator ddAList = [ (lb, ub) | DimensionDeclarator _ _ lbExp ubExp <- aStr
                                    , let ub = do ExpValue _ _ (ValInteger i) <- ubExp
                                                  return $ read i ]
 
--- | Conjure an FV type from a 'BaseType' and a 'Kind'.
-conjureFVType :: BaseType -> Kind -> SemType
-conjureFVType bt k =
-    case bt of
-      TypeInteger         -> STInteger k
-      TypeReal            -> STReal k
-      TypeComplex         -> STComplex k
-      TypeLogical         -> STLogical k
-      TypeByte            -> STByte k
-
-      -- TODO: unsure on the overlap between syntax and semantics here
-      -- (I think one or two of these map to error in FV)
-      ClassStar           -> STCustom "ClassStar"
-      TypeCustom    str   -> STCustom ("TypeCustom "  <> str)
-      ClassCustom   str   -> STCustom ("ClassCustom " <> str)
-
-      -- TODO: what's the kind stored in a TypeCharacter, how different to
-      -- Selector (apart from String vs. Expr)
-      TypeCharacter tLen tKind -> STCharacter (maybe Nothing fvCharLen tLen)
-
-      -- TODO: Likely TypeReal, TypeComplex with static kinds.
-      -- According to ~2004 gfortran docs, KIND=2 corresponds to the double
-      -- precision types: DOUBLE PRECISION = REAL*8, DOUBLE COMPLEX =
-      -- COMPLEX*16. I shall hardcode those for now.
-      TypeDoublePrecision -> STReal 2
-      TypeDoubleComplex   -> STComplex 2
-
--- Constant ints are copied, all others are replaced with Nothing.
---
--- This is due to FV dropping much of the type info strings have.
-fvCharLen :: CharacterLen -> Maybe Kind
-fvCharLen = \case
-  CharLenInt x -> Just x
-  _            -> Nothing
-
--- https://gcc.gnu.org/onlinedocs/gfortran/KIND-Type-Parameters.html
-conjureFVDefaultKind :: BaseType -> Kind
-conjureFVDefaultKind = \case
-  -- TODO: what's the kind stored in a TypeCharacter, how different to
-  -- Selector (apart from String vs. Expr)
-  TypeCharacter _ _ -> 1
-
-  TypeDoublePrecision -> 8
-
-  -- guess
-  TypeCustom  _ -> 1
-  ClassStar     -> 1
-  ClassCustom _ -> 1
-  TypeByte      -> 1
-
-  -- ints, logicals, reals, complexes appear to default to 4
-  _                 -> 4
-
--- https://gcc.gnu.org/onlinedocs/gfortran/KIND-Type-Parameters.html
--- matches storage size in bytes except for COMPLEX, which is *2
-type StorageBytes = Int
-typeSizeMapGFortran :: BaseType -> Kind -> StorageBytes
-typeSizeMapGFortran bt k =
-    case bt of
-      TypeComplex -> k*2
-      _           -> k
-
 statement :: Data a => InferFunc (Statement (Analysis a))
--- maybe FIXME: should Kind Selectors be part of types?
-statement (StDeclaration _ _ (TypeSpec _ _ baseType sel) mAttrAList declAList)
+statement (StDeclaration _ _ ts@(TypeSpec _ _ baseType _) mAttrAList declAList)
   | mAttrs  <- maybe [] aStrip mAttrAList
   , attrDim <- find isAttrDimension mAttrs
   , isParam <- any isAttrParameter mAttrs
@@ -237,20 +172,12 @@ statement (StDeclaration _ _ (TypeSpec _ _ baseType sel) mAttrAList declAList)
                 | Just (IDType _ (Just ct)) <- M.lookup n env
                 , ct /= CTIntrinsic                           = ct
                 | otherwise                                   = CTVariable
-    let charLen (ExpValue _ _ (ValInteger i)) = CharLenInt (read i)
-        charLen (ExpValue _ _ ValStar)        = CharLenStar
-        charLen _                             = CharLenExp
-    let selKind (Just (Selector _ _ _ (Just (ExpValue _ _ (ValInteger k))))) = Just (read k)
-        selKind _ = Nothing
-        kind = maybe (conjureFVDefaultKind baseType) id (selKind sel)
-    let sType (Just e)
-          | TypeCharacter len kind <- baseType = STCharacter (maybe Nothing fvCharLen len)
-          | otherwise                          = STCharacter Nothing
-        sType Nothing  = conjureFVType baseType kind
-    -- TODO: probably OK to use 'StDeclaration' 'BaseType', @bType@ only wraps
+    semType <- deriveSemTypeFromTypeSpec ts
     forM_ decls $ \ decl -> case decl of
-      DeclArray _ _ v ddAList e _ -> recordType (sType e) (CTArray $ dimDeclarator ddAList) (varName v)
-      DeclVariable _ _ v e _      -> recordType (sType e) (cType n) n where n = varName v
+        -- TODO: we're throwing away the (Maybe Expr) in the Declarator -- is
+        -- that bad? the original usage was confusing
+        DeclArray _ _ v ddAList _ _ -> recordType semType (CTArray $ dimDeclarator ddAList) (varName v)
+        DeclVariable _ _ v _ _      -> recordType semType (cType n) n where n = varName v
 
 statement (StExternal _ _ varAList) = do
   let vars = aStrip varAList
@@ -262,7 +189,7 @@ statement (StExpressionAssign _ _ (ExpSubscript _ _ v ixAList) _)
     mIDType <- getRecordedType n
     case mIDType of
       Just (IDType _ (Just CTArray{})) -> return ()                -- do nothing, it's already known to be an array
-      _                                  -> recordCType CTFunction n -- assume it's a function statement
+      _                                -> recordCType CTFunction n -- assume it's a function statement
 
 -- FIXME: if StFunctions can only be identified after types analysis
 -- is complete and disambiguation is performed, then how do we get
@@ -280,16 +207,23 @@ statement (StDimension _ _ declAList) = do
 statement _ = return ()
 
 annotateExpression :: Data a => Expression (Analysis a) -> Infer (Expression (Analysis a))
+
+-- handle the various literals
 annotateExpression e@(ExpValue _ _ (ValVariable _))    = maybe e (`setIDType` e) `fmap` getRecordedType (varName e)
 annotateExpression e@(ExpValue _ _ (ValIntrinsic _))   = maybe e (`setIDType` e) `fmap` getRecordedType (varName e)
 annotateExpression e@(ExpValue _ ss (ValReal r))        = do
-    k <- realLiteralKind ss r
-    return $ IDType (Just (STReal k)) Nothing `setIDType` e
+    k <- deriveRealLiteralKind ss r
+    return $ setSemType (STReal k) e
 annotateExpression e@(ExpValue _ ss (ValComplex e1 e2)) = do
     st <- complexLiteralType ss e1 e2
-    return $ IDType (Just st) Nothing `setIDType` e
-annotateExpression e@(ExpValue _ _ (ValInteger _))     = return $ IDType (Just (STInteger conjuredKind)) Nothing `setIDType` e
-annotateExpression e@(ExpValue _ _ (ValLogical _))     = return $ IDType (Just (STLogical conjuredKind)) Nothing `setIDType` e
+    return $ setSemType st e
+annotateExpression e@(ExpValue _ _ (ValInteger _))     =
+    -- TODO: in >F90, int lits can have kind info on end, same as real lits. We
+    -- do parse this
+    return $ setSemType (deriveSemTypeFromBaseType TypeInteger) e
+annotateExpression e@(ExpValue _ _ (ValLogical _))     =
+    return $ setSemType (deriveSemTypeFromBaseType TypeLogical) e
+
 annotateExpression e@(ExpBinary _ _ op e1 e2)          = flip setIDType e `fmap` binaryOpType (getSpan e) op e1 e2
 annotateExpression e@(ExpUnary _ _ op e1)              = flip setIDType e `fmap` unaryOpType (getSpan e1) op e1
 annotateExpression e@(ExpSubscript _ _ e1 idxAList)    = flip setIDType e `fmap` subscriptType (getSpan e) e1 idxAList
@@ -300,11 +234,12 @@ annotateProgramUnit :: Data a => ProgramUnit (Analysis a) -> Infer (ProgramUnit 
 annotateProgramUnit pu | Named n <- puName pu = maybe pu (`setIDType` pu) `fmap` getRecordedType n
 annotateProgramUnit pu                        = return pu
 
--- upgraded to Infer so we can return type errors
--- logic taken from HP's F90 reference pg.33, and matches gfortran's behaviour
--- TODO: overview in haddock
-realLiteralKind :: SrcSpan -> String -> Infer Kind
-realLiteralKind ss r =
+-- | Derive the kind of a REAL literal constant.
+--
+-- Logic taken from HP's F90 reference pg.33, written to gfortran's behaviour.
+-- Stays in the 'Infer' monad so it can report type errors
+deriveRealLiteralKind :: SrcSpan -> String -> Infer Kind
+deriveRealLiteralKind ss r =
     case realLitKindParam realLit of
       Nothing -> return kindFromExpOrDefault
       Just k  ->
@@ -315,7 +250,8 @@ realLiteralKind ss r =
             case expLetter expo of
               ExpLetterE -> return k
               _          -> do
-                -- badly formed literal, but we'll allow and default to kind param
+                -- badly formed literal, but we'll allow and use the provided
+                -- kind param (with no doubling or anything)
                 typeError "only real literals with exponent letter 'e' can specify explicit kind parameter" ss
                 return k
   where
@@ -329,11 +265,14 @@ realLiteralKind ss r =
               ExpLetterE -> 4
               ExpLetterD -> 8
 
+-- | Get the type of a COMPLEX literal constant.
+--
+-- The kind is derived only from the first expression, the second is ignored.
 complexLiteralType :: SrcSpan -> Expression a -> Expression a -> Infer SemType
 complexLiteralType ss (ExpValue _ _ (ValReal r)) _ = do
-    k1 <- realLiteralKind ss r
+    k1 <- deriveRealLiteralKind ss r
     return $ STComplex k1
-complexLiteralType _ _ _ = return $ STComplex conjuredKind
+complexLiteralType _ _ _ = return $ deriveSemTypeFromBaseType TypeComplex
 
 binaryOpType :: Data a => SrcSpan -> BinaryOp -> Expression (Analysis a) -> Expression (Analysis a) -> Infer IDType
 binaryOpType ss op e1 e2 = do
@@ -352,41 +291,38 @@ binaryOpType ss op e1 e2 = do
         Just st
           | op `elem` [ Addition, Subtraction, Multiplication, Division
                       , Exponentiation, Concatenation, Or, XOr, And ]       -> return $ Just st
-          | op `elem` [GT, GTE, LT, LTE, EQ, NE, Equivalent, NotEquivalent] -> return $ Just (STLogical conjuredKind)
+          | op `elem` [GT, GTE, LT, LTE, EQ, NE, Equivalent, NotEquivalent] -> return $ Just (deriveSemTypeFromBaseType TypeLogical)
           | BinCustom{} <- op -> typeError "custom binary ops not supported" ss >> return Nothing
         _ -> return Nothing
 
       return $ IDType mst' Nothing -- FIXME: might have to check kinds of each operand
 
--- TODO
+-- | Combine two 'SemType's with a 'BinaryOp'.
+--
+-- No real work done here, no kind combining, just selection.
 binopSimpleCombineSemTypes :: SrcSpan -> BinaryOp -> SemType -> SemType -> Infer (Maybe SemType)
 binopSimpleCombineSemTypes ss op st1 st2 = do
     case (st1, st2) of
-      (_, STComplex k2) -> ret $ STComplex k2
-      (_, STReal k2)    -> ret $ STReal k2
-      (_, STInteger k2) -> ret $ STInteger k2
-      (_, STByte k2)    -> ret $ STByte k2
-      (_, STLogical k2) -> ret $ STLogical k2
-      (STCustom n1, STCustom n2) -> do
+      (_           , STComplex k2) -> ret $ STComplex k2
+      (STComplex k1, _           ) -> ret $ STComplex k1
+      (_           , STReal    k2) -> ret $ STReal k2
+      (STReal    k1, _           ) -> ret $ STReal k1
+      (_           , STInteger k2) -> ret $ STInteger k2
+      (STInteger k1, _           ) -> ret $ STInteger k1
+      (STByte    k1, STByte    _ ) -> ret $ STByte k1
+      (STLogical k1, STLogical _ ) -> ret $ STLogical k1
+      (STCustom  n1, STCustom  n2) -> do
         typeError "custom types / binary op not supported" ss
         return Nothing
       (STCharacter k1, STCharacter k2)
-        | op == Concatenation -> ret $ STCharacter (charLen'Concat k1 k2)
-        | op `elem` [EQ, NE]  -> ret $ STLogical conjuredKind
+        | op == Concatenation -> ret $ STCharacter (liftA2 (+) k1 k2)
+        | op `elem` [EQ, NE]  -> ret $ deriveSemTypeFromBaseType TypeLogical
         | otherwise -> do typeError "Invalid op on character strings" ss
                           return Nothing
       _ -> do typeError "Type error between operands of binary operator" ss
               return Nothing
   where
     ret = return . Just
-
-conjuredKind :: Kind
-conjuredKind = 0
-
--- Simpler than original because FV's type rep drops extra syntactic info about
--- char lengths (all non-ints pushed into Nothing)
-charLen'Concat :: Maybe Kind -> Maybe Kind -> Maybe Kind
-charLen'Concat = liftA2 (+)
 
 unaryOpType :: Data a => SrcSpan -> UnaryOp -> Expression (Analysis a) -> Infer IDType
 unaryOpType ss op e = do
@@ -446,7 +382,7 @@ functionCallType ss e1 _ = case getIDType e1 of
   Just (IDType (Just st) (Just CTExternal)) -> return $ IDType (Just st) Nothing
   _ -> typeError "non-function invoked by call" ss >> return emptyType
 
--- TODO: use default kinds
+-- TODO: do this (what is 'IntrinsicType'?)
 intrinsicToMaybeSemType :: IntrinsicType -> Maybe SemType
 intrinsicToMaybeSemType = const Nothing
 
@@ -517,6 +453,19 @@ setIDType ty x
 getIDType :: (Annotated f, Data a) => f (Analysis a) -> Maybe IDType
 getIDType x = idType (getAnnotation x)
 
+-- | For all types holding an 'IDType' (in an 'Analysis'), set the 'SemType'
+--   field of the 'IDType'.
+setSemType :: (Annotated f, Data a) => SemType -> f (Analysis a) -> f (Analysis a)
+setSemType st x =
+    let anno  = getAnnotation x
+        idt   = idType anno
+        anno' = anno { idType = Just (setIDTypeSemType idt) }
+     in setAnnotation anno' x
+  where
+    setIDTypeSemType :: Maybe IDType -> IDType
+    setIDTypeSemType (Just (IDType _ mCt)) = IDType (Just st) mCt
+    setIDTypeSemType Nothing               = IDType (Just st) Nothing
+
 -- Set the CType part of idType annotation
 --setCType :: (Annotated f, Data a) => ConstructType -> f (Analysis a) -> f (Analysis a)
 --setCType ct x
@@ -552,6 +501,122 @@ isAttrExternal _               = False
 isIxSingle :: Index a -> Bool
 isIxSingle IxSingle {} = True
 isIxSingle _           = False
+
+--------------------------------------------------
+
+-- Most, but not all deriving functions can report type errors. So most of these
+-- functions are in the Infer monad.
+
+-- | Attempt to derive a 'SemType' from a 'TypeSpec' (and the 'BaseType' etc.
+--   inside).
+--
+-- This is an 'Infer' action so that it can report type errors.
+deriveSemTypeFromTypeSpec :: TypeSpec a -> Infer SemType
+deriveSemTypeFromTypeSpec (TypeSpec _ _ bt mSel) =
+    case mSel of
+      -- Selector present: we might have kind/other info provided
+      Just sel -> deriveSemTypeFromBaseTypeAndSelector bt sel
+
+      -- no Selector: derive using default kinds
+      Nothing  -> return $ deriveSemTypeFromBaseType bt
+
+-- | Attempt to derive a SemType from a 'BaseType' and a 'Selector' (e.g.
+--   extracted from a 'TypeSpec').
+deriveSemTypeFromBaseTypeAndSelector :: BaseType -> Selector a -> Infer SemType
+deriveSemTypeFromBaseTypeAndSelector bt (Selector _ ss mLen mKindExpr) =
+    case mLen of
+      Nothing  ->
+        case mKindExpr of
+          Nothing       -> defaultSemType
+          Just kindExpr ->
+            -- only support integer kind selectors for now, no params
+            case kindExpr of
+              ExpValue _ _ (ValInteger k) ->
+                deriveSemTypeFromBaseTypeAndKind bt (read k)
+              _ -> do
+                typeError "unsupported or invalid kind selector" (getSpan kindExpr)
+                defaultSemType
+      Just len ->
+        -- length only makes sense with a CHARACTER (AST does not enforce)
+        case bt of
+          TypeCharacter mCharLenExpr mKindStr ->
+            -- soft todo: OK, here we have:
+            --   * the Selector (a Maybe lenexpr and Maybe kindexp)
+            --   * the Selector parsed into a CharacterLen and a stricter kind
+            -- and we need to stuff those into a single Maybe Kind (Int). I
+            -- can't see how fortran-vars does it! TypeCheck.typeOfValue is for
+            -- constants, and sets Just (length str). The stuff in Kind sets
+            -- Just 1??? As a placeholder, I assume.
+            -- So if we got a CharLenInt, we'll use that. Otherwise we'll leave
+            -- a placeholder saying it's invalid for now.
+            case mCharLenExpr of
+              Just (CharLenInt chLen) -> return $ STCharacter (Just chLen)
+              Just charLenExpr -> do
+                typeError "non-int char length spec currently unsupported, invalidating" ss
+                return $ STCharacter (Just invalidKind)
+              _ -> return $ STCharacter (Just invalidKind)
+          _ -> do
+            -- (upon tests, likely unreachable due to parser behaviour)
+            typeError "only CHARACTER types can specify length (separate to kind)" ss
+            defaultSemType
+  where
+    -- Same behaviour as for no Selector, intended to handle type error cases or
+    -- empty Selectors (though latter should not occur).
+    defaultSemType = return $ deriveSemTypeFromBaseType bt
+
+deriveSemTypeFromBaseType :: BaseType -> SemType
+deriveSemTypeFromBaseType = \case
+  TypeInteger         -> STInteger 4
+  TypeReal            -> STReal    4
+  TypeComplex         -> STComplex 4
+  TypeLogical         -> STLogical 4
+
+  -- Fortran specs & compilers seem to agree on equating these intrinsic types
+  -- to others with a larger kind, so we drop the extra syntactic info here.
+  TypeDoublePrecision -> STReal    8
+  TypeDoubleComplex   -> STComplex 8
+
+  -- BYTE: HP's Fortran 90 reference says that BYTE is an HP extension, equates
+  -- it to INTEGER(1), and indicates that it doesn't take a kind selector.
+  -- Don't know how BYTEs are used in the wild. I wonder if we could safely
+  -- equate BYTE to (STInteger 1)?
+  TypeByte            -> STByte    noKind
+
+  -- (see deriveSemTypeFromBaseTypeAndSelector)
+  TypeCharacter mLen mKindExpr ->
+    -- If we're here, mLen and mKindExpr are almost certainly Nothing. So we'll
+    -- ignore them and say "dynamic length" (unsure if that's true)
+    STCharacter Nothing
+
+  -- TODO: no clue what to do here. SemType maybe doesn't support F90 properly.
+  -- (I think one or two of these map to error in FV)
+  ClassStar           -> STCustom "ClassStar"
+  TypeCustom    str   -> STCustom ("TypeCustom "  <> str)
+  ClassCustom   str   -> STCustom ("ClassCustom " <> str)
+
+noKind, invalidKind :: Kind
+noKind      = -1
+invalidKind = -2
+
+-- in the Infer monad because some intrinsic types may not take a kind, so it'd
+-- be best to type error here to inform
+-- but it's small fry stuff so we just write the given kind regardless
+deriveSemTypeFromBaseTypeAndKind :: BaseType -> Kind -> Infer SemType
+deriveSemTypeFromBaseTypeAndKind bt k =
+    return $ setTypeKind (deriveSemTypeFromBaseType bt) k
+
+setTypeKind :: SemType -> Kind -> SemType
+setTypeKind st k = case st of
+  STInteger   _ -> STInteger   k
+  STReal      _ -> STReal      k
+  STComplex   _ -> STComplex   k
+  STLogical   _ -> STLogical   k
+  STByte      _ -> STByte      k
+  STCharacter _ -> STCharacter (Just k)
+  STCustom    s -> STCustom s
+  STArray st' mDims ->
+    -- TODO: appears invalid -- however none of my code creates 'STArray's
+    STArray st' mDims
 
 --------------------------------------------------
 

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -1144,6 +1144,7 @@ data Token =
   | TComment            SrcSpan String
   | TString             SrcSpan String
   | TIntegerLiteral     SrcSpan String
+  -- | TRealLiteral        SrcSpan String (Maybe RealExponent) (Maybe KindParam)
   | TRealLiteral        SrcSpan String
   | TBozLiteral         SrcSpan String
   | TComma              SrcSpan

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1012,9 +1012,9 @@ MAYBE_TYPE_SPEC :: { Maybe (TypeSpec A0) }
 TYPE_SPEC :: { TypeSpec A0 }
 : integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
 | real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
 | complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
 | logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
 | type '(' id ')'
   { let TId _ id = $3

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -1020,17 +1020,15 @@ LABEL_IN_STATEMENT :: { Expression A0 } : int { ExpValue () (getSpan $1) (let (T
 
 TYPE_SPEC :: { TypeSpec A0 }
 TYPE_SPEC
-: integer KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2  }
-| doublePrecision KIND_SELECTOR
-  { TypeSpec () (getSpan ($1, $2)) TypeDoublePrecision $2 }
-| logical KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| complex KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| doubleComplex KIND_SELECTOR
-  { TypeSpec () (getSpan ($1, $2)) TypeDoubleComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| byte KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeByte $2 }
-| record '/' NAME '/' { TypeSpec () (getSpan ($1, $4)) (TypeCustom $3) Nothing }
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2  }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing}
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| doubleComplex           { TypeSpec () (getSpan $1)       TypeDoubleComplex Nothing}
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| byte      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeByte $2 }
+| record    '/' NAME '/'  { TypeSpec () (getSpan ($1, $4)) (TypeCustom $3) Nothing }
 
 KIND_SELECTOR :: { Maybe (Selector A0) }
 KIND_SELECTOR

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -868,13 +868,13 @@ DIMENSION_DECLARATOR :: { DimensionDeclarator A0 }
     in DimensionDeclarator () span Nothing Nothing }
 
 TYPE_SPEC :: { TypeSpec A0 }
-: integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
-| complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| type '(' id ')'
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| type      '(' id ')'
   { let TId _ id = $3
     in TypeSpec () (getTransSpan $1 $4) (TypeCustom id) Nothing }
 

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -881,13 +881,13 @@ DIMENSION_DECLARATOR :: { DimensionDeclarator A0 }
     in DimensionDeclarator () span Nothing Nothing }
 
 TYPE_SPEC :: { TypeSpec A0 }
-: integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
-| complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| type '(' id ')'
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| type      '(' id ')'
   { let TId _ id = $3
     in TypeSpec () (getTransSpan $1 $4) (TypeCustom id) Nothing }
 

--- a/src/Language/Fortran/Parser/Utils.hs
+++ b/src/Language/Fortran/Parser/Utils.hs
@@ -1,7 +1,21 @@
+{-# LANGUAGE LambdaCase #-}
+
 {-| Simple module to provide functions that read Fortran literals -}
-module Language.Fortran.Parser.Utils (readReal, readInteger) where
+module Language.Fortran.Parser.Utils
+  ( readReal
+  , readInteger
+  , parseRealLiteral
+  , RealLit(..)
+  , Exponent(..)
+  , NumSign(..)
+  , ExponentLetter(..)
+  ) where
+
+import Language.Fortran.AST (Kind)
+
 import Data.Char
 import Numeric
+import Text.Read (readMaybe)
 
 breakAtDot :: String -> (String, String)
 replaceDwithE :: Char -> Char
@@ -41,3 +55,73 @@ replaceDwithE c     = c
 readsToMaybe r = case r of
   (x, _):_ -> Just x
   _ -> Nothing
+
+--------------------------------------------------------------------------------
+
+-- TODO incorrect, kind params also allow 'Name's
+type KindParam = Kind
+
+-- | A REAL literal may have an optional exponent and kind.
+--
+-- The value can be retrieved as a 'Double' by using these parts.
+data RealLit = RealLit
+  { realLitValue     :: String
+  , realLitExponent  :: Maybe Exponent
+  , realLitKindParam :: Maybe KindParam
+  } deriving Show
+
+-- | An exponent is an exponent letter (E, D) and a value (with an optional
+-- sign).
+data Exponent = Exponent
+  { expLetter :: ExponentLetter
+  , expSign   :: Maybe NumSign
+  , expNum    :: String
+  } deriving Show
+
+-- Note: Some Fortran language references include extensions here. HP's F90
+-- reference provides a Q exponent letter which sets kind to 16.
+data ExponentLetter
+  = ExpLetterD
+  | ExpLetterE
+    deriving Show
+
+data NumSign
+  = SignPos
+  | SignNeg
+    deriving Show
+
+-- | Parse a Fortran literal real to its constituent parts.
+parseRealLiteral :: String -> RealLit
+parseRealLiteral r =
+    RealLit { realLitValue     = takeWhile isValuePart r
+            , realLitExponent  = parseRealLitExponent (dropWhile isValuePart r)
+            , realLitKindParam = parseRealLitKindInt (dropWhile (/= '_') r)
+            }
+  where
+    isValuePart :: Char -> Bool
+    isValuePart ch
+      | isDigit ch = True
+      | ch == '.'  = True
+      | otherwise  = False
+    parseRealLitKindInt :: String -> Maybe Kind
+    parseRealLitKindInt = \case
+      '_':chs -> readMaybe chs
+      _       -> Nothing
+    parseRealLitExponent :: String -> Maybe Exponent
+    parseRealLitExponent "" = Nothing
+    parseRealLitExponent (c:cs) = do
+        letter <-
+                case toLower c of
+                  'e' -> Just ExpLetterE
+                  'd' -> Just ExpLetterD
+                  _   -> Nothing
+        let (sign, cs'') =
+                case cs of
+                  ""       -> (Nothing, cs)
+                  c':cs'  -> -- TODO: want to locally scope cs'' but unsure how to??
+                    case c' of
+                      '-' -> (Just SignNeg, cs')
+                      '+' -> (Just SignPos, cs')
+                      _   -> (Nothing     , cs)
+            digitStr = read (takeWhile isDigit cs'')
+        return $ Exponent letter sign digitStr

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -12,7 +12,7 @@ import Data.List (foldl')
 import Prelude hiding (EQ,LT,GT,pred,exp,(<>))
 
 import Language.Fortran.AST
-import Language.Fortran.ParserMonad
+import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 
 import Text.PrettyPrint
@@ -353,7 +353,7 @@ instance Pretty BaseType where
       | v == Fortran77Extended = "double complex"
       | otherwise = tooOld v "Double complex" Fortran77Extended
     pprint' _ TypeLogical = "logical"
-    pprint' v (TypeCharacter _ _)
+    pprint' v TypeCharacter
       | v >= Fortran77 = "character"
       | otherwise = tooOld v "Character data type" Fortran77
     pprint' v (TypeCustom str)
@@ -369,12 +369,6 @@ instance Pretty BaseType where
     pprint' v (ClassCustom str)
       | v >= Fortran2003 = "class" <> parens (text str)
       | otherwise = tooOld v "Class(spec)" Fortran2003
-
-instance Pretty CharacterLen where
-  pprint' _ CharLenStar = "*"
-  pprint' _ CharLenColon = ":"
-  pprint' _ CharLenExp  = "*" -- FIXME, possibly, with a more robust const-exp
-  pprint' _ (CharLenInt i) = text (show i)
 
 instance Pretty (TypeSpec a) where
     pprint' v (TypeSpec _ _ baseType mSelector) =

--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -22,7 +22,7 @@ disambiguateFunctionStatements = modifyProgramFile (trans statement)
   where
     trans = transformBi :: Data a => TransFunc Statement ProgramFile a
     statement (StExpressionAssign a1 s (ExpSubscript _ _ v@(ExpValue a _ (ValVariable _)) indicies) e2)
-      | Just (IDType _ (Just CTFunction) _ _) <- idType a
+      | Just (IDType _ (Just CTFunction)) <- idType a
       , indiciesRangeFree indicies = StFunction a1 s v (aMap fromIndex indicies) e2
     -- nullary statement function
     statement (StExpressionAssign a1 s1 (ExpFunctionCall _ _ v@(ExpValue a s (ValVariable _)) Nothing) e2)
@@ -34,16 +34,16 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
-      | Just (IDType _ (Just CTFunction) _ _) <- idType a
+      | Just (IDType _ (Just CTFunction)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTExternal) _ _) <- idType a
+      | Just (IDType _ (Just CTExternal)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTVariable) _ _) <- idType a
+      | Just (IDType _ (Just CTVariable)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
       | Nothing <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
-      | Just (IDType _ (Just CTIntrinsic) _ _) <- idType a
+      | Just (IDType _ (Just CTIntrinsic)) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression e                                      = e
 

--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -22,7 +22,7 @@ disambiguateFunctionStatements = modifyProgramFile (trans statement)
   where
     trans = transformBi :: Data a => TransFunc Statement ProgramFile a
     statement (StExpressionAssign a1 s (ExpSubscript _ _ v@(ExpValue a _ (ValVariable _)) indicies) e2)
-      | Just (IDType _ (Just CTFunction)) <- idType a
+      | Just (IDType _ (Just CTFunction) _) <- idType a
       , indiciesRangeFree indicies = StFunction a1 s v (aMap fromIndex indicies) e2
     -- nullary statement function
     statement (StExpressionAssign a1 s1 (ExpFunctionCall _ _ v@(ExpValue a s (ValVariable _)) Nothing) e2)
@@ -34,16 +34,16 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
-      | Just (IDType _ (Just CTFunction)) <- idType a
+      | Just (IDType _ (Just CTFunction) _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTExternal)) <- idType a
+      | Just (IDType _ (Just CTExternal) _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTVariable)) <- idType a
+      | Just (IDType _ (Just CTVariable) _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
       | Nothing <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
-      | Just (IDType _ (Just CTIntrinsic)) <- idType a
+      | Just (IDType _ (Just CTIntrinsic) _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression e                                      = e
 

--- a/src/Language/Fortran/Transformation/Disambiguation/Function.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Function.hs
@@ -22,7 +22,7 @@ disambiguateFunctionStatements = modifyProgramFile (trans statement)
   where
     trans = transformBi :: Data a => TransFunc Statement ProgramFile a
     statement (StExpressionAssign a1 s (ExpSubscript _ _ v@(ExpValue a _ (ValVariable _)) indicies) e2)
-      | Just (IDType _ (Just CTFunction) _) <- idType a
+      | Just (IDType _ (Just CTFunction) _ _) <- idType a
       , indiciesRangeFree indicies = StFunction a1 s v (aMap fromIndex indicies) e2
     -- nullary statement function
     statement (StExpressionAssign a1 s1 (ExpFunctionCall _ _ v@(ExpValue a s (ValVariable _)) Nothing) e2)
@@ -34,16 +34,16 @@ disambiguateFunctionCalls = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValVariable _)) indicies)
-      | Just (IDType _ (Just CTFunction) _) <- idType a
+      | Just (IDType _ (Just CTFunction) _ _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTExternal) _) <- idType a
+      | Just (IDType _ (Just CTExternal) _ _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
-      | Just (IDType _ (Just CTVariable) _) <- idType a
+      | Just (IDType _ (Just CTVariable) _ _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
       | Nothing <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression (ExpSubscript a1 s v@(ExpValue a _ (ValIntrinsic _)) indicies)
-      | Just (IDType _ (Just CTIntrinsic) _) <- idType a
+      | Just (IDType _ (Just CTIntrinsic) _ _) <- idType a
       , indiciesRangeFree indicies = ExpFunctionCall a1 s v (Just $ aMap fromIndex indicies)
     expression e                                      = e
 

--- a/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
@@ -17,8 +17,8 @@ disambiguateIntrinsic = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpValue a s (ValVariable v))
-      | Just (IDType _ (Just CTIntrinsic)) <- idType a = ExpValue a s (ValIntrinsic v)
-    expression e                                      = e
+      | Just (IDType _ (Just CTIntrinsic) _) <- idType a = ExpValue a s (ValIntrinsic v)
+    expression e                                         = e
 
 --------------------------------------------------
 

--- a/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
@@ -17,7 +17,7 @@ disambiguateIntrinsic = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpValue a s (ValVariable v))
-      | Just (IDType _ (Just CTIntrinsic) _) <- idType a = ExpValue a s (ValIntrinsic v)
+      | Just (IDType _ (Just CTIntrinsic) _ _) <- idType a = ExpValue a s (ValIntrinsic v)
     expression e                                         = e
 
 --------------------------------------------------

--- a/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
+++ b/src/Language/Fortran/Transformation/Disambiguation/Intrinsic.hs
@@ -17,7 +17,7 @@ disambiguateIntrinsic = modifyProgramFile (trans expression)
   where
     trans = transformBi :: Data a => TransFunc Expression ProgramFile a
     expression (ExpValue a s (ValVariable v))
-      | Just (IDType _ (Just CTIntrinsic) _ _) <- idType a = ExpValue a s (ValIntrinsic v)
+      | Just (IDType _ (Just CTIntrinsic)) <- idType a = ExpValue a s (ValIntrinsic v)
     expression e                                         = e
 
 --------------------------------------------------

--- a/src/Language/Fortran/Vars/Types.hs
+++ b/src/Language/Fortran/Vars/Types.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Language.Fortran.Vars.Types where
+
+import           Data.Data                      ( Data )
+import           Data.Map                       ( Map )
+import           Data.Typeable                  ( Typeable )
+import           GHC.Generics                   ( Generic )
+import           Control.DeepSeq                ( NFData )
+import           Language.Fortran.AST           ( Name
+                                                , ProgramUnitName
+                                                , Expression
+                                                )
+import           Language.Fortran.Util.Position ( SrcSpan(..)
+                                                , Position(..)
+                                                )
+
+import           Text.PrettyPrint.GenericPretty (Out(..))
+import           Data.Binary (Binary(..))
+
+-- | The evaluated value of a FORTRAN expression
+data ExpVal
+  = Int     Int
+  | Real    Double
+  | Str     String
+  | Logical Bool
+  | Boz     String
+  deriving (Eq, Ord, Show, Data, Typeable, Generic, NFData)
+
+-- | Memory offset given to a variable in memory
+type Offset = Int
+
+-- | The name of block of memory
+type MemoryBlockName = Name
+
+-- | The location of a variable, i.e. the 'MemoryBlockName' that
+-- contains it as well as the 'Offset' to its location in memory
+type Location = (MemoryBlockName, Offset)
+
+-- | The declared lifetimes of the variables in memory
+data StorageClass
+  = Static
+  | Automatic
+  | Constant
+  | Common
+  | Unspecified
+  deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+-- | The declared dimensions of a staticically typed array variable
+-- type is of the form [(dim1_lower, dim1_upper), (dim2_lower, dim2_upper)]
+type Dimensions = [(Int, Int)]
+
+-- | An entry in the 'SymbolTable' for some variable
+data SymbolTableEntry
+  = SParameter { parType :: Type , parVal :: ExpVal }
+  | SVariable { varType :: Type , varLoc :: Location }
+  | SDummy { dumType :: Type }
+  | SExternal {extType :: Type }
+  deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+type Kind = Int
+
+data Type
+  = TInteger Kind
+  | TReal Kind
+  | TComplex Kind
+  | TLogical Kind
+  | TByte Kind
+  | TCharacter (Maybe Kind) -- ^ Nothing denotes dynamic length
+  | TArray Type (Maybe Dimensions) -- ^ Nothing denotes dynamic dimensions
+  | TCustom String
+  deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+instance Binary Type
+instance Out    Type
+
+-- | Symbol table containing all non-intrisic symbols declared in a program
+type SymbolTable = Map Name SymbolTableEntry
+
+-- | Structure to hold information about the named blocks of memory
+-- in the program
+data MemoryBlock = MemoryBlock
+  { blockSize    :: Maybe Int -- ^ Nothing for when block is dynamically sized
+  , storageClass :: StorageClass
+  , variables    :: [Name]
+  } deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+-- | Map from a structure name to its internal structure, specifying members
+-- and their corresponding type. This can then be used to check the type of a
+-- data reference expression.
+type StructureTable = Map String Structure
+
+-- List of structure fields forming a structure
+type Structure = [StructureTableEntry]
+
+-- | Data structurue for a single field of a structure
+data StructureTableEntry
+  = FieldEntry String Type
+  | UnionEntry [Structure]
+  deriving (Eq, Show, Data)
+
+-- | Mapping from the name of a memory block to the information about it
+type StorageTable = Map MemoryBlockName MemoryBlock
+
+-- | The model to represent an individual 'Language.Fortran.AST.ProgramUnit'
+type ProgramUnitModel = (SymbolTable, StorageTable)
+
+-- | Mapping from the name of a 'Language.Fortran.AST.ProgramUnit' to
+-- its 'ProgramUnitModel'
+type ProgramFileModel = Map ProgramUnitName ProgramUnitModel
+
+-- | Mapping from name of a program unit to relevant structure table
+type ProgramStructureTables = Map ProgramUnitName StructureTable
+
+data TypeError
+  = TypeError FilePath SrcSpan String
+  | UnknownType SrcSpan
+  | UnboundVariable Name
+  | UnknownField String
+  deriving (Eq, Ord, Show, Generic)
+
+-- | Helper method for getting the FilePath out of SrcSpan
+typeError :: SrcSpan -> String -> TypeError
+typeError sp = let SrcSpan p _ = sp in TypeError (filePath p) sp
+
+type TypeOf a = Expression a -> Either TypeError Type

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -333,7 +333,7 @@ showTypes :: TypeEnv -> String
 showTypes tenv =
     flip concatMap (M.toList tenv) $
       \ (name, IDType { idVType = vt, idCType = ct }) ->
-        printf "%s\t\t%s %s\n" name (drop 2 $ maybe "  -" show vt) (drop 2 $ maybe "   " show ct)
+        printf "%s\t\t%s %s\n" name (drop 3 $ maybe "  -" show vt) (drop 2 $ maybe "   " show ct)
 printTypes :: TypeEnv -> IO ()
 printTypes = putStrLn . showTypes
 showTypeErrors :: [TypeError] -> String

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -128,9 +128,6 @@ main = do
                  , b <- concatMap snd $ labNodes (bbgrGr bbgr)
                  , insLabel (getAnnotation b) == Just astBlockId ]
       case actionOpt of
-        Tmp        ->
-            let pf = parserF mods contents path
-             in (print . snd) $ analyseTypes (initAnalysis pf)
         Lex | version `elem` [ Fortran66, Fortran77, Fortran77Extended, Fortran77Legacy ] ->
           print $ FixedForm.collectFixedTokens version contents
         Lex | version `elem` [Fortran90, Fortran2003, Fortran2008] ->
@@ -343,7 +340,7 @@ printTypeErrors = putStrLn . showTypeErrors
 
 data Action
   = Lex | Parse | Typecheck | Rename | BBlocks | SuperGraph | Reprint | DumpModFile | Compile
-  | ShowFlows Bool Bool Int | ShowBlocks (Maybe Int) | ShowMakeGraph | Make | Tmp
+  | ShowFlows Bool Bool Int | ShowBlocks (Maybe Int) | ShowMakeGraph | Make
   deriving Eq
 
 instance Read Action where
@@ -375,10 +372,6 @@ options =
       ["fortranVersion"]
       (ReqArg (\v opts -> opts { fortranVersion = selectFortranVersion v }) "VERSION")
       "Fortran version to use, format: Fortran[66/77/77Legacy/77Extended/90]"
-  , Option []
-      ["tmp"]
-      (NoArg $ \ opts -> opts { action = Tmp })
-      "tmp action"
   , Option ['a']
       ["action"]
       (ReqArg (\a opts -> opts { action = read a }) "ACTION")

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -332,8 +332,8 @@ showModuleMap = concatMap (\ (n, m) -> show n ++ ":\n" ++ (unlines . map ("  "++
 showTypes :: TypeEnv -> String
 showTypes tenv =
     flip concatMap (M.toList tenv) $
-      \ (name, IDType { idVType = vt, idCType = ct, idKind = k, idFVType = fvt }) ->
-        printf "%s\t\t%s %s %s %s\n" name (drop 4 $ maybe "  -" show vt) (drop 2 $ maybe "   " show ct) (show k) (show fvt)
+      \ (name, IDType { idVType = vt, idCType = ct }) ->
+        printf "%s\t\t%s %s\n" name (drop 2 $ maybe "  -" show vt) (drop 2 $ maybe "   " show ct)
 printTypes :: TypeEnv -> IO ()
 printTypes = putStrLn . showTypes
 showTypeErrors :: [TypeError] -> String

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -134,16 +134,17 @@ spec = do
     describe "Character string types" $
       it "examples of various character variables" $ do
         let mapping = inferTable teststrings1
-        idVType (mapping ! "a") `shouldBe` Just (STyCharacter (CharLenInt 5))
-        idVType (mapping ! "b") `shouldBe` Just (STyCharacter (CharLenInt 10))
-        idVType (mapping ! "c") `shouldBe` Just (STyCharacter (CharLenInt 3))
-        idVType (mapping ! "d") `shouldBe` Just (STyCharacter CharLenExp)
+        idVType (mapping ! "a") `shouldBe` Just (STyCharacter (CharLenInt 5) 1)
+        idVType (mapping ! "b") `shouldBe` Just (STyCharacter (CharLenInt 10) 1)
+        idVType (mapping ! "c") `shouldBe` Just (STyCharacter (CharLenInt 3) 1)
+        idVType (mapping ! "d") `shouldBe` Just (STyCharacter CharLenExp 1)
         idCType (mapping ! "d") `shouldBe` Just (CTArray [(Nothing, Just 10)])
-        idVType (mapping ! "e") `shouldBe` Just (STyCharacter (CharLenInt 10))
+        idVType (mapping ! "e") `shouldBe` Just (STyCharacter (CharLenInt 10) 1)
         idCType (mapping ! "e") `shouldBe` Just (CTArray [(Nothing, Just 20)])
+        idVType (mapping ! "f") `shouldBe` Just (STyCharacter (CharLenInt 1) 2)
         let pf = typedProgramFile teststrings1
         [ () | ExpValue a _ (ValVariable "e") <- uniExpr pf
-             , idType a == Just (IDType (Just (STyCharacter (CharLenInt 10)))
+             , idType a == Just (IDType (Just (STyCharacter (CharLenInt 10) 1))
                                         (Just (CTArray [(Nothing, Just 20)])))]
           `shouldNotSatisfy` null
 
@@ -301,6 +302,7 @@ teststrings1 = resetSrcSpan . flip fortran90Parser "" $ unlines [
   , "  integer, parameter :: k = 8"
   , "  character(k), dimension(10) :: d"
   , "  character :: e(20)*10"
+  , "  character(kind=2) :: f"
   , "end program teststrings"
   ]
 

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -109,12 +109,12 @@ spec = do
         idCType (mapping ! "dabs") `shouldBe` Just CTIntrinsic
         [ ty | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "abs")) _ <- uniExpr pf
              , Just (IDType (Just ty) Nothing) <- [idType a] ]
-          `shouldBe` [STyInteger 8, defSTy TypeComplex]
+          `shouldBe` [defSTy TypeDoublePrecision, defSTy TypeComplex]
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "cabs")) _ <- uniExpr pf
             , idType a == Just (IDType (Just (defSTy TypeComplex)) Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "dabs")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just (STyInteger 8)) Nothing) ]
+            , idType a == Just (IDType (Just (defSTy TypeDoublePrecision)) Nothing) ]
           `shouldNotSatisfy` null
 
     describe "Numeric types" $ do
@@ -127,22 +127,22 @@ spec = do
             , idType a == Just (IDType (Just (defSTy TypeComplex)) Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpBinary a _ Addition (ExpValue _ _ (ValInteger "2")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just (STyInteger 8)) Nothing) ]
+            , idType a == Just (IDType (Just (STyReal 8)) Nothing) ]
           `shouldNotSatisfy` null
 
     describe "Character string types" $
       it "examples of various character variables" $ do
         let mapping = inferTable teststrings1
-        idVType (mapping ! "a") `shouldBe` Just (STyCharacter (Just 5))
-        idVType (mapping ! "b") `shouldBe` Just (STyCharacter (Just 10))
-        idVType (mapping ! "c") `shouldBe` Just (STyCharacter (Just 3))
-        idVType (mapping ! "d") `shouldBe` Just (STyCharacter (Just (-2)))
+        idVType (mapping ! "a") `shouldBe` Just (STyCharacter (CharLenInt 5))
+        idVType (mapping ! "b") `shouldBe` Just (STyCharacter (CharLenInt 10))
+        idVType (mapping ! "c") `shouldBe` Just (STyCharacter (CharLenInt 3))
+        idVType (mapping ! "d") `shouldBe` Just (STyCharacter CharLenExp)
         idCType (mapping ! "d") `shouldBe` Just (CTArray [(Nothing, Just 10)])
-        idVType (mapping ! "e") `shouldBe` Just (STyCharacter (Just 10))
+        idVType (mapping ! "e") `shouldBe` Just (STyCharacter (CharLenInt 10))
         idCType (mapping ! "e") `shouldBe` Just (CTArray [(Nothing, Just 20)])
         let pf = typedProgramFile teststrings1
         [ () | ExpValue a _ (ValVariable "e") <- uniExpr pf
-             , idType a == Just (IDType (Just (STyCharacter (Just 10)))
+             , idType a == Just (IDType (Just (STyCharacter (CharLenInt 10)))
                                         (Just (CTArray [(Nothing, Just 20)])))]
           `shouldNotSatisfy` null
 

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -128,23 +128,23 @@ spec = do
             , idType a == Just (IDType (Just (defSTy TypeComplex)) Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpBinary a _ Addition (ExpValue _ _ (ValInteger "2")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just (STyReal 8)) Nothing) ]
+            , idType a == Just (IDType (Just (TReal 8)) Nothing) ]
           `shouldNotSatisfy` null
 
     describe "Character string types" $
       it "examples of various character variables" $ do
         let mapping = inferTable teststrings1
-        idVType (mapping ! "a") `shouldBe` Just (STyCharacter (CharLenInt 5) 1)
-        idVType (mapping ! "b") `shouldBe` Just (STyCharacter (CharLenInt 10) 1)
-        idVType (mapping ! "c") `shouldBe` Just (STyCharacter (CharLenInt 3) 1)
-        idVType (mapping ! "d") `shouldBe` Just (STyCharacter CharLenExp 1)
+        idVType (mapping ! "a") `shouldBe` Just (TCharacter (CharLenInt 5) 1)
+        idVType (mapping ! "b") `shouldBe` Just (TCharacter (CharLenInt 10) 1)
+        idVType (mapping ! "c") `shouldBe` Just (TCharacter (CharLenInt 3) 1)
+        idVType (mapping ! "d") `shouldBe` Just (TCharacter CharLenExp 1)
         idCType (mapping ! "d") `shouldBe` Just (CTArray [(Nothing, Just 10)])
-        idVType (mapping ! "e") `shouldBe` Just (STyCharacter (CharLenInt 10) 1)
+        idVType (mapping ! "e") `shouldBe` Just (TCharacter (CharLenInt 10) 1)
         idCType (mapping ! "e") `shouldBe` Just (CTArray [(Nothing, Just 20)])
-        idVType (mapping ! "f") `shouldBe` Just (STyCharacter (CharLenInt 1) 2)
+        idVType (mapping ! "f") `shouldBe` Just (TCharacter (CharLenInt 1) 2)
         let pf = typedProgramFile teststrings1
         [ () | ExpValue a _ (ValVariable "e") <- uniExpr pf
-             , idType a == Just (IDType (Just (STyCharacter (CharLenInt 10) 1))
+             , idType a == Just (IDType (Just (TCharacter (CharLenInt 10) 1))
                                         (Just (CTArray [(Nothing, Just 20)])))]
           `shouldNotSatisfy` null
 

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -32,69 +32,68 @@ spec = do
   describe "Global type inference" $ do
     it "types integer returning function" $ do
       let entry = inferTable ex1 ! "f1"
-      entry `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing
+      entry `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing Nothing
 
     it "types multiples program units" $ do
       let mapping = inferTable ex2
-      mapping ! "f1" `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing
-      mapping ! "s1" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing
+      mapping ! "f1" `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing Nothing
+      mapping ! "s1" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing Nothing
 
     it "types ENTRY points within subprograms" $ do
       let mapping = inferTable ex3
-      mapping ! "e1" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing
-      mapping ! "e2" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing
-      mapping ! "e3" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing
+      mapping ! "e1" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing Nothing
+      mapping ! "e2" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing Nothing
+      mapping ! "e3" `shouldBe` IDType Nothing (Just CTSubroutine) Nothing Nothing
 
   describe "Local type inference" $ do
     it "infers from type declarations" $ do
       let mapping = inferTable ex4
       let pf = typedProgramFile ex4
-      mapping ! "x" `shouldBe` IDType (Just TypeInteger) (Just CTVariable) Nothing
-      mapping ! "y" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 10)]) Nothing
-      mapping ! "c" `shouldBe` IDType (Just $ TypeCharacter Nothing Nothing) (Just CTVariable) Nothing
-      mapping ! "log" `shouldBe` IDType (Just TypeLogical) (Just CTVariable) Nothing
+      mapping ! "y" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 10)]) Nothing Nothing
+      mapping ! "c" `shouldBe` IDType (Just $ TypeCharacter Nothing Nothing) (Just CTVariable) Nothing Nothing
+      mapping ! "log" `shouldBe` IDType (Just TypeLogical) (Just CTVariable) Nothing Nothing
       [ () | ExpValue a _ (ValVariable "x") <- uniExpr pf
-           , idType a == Just (IDType (Just TypeInteger) (Just CTVariable) Nothing) ]
+           , idType a == Just (IDType (Just TypeInteger) (Just CTVariable) Nothing Nothing) ]
         `shouldNotSatisfy` null
       [ () | ExpValue a _ (ValVariable "y") <- uniExpr pf
-           , idType a == Just (IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 10)]) Nothing) ]
+           , idType a == Just (IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 10)]) Nothing Nothing) ]
         `shouldNotSatisfy` null
 
     it "infers from dimension declarations" $ do
       let mapping = inferTable ex5
-      mapping ! "x" `shouldBe` IDType Nothing (Just $ CTArray [(Nothing, Just 1)]) Nothing
-      mapping ! "y" `shouldBe` IDType Nothing (Just $ CTArray [(Nothing, Just 1)]) Nothing
+      mapping ! "x" `shouldBe` IDType Nothing (Just $ CTArray [(Nothing, Just 1)]) Nothing Nothing
+      mapping ! "y" `shouldBe` IDType Nothing (Just $ CTArray [(Nothing, Just 1)]) Nothing Nothing
 
     it "infers from function statements" $ do
       let mapping = inferTable ex6
-      mapping ! "a" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 1)]) Nothing
-      mapping ! "b" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 1)]) Nothing
-      mapping ! "c" `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing
-      mapping ! "d" `shouldBe` IDType Nothing (Just CTFunction) Nothing
+      mapping ! "a" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 1)]) Nothing Nothing
+      mapping ! "b" `shouldBe` IDType (Just TypeInteger) (Just $ CTArray [(Nothing, Just 1)]) Nothing Nothing
+      mapping ! "c" `shouldBe` IDType (Just TypeInteger) (Just CTFunction) Nothing Nothing
+      mapping ! "d" `shouldBe` IDType Nothing (Just CTFunction) Nothing Nothing
 
     describe "Intrinsics type analysis" $ do
       it "disambiguates intrinsics from functions and variables" $ do
         let mapping = inferTable intrinsics1
         let pf = typedProgramFile intrinsics1
         [ () | ExpValue a _ (ValVariable "x") <- uniExpr pf
-             , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing) ]
+             , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing Nothing) ]
           `shouldSatisfy` ((== 5) . length)
 
         -- the following are true because dabs and cabs are defined as function and array in this program.
         idCType (mapping ! "dabs") `shouldBe` Just CTFunction
         [ a | ExpValue a _ (ValIntrinsic "dabs") <- uniExpr pf
-             ] -- , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing) ]
+             ] -- , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing Nothing) ]
           `shouldSatisfy` null
 
         idCType (mapping ! "cabs") `shouldBe` Just (CTArray [(Nothing, Just 3)])
         [ a | ExpValue a _ (ValIntrinsic "cabs") <- uniExpr pf
-             ] -- , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing) ]
+             ] -- , idType a == Just (IDType (Just TypeReal) (Just CTVariable) Nothing Nothing) ]
           `shouldSatisfy` null
 
         -- abs is an actual intrinsic
         idCType (mapping ! "abs") `shouldBe` Just CTIntrinsic
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "abs")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeInteger) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeInteger) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
 
       it "intrinsics and numeric types" $ do
@@ -104,26 +103,26 @@ spec = do
         idCType (mapping ! "cabs") `shouldBe` Just CTIntrinsic
         idCType (mapping ! "dabs") `shouldBe` Just CTIntrinsic
         [ ty | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "abs")) _ <- uniExpr pf
-             , Just (IDType (Just ty) Nothing Nothing) <- [idType a] ]
+             , Just (IDType (Just ty) Nothing Nothing Nothing) <- [idType a] ]
           `shouldBe` [TypeDoublePrecision, TypeComplex]
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "cabs")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeComplex) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeComplex) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "dabs")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeDoublePrecision) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeDoublePrecision) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
 
     describe "Numeric types" $ do
       it "Widening / upgrading" $ do
         let pf = typedProgramFile numerics1
         [ a | ExpFunctionCall a _ (ExpValue _ _ (ValIntrinsic "abs")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeReal) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeReal) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpBinary a _ Addition (ExpValue _ _ (ValInteger "1")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeComplex) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeComplex) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
         [ a | ExpBinary a _ Addition (ExpValue _ _ (ValInteger "2")) _ <- uniExpr pf
-            , idType a == Just (IDType (Just TypeDoublePrecision) Nothing Nothing) ]
+            , idType a == Just (IDType (Just TypeDoublePrecision) Nothing Nothing Nothing) ]
           `shouldNotSatisfy` null
 
     describe "Character string types" $
@@ -140,6 +139,7 @@ spec = do
         [ () | ExpValue a _ (ValVariable "e") <- uniExpr pf
              , idType a == Just (IDType (Just (TypeCharacter (Just (CharLenInt 10)) Nothing))
                                         (Just (CTArray [(Nothing, Just 20)]))
+                                        Nothing
                                         Nothing) ]
           `shouldNotSatisfy` null
 

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -8,9 +8,10 @@ import Data.Map ((!))
 import Data.Data
 import Data.Generics.Uniplate.Data
 import Language.Fortran.AST
-import Language.Fortran.Analysis.Types
-import Language.Fortran.Analysis.Renaming
 import Language.Fortran.Analysis
+import Language.Fortran.Analysis.Types
+import Language.Fortran.Analysis.SemanticTypes
+import Language.Fortran.Analysis.Renaming
 import qualified Language.Fortran.Parser.Fortran90 as F90
 import Language.Fortran.ParserMonad
 import qualified Data.ByteString.Char8 as B
@@ -55,7 +56,7 @@ spec = do
       let mapping = inferTable ex4
       let pf = typedProgramFile ex4
       mapping ! "y" `shouldBe` IDType (Just (defSTy TypeInteger)) (Just $ CTArray [(Nothing, Just 10)])
-      mapping ! "c" `shouldBe` IDType (Just (defSTy (TypeCharacter Nothing Nothing))) (Just CTVariable)
+      mapping ! "c" `shouldBe` IDType (Just (defSTy TypeCharacter)) (Just CTVariable)
       mapping ! "log" `shouldBe` IDType (Just (defSTy TypeLogical)) (Just CTVariable)
       [ () | ExpValue a _ (ValVariable "x") <- uniExpr pf
            , idType a == Just (IDType (Just (defSTy TypeInteger)) (Just CTVariable)) ]
@@ -177,7 +178,7 @@ ex4pu1bs =
         [ DeclVariable () u (varGen "x") Nothing Nothing
         , DeclArray () u (varGen "y")
             (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ]) Nothing Nothing ]))
-  , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing
+  , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing
       (AList () u [ DeclVariable () u (varGen "c") Nothing Nothing ]))
   , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeLogical Nothing) Nothing
       (AList () u [ DeclVariable () u (varGen "log") Nothing Nothing ])) ]

--- a/test/Language/Fortran/Parser/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran2003Spec.hs
@@ -122,14 +122,14 @@ spec =
 
       it "parses allocate with type_spec" $ do
         let sel = Selector () u (Just (ExpValue () u ValColon)) (Just (varGen "foo"))
-        let ty = TypeSpec () u (TypeCharacter (Just $ CharLenColon) (Just "foo")) (Just sel)
+        let ty = TypeSpec () u TypeCharacter (Just sel)
         let decls = [DeclVariable () u (varGen "s") Nothing Nothing]
         let st = StDeclaration () u ty (Just (AList () u [AttrAllocatable () u])) (AList () u decls)
         sParser "character(len=:,kind=foo), allocatable :: s" `shouldBe'` st
 
       it "parses allocate with type_spec" $ do
         let sel = Selector () u (Just (intGen 3)) (Just (varGen "foo"))
-        let ty = TypeSpec () u (TypeCharacter (Just $ CharLenInt 3) (Just "foo")) (Just sel)
+        let ty = TypeSpec () u TypeCharacter (Just sel)
         let st = StAllocate () u (Just ty) (AList () u [varGen "s"]) Nothing
         sParser "allocate(character(len=3,kind=foo) :: s)" `shouldBe'` st
 

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -161,7 +161,7 @@ spec =
       it "parses 'implicit character*30 (a, b, c), integer (a-z, l)" $ do
         let impEls = [ImpCharacter () u "a", ImpCharacter () u "b", ImpCharacter () u "c"]
             sel = Selector () u (Just (intGen 30)) Nothing
-            imp1 = ImpList () u (TypeSpec () u (TypeCharacter (Just $ CharLenInt 30) Nothing) (Just sel)) $ AList () u impEls
+            imp1 = ImpList () u (TypeSpec () u TypeCharacter (Just sel)) $ AList () u impEls
             imp2 = ImpList () u (TypeSpec () u TypeInteger Nothing) $ AList () u [ImpRange () u "a" "z", ImpCharacter () u "l"]
             st = StImplicit () u $ Just $ AList () u [imp1, imp2]
         sParser "      implicit character*30 (a, b, c), integer (a-z, l)" `shouldBe'` st
@@ -202,7 +202,7 @@ spec =
 
     it "parses 'character a*8'" $ do
       let decl = DeclVariable () u (varGen "a") (Just $ intGen 8) Nothing
-          typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          typeSpec = TypeSpec () u TypeCharacter Nothing
           st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
       sParser "      character a*8" `shouldBe'` st
 
@@ -210,7 +210,7 @@ spec =
       let args = AList () u [ IxSingle () u Nothing (ExpValue () u (ValString "A")) ]
           lenExpr = ExpSubscript () u (ExpValue () u (ValVariable "ichar")) args
           decl = DeclVariable () u (varGen "c") (Just $ lenExpr) Nothing
-          typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          typeSpec = TypeSpec () u TypeCharacter Nothing
           st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
       sParser "      character c*(ichar('A'))" `shouldBe'` st
 
@@ -308,7 +308,7 @@ spec =
 
       it "parses character declarations with unspecfied lengths" $ do
         let src = "      character s*(*)"
-            st = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclVariable () u
                                (ExpValue () u (ValVariable "s"))
                                (Just (ExpValue () u ValStar))
@@ -328,7 +328,7 @@ spec =
 
         let src1 = "      character xs(2)*5 / 'hello', 'world' /"
             inits1 = [ExpValue () u (ValString "hello"), ExpValue () u (ValString "world")]
-            st1 = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st1 = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclArray () u
                                (ExpValue () u (ValVariable "xs"))
                                (AList () u [DimensionDeclarator () u Nothing (Just (ExpValue () u (ValInteger "2")))])
@@ -338,7 +338,7 @@ spec =
 
         let src2 = "      character xs*5(2) / 'hello', 'world' /"
             inits2 = [ExpValue () u (ValString "hello"), ExpValue () u (ValString "world")]
-            st2 = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st2 = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclArray () u
                                (ExpValue () u (ValVariable "xs"))
                                (AList () u [DimensionDeclarator () u Nothing (Just (ExpValue () u (ValInteger "2")))])

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -285,7 +285,7 @@ spec =
           sParser "implicit none" `shouldBe'` st
 
         it "parses implicit with single" $ do
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec = TypeSpec () u TypeCharacter Nothing
           let impEls = [ ImpCharacter () u "k" ]
           let impLists = [ ImpList () u typeSpec (fromList () impEls) ]
           let st = StImplicit () u (Just $ fromList () impLists)
@@ -299,7 +299,7 @@ spec =
           sParser "implicit logical (x-z)" `shouldBe'` st
 
         it "parses implicit statement" $ do
-          let typeSpec1 = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec1 = TypeSpec () u TypeCharacter Nothing
           let typeSpec2 = TypeSpec () u TypeInteger Nothing
           let impEls1 = [ ImpCharacter () u "s", ImpCharacter () u "a" ]
           let impEls2 = [ ImpRange () u "x" "z" ]

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -337,7 +337,7 @@ spec =
           sParser "implicit none" `shouldBe'` st
 
         it "parses implicit with single" $ do
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec = TypeSpec () u TypeCharacter Nothing
               impEls = [ ImpCharacter () u "k" ]
               impLists = [ ImpList () u typeSpec (fromList () impEls) ]
               st = StImplicit () u (Just $ fromList () impLists)
@@ -351,7 +351,7 @@ spec =
           sParser "implicit logical (x-z)" `shouldBe'` st
 
         it "parses implicit statement" $ do
-          let typeSpec1 = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec1 = TypeSpec () u TypeCharacter Nothing
               typeSpec2 = TypeSpec () u TypeInteger Nothing
               impEls1 = [ ImpCharacter () u "s", ImpCharacter () u "a" ]
               impEls2 = [ ImpRange () u "x" "z" ]

--- a/test/Language/Fortran/Parser/UtilsSpec.hs
+++ b/test/Language/Fortran/Parser/UtilsSpec.hs
@@ -30,11 +30,13 @@ spec =
 
     describe "parseRealLiteral" $ do
       it "parses various well-formed valid real literals" $ do
-        prl "1"         `shouldBe` rl "1" n n
-        prl "1e0"       `shouldBe` rl "1" (jExp expE n 0) n
-        prl "1e0_4"     `shouldBe` rl "1" (jExp expE n 0) (j 4)
+        prl "1"         `shouldBe` rl "1"    n n
+        prl "1."        `shouldBe` rl "1."   n n
+        prl ".0"        `shouldBe` rl ".0"   n n
+        prl "1e0"       `shouldBe` rl "1"    (jExp expE n 0) n
+        prl "1e0_4"     `shouldBe` rl "1"    (jExp expE n 0) (j 4)
         --prl "1e0_k"     `shouldBe` rl "1" _ _
-        prl "1.0e0_4"   `shouldBe` rl "1.0" (jExp expE n 0) (j 4)
+        prl "1.0e0_4"   `shouldBe` rl "1.0"  (jExp expE n 0) (j 4)
         prl "+1.0e0_4"  `shouldBe` rl "+1.0" (jExp expE n 0) (j 4)
         prl "-1.0e0_4"  `shouldBe` rl "-1.0" (jExp expE n 0) (j 4)
         prl "-1.0e+0_4" `shouldBe` rl "-1.0" (jExp expE (j SignPos) 0) (j 4)

--- a/test/Language/Fortran/Parser/UtilsSpec.hs
+++ b/test/Language/Fortran/Parser/UtilsSpec.hs
@@ -7,7 +7,8 @@ import Language.Fortran.Parser.Utils
 spec :: Spec
 spec =
   describe "Fortran Parser Utils" $ do
-    describe "readReal" $
+
+    describe "readReal" $ do
       it "tests" $ do
         readReal "+12"       `shouldBe` Just 12
         readReal "-1.2"      `shouldBe` Just (-1.2)
@@ -17,7 +18,8 @@ spec =
         readReal ".12"       `shouldBe` Just 0.12
         readReal "-.12"      `shouldBe` Just (-0.12)
         readReal "1_f"       `shouldBe` Just 1
-    describe "readInteger" $
+
+    describe "readInteger" $ do
       it "tests" $ do
         readInteger "b'101'" `shouldBe` Just 5
         readInteger "o'22'"  `shouldBe` Just 18
@@ -25,3 +27,52 @@ spec =
         readInteger "1_f"    `shouldBe` Just 1
         readInteger "+123"   `shouldBe` Just 123
         readInteger "-123"   `shouldBe` Just (-123)
+
+    describe "parseRealLiteral" $ do
+      it "parses various well-formed valid real literals" $ do
+        prl "1"         `shouldBe` rl "1" n n
+        prl "1e0"       `shouldBe` rl "1" (jExp expE n 0) n
+        prl "1e0_4"     `shouldBe` rl "1" (jExp expE n 0) (j 4)
+        --prl "1e0_k"     `shouldBe` rl "1" _ _
+        prl "1.0e0_4"   `shouldBe` rl "1.0" (jExp expE n 0) (j 4)
+        prl "+1.0e0_4"  `shouldBe` rl "+1.0" (jExp expE n 0) (j 4)
+        prl "-1.0e0_4"  `shouldBe` rl "-1.0" (jExp expE n 0) (j 4)
+        prl "-1.0e+0_4" `shouldBe` rl "-1.0" (jExp expE (j SignPos) 0) (j 4)
+        prl "-1.0e-0_4" `shouldBe` rl "-1.0" (jExp expE (j SignNeg) 0) (j 4)
+        prl "-1.0d-0_4" `shouldBe` rl "-1.0" (jExp expD (j SignNeg) 0) (j 4)
+
+      -- Literals we gladly parse, but that most Fortran specs consider invalid.
+      -- These will prompt an error during type analysis.
+      it "parses various well-formed invalid real literals" $ do
+        -- only exponent letter e allows kind param
+        -- even if you use kind 8 (== what d sets), it should be considered
+        -- invalid
+        prl "1d0_8"   `shouldBe` rl "1" (jExp expD n 0) (j 8)
+        prl "1d0_4"   `shouldBe` rl "1" (jExp expD n 0) (j 4)
+
+      -- parseRealLiteral runtime errors on poorly-formed real literals because
+      -- the parser should ensure we only ever receive well-formed ones.
+      -- TODO: unable to test these while the parser uses 'error'
+      it "fails to parse poorly-formed real literals" $ do
+        pending
+        {-
+        -- exponent number can't be empty
+        fails $ prl "1e"
+
+        -- exponent number must be an integer
+        fails $ prl "1ex"
+        fails $ prl "1ex1"
+        --fails $ prl "1e0.0"       -- not detected, we take the digits before
+                                    -- the decimal point
+        -}
+
+
+      where
+        prl = parseRealLiteral
+        rl = RealLit
+        n = Nothing
+        j = Just
+        jExp a b c = Just (Exponent a b c)
+        expE = ExpLetterE
+        expD = ExpLetterD
+        fails test = return test `shouldThrow` anyException

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -106,7 +106,7 @@ spec =
       describe "Declaration" $ do
         it "prints 90 style with attributes" $ do
           let sel = Selector () u (Just $ intGen 3) Nothing
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) (Just sel)
+          let typeSpec = TypeSpec () u TypeCharacter (Just sel)
           let attrs = [ AttrIntent () u In , AttrPointer () u ]
           let declList =
                 [ DeclVariable () u (varGen "x") Nothing (Just $ intGen 42)
@@ -254,7 +254,7 @@ spec =
           it "prints allocate statement with type spec" $ do
             let stat = AOStat () u (varGen "s")
             let sel = Selector () u (Just (intGen 30)) Nothing
-            let ty = TypeSpec () u (TypeCharacter (Just $ CharLenInt 30) Nothing) (Just sel)
+            let ty = TypeSpec () u TypeCharacter (Just sel)
             let st = StAllocate () u (Just ty) (AList () u [ varGen "x" ]) (Just (AList () u [stat]))
             pprint Fortran2003 st Nothing `shouldBe` "allocate (character(len=30) :: x, stat=s)"
 

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -3,7 +3,6 @@ module Language.Fortran.Transformation.Disambiguation.FunctionSpec (spec) where
 import Test.Hspec
 import TestUtil
 
-import Language.Fortran.Analysis
 import Language.Fortran.AST
 import Language.Fortran.Transformer
 

--- a/wip/decl-char.f90
+++ b/wip/decl-char.f90
@@ -1,0 +1,34 @@
+program main
+    integer, parameter :: k4 = 4
+
+    ! equivalent: STyCharacter (CharLenInt 3)
+    character(3)              :: s11 = "sup"
+    character(len=3)          :: s12 = "sup"
+    character(len=3 , kind=1) :: s13 = "sup"
+    character(kind=1, len=3 ) :: s14 = "sup"
+
+    ! equivalent: STyCharacter (CharLenInt 1)
+    character                 :: s21 = "c"
+    character(1)              :: s22 = "c"
+    character(len=1)          :: s23 = "c"
+    character(kind=1)         :: s24 = "c"
+    character(len=1 , kind=1) :: s25 = "c"
+    character(kind=1, len=1 ) :: s26 = "c"
+
+    ! equivalent: STyCharacter (CharLenInt 3)
+    character    :: s31*3 = "sup"
+    character(3) :: s32   = "sup"
+    character(3) :: s33*3 = "sup"   ! FS soft type error (...using decl length)
+    character(2) :: s34*3 = "sup"   ! FS soft type error (...using decl length)
+    character(9) :: s35*3 = "sup"   ! FS soft type error (...using decl length)
+
+    ! type error: non-CHARACTER given length
+    integer      :: i11*4 = 1234
+
+    ! special RHS len expr
+    character    :: s41*(*)   = "buh?"
+
+    ! unimplemented: unsupported RHS len expr
+    character    :: s43*k4    = "uhhh"
+    character    :: s44*(2*2) = "huh."
+end program main


### PR DESCRIPTION
Replaces `BaseType` in `IDType` with a type representation adapted from fortran-vars. Type analysis now derives `SemType` values for expressions, which include kind information and turn `DOUBLE PRECISION`s into `REAL(8)`s etc.

## Overview of changes
  * use `SemType` instead of `BaseType` in `IDType` (type analysis)
    * Constructors match original fortran-vars naming.
  * move `CharacterLen` from parsing to type analysis
    * `BaseType` values are now simple tags.
    * deleted some CharacterLen code due to no longer being in AST
  * F90 real literal parser (parse kind info)
  * export some infer monad utils (potentially useful for running just parts of type analysis)
  * some parsing fixes (type kind selectors)
  * tweaks