### PR TITLE
Support percent data references in legacy parser

### DIFF
--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -55,7 +55,7 @@ $special = [\ \=\+\-\*\/\(\)\,\.\$]
 @id = $letter $alphanumeric{0,5}
 @label = $digit{1,5}
 
-@idLegacy = [$letter \_ \%] [$alphanumericExtended \$]*
+@idLegacy = [$letter \_] [$alphanumericExtended \$]*
 
 @datatype = "integer" | "real" | "doubleprecision" | "complex" | "logical"
           -- legacy extensions
@@ -97,6 +97,7 @@ tokens :-
   <st,iif> "/)" / { formatExtendedP }         { addSpan TRightArrayPar }
   <st,iif,doo,keyword> ","                    { addSpan TComma }
   <st,iif,keyword> "."                        { addSpan TDot }
+  <st,iif,keyword> "%"                        { addSpan TPercent }
   <keyword> "." / { legacy77P }               { addSpan TDot }
   <st,iif> ":" / { fortran77P }               { addSpan TColon }
 
@@ -730,6 +731,7 @@ data Token = TLeftPar             SrcSpan
            | TRightArrayPar       SrcSpan
            | TComma               SrcSpan
            | TDot                 SrcSpan
+           | TPercent             SrcSpan
            | TColon               SrcSpan
            | TInclude             SrcSpan
            | TProgram             SrcSpan

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -34,7 +34,7 @@ iParser sourceCode =
   fromParseResultUnsafe $ includeParser Fortran77Legacy (B.pack sourceCode) "<unknown>"
 
 pParser :: String -> ProgramFile ()
-pParser source = fromParseResultUnsafe $ fortran77Parser (B.pack source) "<unknown>"
+pParser source = fromParseResultUnsafe $ legacy77Parser (B.pack source) "<unknown>"
 
 spec :: Spec
 spec =
@@ -286,6 +286,18 @@ spec =
             st = StStructure () u (Just "foo") $ AList () u [innerst]
         resetSrcSpan (slParser src) `shouldBe` st
 
+      it "parse special intrinsics to arguments" $ do
+        let blStmt stmt = BlStatement () u Nothing stmt
+            var = ExpValue () u . ValVariable
+            ext = blStmt $ StExternal () u $ AList () u [var "bar"]
+            arg = Just . AList () u . pure . Argument () u Nothing
+            valBar = ExpFunctionCall () u (ExpValue () u (ValIntrinsic "%val"))
+                     $ arg $ var "baz"
+            call = blStmt $ StCall () u (var "bar") $ arg valBar
+            pu = ProgramFile mi77 [ PUSubroutine () u (Nothing, Nothing) "foo"
+                                   (Just $ AList () u [var "baz"]) [ ext, call ] Nothing ]
+        resetSrcSpan (pParser exampleProgram3) `shouldBe` pu
+
       it "parses character declarations with unspecfied lengths" $ do
         let src = "      character s*(*)"
             st = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
@@ -368,6 +380,13 @@ exampleProgram2 = unlines
   [ "      block data hello"
   , "      integer x"
   , "      end" ]
+
+exampleProgram3 :: String
+exampleProgram3 = unlines
+  [ "      subroutine foo(baz)"
+  , "      external bar"
+  , "      call bar(%val(baz))"
+  , "      end subroutine foo"]
 
 -- Local variables:
 -- mode: haskell

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -286,6 +286,14 @@ spec =
             st = StStructure () u (Just "foo") $ AList () u [innerst]
         resetSrcSpan (slParser src) `shouldBe` st
 
+      it "parses structure data references " $ do
+        let src = init $ unlines [ "      print *, foo % bar"
+                                 , "      print *, foo.bar" ]
+            expStar = ExpValue () u ValStar
+            foobar = ExpDataRef () u (ExpValue () u (ValVariable "foo")) (ExpValue () u (ValVariable "bar"))
+            blStmt = BlStatement () u Nothing $ StPrint () u expStar $ Just $ AList () u [foobar]
+        resetSrcSpan (iParser src) `shouldBe` [ blStmt, blStmt ]
+
       it "parse special intrinsics to arguments" $ do
         let blStmt stmt = BlStatement () u Nothing stmt
             var = ExpValue () u . ValVariable


### PR DESCRIPTION
Previously we were happily printing out the new standard style of data references but the legacy parser doesn't actually deal with them correctly.

This changes adds some tests for the argument passing intrinsics as it wasn't previously covered, and updates the parser to deal with the new style references, changing the legacy identifier to not catch percentage starting symbols and explicitly catch argument passing intrinsics in `CALLABLE_EXPRESSION` which is the only place they can appear.