### PR TITLE
Remove Maybe length, kind fields in TypeCharacter

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -89,7 +89,7 @@ data BaseType =
   | TypeComplex
   | TypeDoubleComplex
   | TypeLogical
-  | TypeCharacter (Maybe CharacterLen) (Maybe String) -- ^ len and kind, if specified
+  | TypeCharacter
   | TypeCustom String
   | ClassStar
   | ClassCustom String
@@ -97,29 +97,6 @@ data BaseType =
   deriving (Ord, Eq, Show, Data, Typeable, Generic)
 
 instance Binary BaseType
-
-data CharacterLen = CharLenStar    -- ^ specified with a *
-                  | CharLenColon   -- ^ specified with a : (Fortran2003)
-                    -- FIXME, possibly, with a more robust const-exp:
-                  | CharLenExp     -- ^ specified with a non-trivial expression
-                  | CharLenInt Int -- ^ specified with a constant integer
-  deriving (Ord, Eq, Show, Data, Typeable, Generic)
-
-instance Binary CharacterLen
-
-charLenSelector :: Maybe (Selector a) -> (Maybe CharacterLen, Maybe String)
-charLenSelector Nothing                          = (Nothing, Nothing)
-charLenSelector (Just (Selector _ _ mlen mkind)) = (l, k)
-  where
-    l | Just (ExpValue _ _ ValStar) <- mlen        = Just CharLenStar
-      | Just (ExpValue _ _ ValColon) <- mlen       = Just CharLenColon
-      | Just (ExpValue _ _ (ValInteger i)) <- mlen = Just $ CharLenInt (read i)
-      | Nothing <- mlen                            = Nothing
-      | otherwise                                  = Just CharLenExp
-    k | Just (ExpValue _ _ (ValInteger i)) <- mkind  = Just i
-      | Just (ExpValue _ _ (ValVariable s)) <- mkind = Just s
-      -- FIXME: some references refer to things like kind=kanji but I can't find any spec for it
-      | otherwise                                    = Nothing
 
 -- | The type specification of a declaration statement, containing the syntactic
 --   type name and kind selector.
@@ -976,7 +953,6 @@ instance Out a => Out (FlushSpec a)
 instance Out a => Out (Value a)
 instance Out a => Out (TypeSpec a)
 instance Out a => Out (Selector a)
-instance Out CharacterLen
 instance Out BaseType
 instance Out a => Out (Declarator a)
 instance Out a => Out (DimensionDeclarator a)
@@ -1074,7 +1050,6 @@ instance NFData a => NFData (StructureItem a)
 instance NFData a => NFData (UnionMap a)
 instance NFData MetaInfo
 instance NFData FortranVersion
-instance NFData CharacterLen
 instance NFData BaseType
 instance NFData UnaryOp
 instance NFData BinaryOp

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -7,7 +7,7 @@ module Language.Fortran.Analysis
   ( initAnalysis, stripAnalysis, Analysis(..), Constant(..)
   , varName, srcName, lvVarName, lvSrcName, isNamedExpression
   , genVar, puName, puSrcName, blockRhsExprs, rhsExprs
-  , ModEnv, NameType(..), IDType(..), ConstructType(..), SemType(..)
+  , ModEnv, NameType(..), IDType(..), ConstructType(..)
   , lhsExprs, isLExpr, allVars, analyseAllLhsVars, analyseAllLhsVars1, allLhsVars
   , blockVarUses, blockVarDefs
   , BB, BBNode, BBGr(..), bbgrMap, bbgrMapM, bbgrEmpty

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -884,21 +884,11 @@ showBaseType TypeDoublePrecision = "double"
 showBaseType TypeComplex         = "complex"
 showBaseType TypeDoubleComplex   = "doublecomplex"
 showBaseType TypeLogical         = "logical"
-showBaseType (TypeCharacter l k) = case (l, k) of
-  (Just cl, Just ki) -> "character(" ++ showCharLen cl ++ "," ++ ki ++ ")"
-  (Just cl, Nothing) -> "character(" ++ showCharLen cl ++ ")"
-  (Nothing, Just ki) -> "character(kind=" ++ ki ++ ")"
-  (Nothing, Nothing) -> "character"
+showBaseType TypeCharacter       = "character"
 showBaseType (TypeCustom s)      = "type(" ++ s ++ ")"
 showBaseType TypeByte            = "byte"
 showBaseType ClassStar           = "class(*)"
 showBaseType (ClassCustom s)     = "class(" ++ s ++ ")"
-
-showCharLen :: CharacterLen -> String
-showCharLen CharLenStar = "*"
-showCharLen CharLenColon = ":"
-showCharLen CharLenExp  = "*" -- FIXME, possibly, with a more robust const-exp
-showCharLen (CharLenInt i) = show i
 
 showDecl :: Declarator a -> String
 showDecl (DeclArray _ _ e adims length' initial) =

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -545,9 +545,6 @@ isIxSingle _           = False
 -- If a length was defined on both sides, the declaration length (RHS) is used.
 -- This matches gfortran's behaviour, though even with -Wall they don't warn on
 -- this rather confusing syntax usage. We report a (soft) type error.
---
--- Complicating the matter is that 'TypeCharacter's store a partly-parsed
--- version of the 'Selector'.
 deriveSemTypeFromDeclaration
     :: SrcSpan -> SrcSpan -> TypeSpec a -> Maybe (Expression a) -> Infer SemType
 deriveSemTypeFromDeclaration stmtSs declSs ts@(TypeSpec _ _ bt mSel) mLenExpr =
@@ -637,6 +634,8 @@ deriveSemTypeFromTypeSpec (TypeSpec _ _ bt mSel) =
 
 -- | Attempt to derive a SemType from a 'BaseType' and a 'Selector' (e.g.
 --   extracted from a 'TypeSpec').
+--
+-- TODO needs cleaning up once we put kind in STyCharacter too
 deriveSemTypeFromBaseTypeAndSelector :: BaseType -> Selector a -> Infer SemType
 deriveSemTypeFromBaseTypeAndSelector bt (Selector _ ss mLen mKindExpr) =
     case mLen of
@@ -654,7 +653,7 @@ deriveSemTypeFromBaseTypeAndSelector bt (Selector _ ss mLen mKindExpr) =
       Just len ->
         -- length only makes sense with a CHARACTER (AST does not enforce)
         case bt of
-          TypeCharacter -> defaultSemType -- TODO ????
+          TypeCharacter -> return $ STyCharacter (charLenSelector' len)
           _ -> do
             -- (unreachable code path in correct parser operation)
             typeError "only CHARACTER types can specify length (separate to kind)" ss

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1012,9 +1012,9 @@ MAYBE_TYPE_SPEC :: { Maybe (TypeSpec A0) }
 TYPE_SPEC :: { TypeSpec A0 }
 : integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
 | real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
 | complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
 | logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
 | type '(' id ')'
   { let TId _ id = $3

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -1019,17 +1019,15 @@ LABEL_IN_STATEMENT :: { Expression A0 } : int { ExpValue () (getSpan $1) (let (T
 
 TYPE_SPEC :: { TypeSpec A0 }
 TYPE_SPEC
-: integer KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2  }
-| doublePrecision KIND_SELECTOR
-  { TypeSpec () (getSpan ($1, $2)) TypeDoublePrecision $2 }
-| logical KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| complex KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| doubleComplex KIND_SELECTOR
-  { TypeSpec () (getSpan ($1, $2)) TypeDoubleComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| byte KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeByte $2 }
-| record '/' NAME '/' { TypeSpec () (getSpan ($1, $4)) (TypeCustom $3) Nothing }
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2  }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing}
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| doubleComplex           { TypeSpec () (getSpan $1)       TypeDoubleComplex Nothing}
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| byte      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeByte $2 }
+| record    '/' NAME '/'  { TypeSpec () (getSpan ($1, $4)) (TypeCustom $3) Nothing }
 
 KIND_SELECTOR :: { Maybe (Selector A0) }
 KIND_SELECTOR

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -868,13 +868,13 @@ DIMENSION_DECLARATOR :: { DimensionDeclarator A0 }
     in DimensionDeclarator () span Nothing Nothing }
 
 TYPE_SPEC :: { TypeSpec A0 }
-: integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
-| complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| type '(' id ')'
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| type      '(' id ')'
   { let TId _ id = $3
     in TypeSpec () (getTransSpan $1 $4) (TypeCustom id) Nothing }
 

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -881,13 +881,13 @@ DIMENSION_DECLARATOR :: { DimensionDeclarator A0 }
     in DimensionDeclarator () span Nothing Nothing }
 
 TYPE_SPEC :: { TypeSpec A0 }
-: integer KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
-| real    KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
-| doublePrecision { TypeSpec () (getSpan $1) TypeDoublePrecision Nothing }
-| complex KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
-| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) (uncurry TypeCharacter $ charLenSelector $2) $2 }
-| logical KIND_SELECTOR   { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
-| type '(' id ')'
+: integer   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeInteger $2 }
+| real      KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeReal $2 }
+| doublePrecision         { TypeSpec () (getSpan $1)       TypeDoublePrecision Nothing }
+| complex   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeComplex $2 }
+| character CHAR_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeCharacter $2 }
+| logical   KIND_SELECTOR { TypeSpec () (getSpan ($1, $2)) TypeLogical $2 }
+| type      '(' id ')'
   { let TId _ id = $3
     in TypeSpec () (getTransSpan $1 $4) (TypeCustom id) Nothing }
 

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -12,7 +12,7 @@ import Data.List (foldl')
 import Prelude hiding (EQ,LT,GT,pred,exp,(<>))
 
 import Language.Fortran.AST
-import Language.Fortran.ParserMonad
+import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 
 import Text.PrettyPrint
@@ -353,7 +353,7 @@ instance Pretty BaseType where
       | v == Fortran77Extended = "double complex"
       | otherwise = tooOld v "Double complex" Fortran77Extended
     pprint' _ TypeLogical = "logical"
-    pprint' v (TypeCharacter _ _)
+    pprint' v TypeCharacter
       | v >= Fortran77 = "character"
       | otherwise = tooOld v "Character data type" Fortran77
     pprint' v (TypeCustom str)
@@ -369,12 +369,6 @@ instance Pretty BaseType where
     pprint' v (ClassCustom str)
       | v >= Fortran2003 = "class" <> parens (text str)
       | otherwise = tooOld v "Class(spec)" Fortran2003
-
-instance Pretty CharacterLen where
-  pprint' _ CharLenStar = "*"
-  pprint' _ CharLenColon = ":"
-  pprint' _ CharLenExp  = "*" -- FIXME, possibly, with a more robust const-exp
-  pprint' _ (CharLenInt i) = text (show i)
 
 instance Pretty (TypeSpec a) where
     pprint' v (TypeSpec _ _ baseType mSelector) =

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -8,9 +8,10 @@ import Data.Map ((!))
 import Data.Data
 import Data.Generics.Uniplate.Data
 import Language.Fortran.AST
-import Language.Fortran.Analysis.Types
-import Language.Fortran.Analysis.Renaming
 import Language.Fortran.Analysis
+import Language.Fortran.Analysis.Types
+import Language.Fortran.Analysis.SemanticTypes
+import Language.Fortran.Analysis.Renaming
 import qualified Language.Fortran.Parser.Fortran90 as F90
 import Language.Fortran.ParserMonad
 import qualified Data.ByteString.Char8 as B
@@ -55,7 +56,7 @@ spec = do
       let mapping = inferTable ex4
       let pf = typedProgramFile ex4
       mapping ! "y" `shouldBe` IDType (Just (defSTy TypeInteger)) (Just $ CTArray [(Nothing, Just 10)])
-      mapping ! "c" `shouldBe` IDType (Just (defSTy (TypeCharacter Nothing Nothing))) (Just CTVariable)
+      mapping ! "c" `shouldBe` IDType (Just (defSTy TypeCharacter)) (Just CTVariable)
       mapping ! "log" `shouldBe` IDType (Just (defSTy TypeLogical)) (Just CTVariable)
       [ () | ExpValue a _ (ValVariable "x") <- uniExpr pf
            , idType a == Just (IDType (Just (defSTy TypeInteger)) (Just CTVariable)) ]
@@ -177,7 +178,7 @@ ex4pu1bs =
         [ DeclVariable () u (varGen "x") Nothing Nothing
         , DeclArray () u (varGen "y")
             (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ]) Nothing Nothing ]))
-  , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing
+  , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing
       (AList () u [ DeclVariable () u (varGen "c") Nothing Nothing ]))
   , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeLogical Nothing) Nothing
       (AList () u [ DeclVariable () u (varGen "log") Nothing Nothing ])) ]

--- a/test/Language/Fortran/Parser/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran2003Spec.hs
@@ -122,14 +122,14 @@ spec =
 
       it "parses allocate with type_spec" $ do
         let sel = Selector () u (Just (ExpValue () u ValColon)) (Just (varGen "foo"))
-        let ty = TypeSpec () u (TypeCharacter (Just $ CharLenColon) (Just "foo")) (Just sel)
+        let ty = TypeSpec () u TypeCharacter (Just sel)
         let decls = [DeclVariable () u (varGen "s") Nothing Nothing]
         let st = StDeclaration () u ty (Just (AList () u [AttrAllocatable () u])) (AList () u decls)
         sParser "character(len=:,kind=foo), allocatable :: s" `shouldBe'` st
 
       it "parses allocate with type_spec" $ do
         let sel = Selector () u (Just (intGen 3)) (Just (varGen "foo"))
-        let ty = TypeSpec () u (TypeCharacter (Just $ CharLenInt 3) (Just "foo")) (Just sel)
+        let ty = TypeSpec () u TypeCharacter (Just sel)
         let st = StAllocate () u (Just ty) (AList () u [varGen "s"]) Nothing
         sParser "allocate(character(len=3,kind=foo) :: s)" `shouldBe'` st
 

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -161,7 +161,7 @@ spec =
       it "parses 'implicit character*30 (a, b, c), integer (a-z, l)" $ do
         let impEls = [ImpCharacter () u "a", ImpCharacter () u "b", ImpCharacter () u "c"]
             sel = Selector () u (Just (intGen 30)) Nothing
-            imp1 = ImpList () u (TypeSpec () u (TypeCharacter (Just $ CharLenInt 30) Nothing) (Just sel)) $ AList () u impEls
+            imp1 = ImpList () u (TypeSpec () u TypeCharacter (Just sel)) $ AList () u impEls
             imp2 = ImpList () u (TypeSpec () u TypeInteger Nothing) $ AList () u [ImpRange () u "a" "z", ImpCharacter () u "l"]
             st = StImplicit () u $ Just $ AList () u [imp1, imp2]
         sParser "      implicit character*30 (a, b, c), integer (a-z, l)" `shouldBe'` st
@@ -202,7 +202,7 @@ spec =
 
     it "parses 'character a*8'" $ do
       let decl = DeclVariable () u (varGen "a") (Just $ intGen 8) Nothing
-          typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          typeSpec = TypeSpec () u TypeCharacter Nothing
           st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
       sParser "      character a*8" `shouldBe'` st
 
@@ -210,7 +210,7 @@ spec =
       let args = AList () u [ IxSingle () u Nothing (ExpValue () u (ValString "A")) ]
           lenExpr = ExpSubscript () u (ExpValue () u (ValVariable "ichar")) args
           decl = DeclVariable () u (varGen "c") (Just $ lenExpr) Nothing
-          typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          typeSpec = TypeSpec () u TypeCharacter Nothing
           st = StDeclaration () u typeSpec Nothing (AList () u [ decl ])
       sParser "      character c*(ichar('A'))" `shouldBe'` st
 
@@ -308,7 +308,7 @@ spec =
 
       it "parses character declarations with unspecfied lengths" $ do
         let src = "      character s*(*)"
-            st = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclVariable () u
                                (ExpValue () u (ValVariable "s"))
                                (Just (ExpValue () u ValStar))
@@ -328,7 +328,7 @@ spec =
 
         let src1 = "      character xs(2)*5 / 'hello', 'world' /"
             inits1 = [ExpValue () u (ValString "hello"), ExpValue () u (ValString "world")]
-            st1 = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st1 = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclArray () u
                                (ExpValue () u (ValVariable "xs"))
                                (AList () u [DimensionDeclarator () u Nothing (Just (ExpValue () u (ValInteger "2")))])
@@ -338,7 +338,7 @@ spec =
 
         let src2 = "      character xs*5(2) / 'hello', 'world' /"
             inits2 = [ExpValue () u (ValString "hello"), ExpValue () u (ValString "world")]
-            st2 = StDeclaration () u (TypeSpec () u (TypeCharacter Nothing Nothing) Nothing) Nothing $
+            st2 = StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing $
                  AList () u [DeclArray () u
                                (ExpValue () u (ValVariable "xs"))
                                (AList () u [DimensionDeclarator () u Nothing (Just (ExpValue () u (ValInteger "2")))])

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -285,7 +285,7 @@ spec =
           sParser "implicit none" `shouldBe'` st
 
         it "parses implicit with single" $ do
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec = TypeSpec () u TypeCharacter Nothing
           let impEls = [ ImpCharacter () u "k" ]
           let impLists = [ ImpList () u typeSpec (fromList () impEls) ]
           let st = StImplicit () u (Just $ fromList () impLists)
@@ -299,7 +299,7 @@ spec =
           sParser "implicit logical (x-z)" `shouldBe'` st
 
         it "parses implicit statement" $ do
-          let typeSpec1 = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec1 = TypeSpec () u TypeCharacter Nothing
           let typeSpec2 = TypeSpec () u TypeInteger Nothing
           let impEls1 = [ ImpCharacter () u "s", ImpCharacter () u "a" ]
           let impEls2 = [ ImpRange () u "x" "z" ]

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -337,7 +337,7 @@ spec =
           sParser "implicit none" `shouldBe'` st
 
         it "parses implicit with single" $ do
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec = TypeSpec () u TypeCharacter Nothing
               impEls = [ ImpCharacter () u "k" ]
               impLists = [ ImpList () u typeSpec (fromList () impEls) ]
               st = StImplicit () u (Just $ fromList () impLists)
@@ -351,7 +351,7 @@ spec =
           sParser "implicit logical (x-z)" `shouldBe'` st
 
         it "parses implicit statement" $ do
-          let typeSpec1 = TypeSpec () u (TypeCharacter Nothing Nothing) Nothing
+          let typeSpec1 = TypeSpec () u TypeCharacter Nothing
               typeSpec2 = TypeSpec () u TypeInteger Nothing
               impEls1 = [ ImpCharacter () u "s", ImpCharacter () u "a" ]
               impEls2 = [ ImpRange () u "x" "z" ]

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -106,7 +106,7 @@ spec =
       describe "Declaration" $ do
         it "prints 90 style with attributes" $ do
           let sel = Selector () u (Just $ intGen 3) Nothing
-          let typeSpec = TypeSpec () u (TypeCharacter Nothing Nothing) (Just sel)
+          let typeSpec = TypeSpec () u TypeCharacter (Just sel)
           let attrs = [ AttrIntent () u In , AttrPointer () u ]
           let declList =
                 [ DeclVariable () u (varGen "x") Nothing (Just $ intGen 42)
@@ -254,7 +254,7 @@ spec =
           it "prints allocate statement with type spec" $ do
             let stat = AOStat () u (varGen "s")
             let sel = Selector () u (Just (intGen 30)) Nothing
-            let ty = TypeSpec () u (TypeCharacter (Just $ CharLenInt 30) Nothing) (Just sel)
+            let ty = TypeSpec () u TypeCharacter (Just sel)
             let st = StAllocate () u (Just ty) (AList () u [ varGen "x" ]) (Just (AList () u [stat]))
             pprint Fortran2003 st Nothing `shouldBe` "allocate (character(len=30) :: x, stat=s)"
 

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -3,7 +3,6 @@ module Language.Fortran.Transformation.Disambiguation.FunctionSpec (spec) where
 import Test.Hspec
 import TestUtil
 
-import Language.Fortran.Analysis
 import Language.Fortran.AST
 import Language.Fortran.Transformer
 


### PR DESCRIPTION
The CHARACTER type previously stored two Maybes for length and kind. These
weren't parsed from the syntax, instead retrieved from the Selector in the
declaration's TypeSpec. With the change to type representation (past the parsing
phase), that info now goes unused.  Removing it makes BaseType more consistent
(now a "type tag" enum) and lets us remove some code.

The info has essentially been "moved" to STyCharacter in SemType (kind isn't there yet, but I plan to add it).