### PR TITLE
Don't lex `;` in first 6 cols in fixed form (#148)

### DIFF
--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -85,7 +85,8 @@ tokens :-
 
   <0,st,keyword,iif,assn,doo> \n              { resetPar >> toSC 0 >> addSpan TNewline }
   <0,st,keyword,iif,assn,doo> \r              ;
-  <0,st,keyword,iif,assn,doo> ";"             { resetPar >> toSC keyword >> addSpan TNewline }
+
+  <st,keyword,iif,assn,doo> ";"               { resetPar >> toSC keyword >> addSpan TNewline }
 
   <st> "("                                    { addSpan TLeftPar }
   <keyword> "(" / { legacy77P }               { addSpan TLeftPar }

--- a/test/Language/Fortran/Lexer/FixedFormSpec.hs
+++ b/test/Language/Fortran/Lexer/FixedFormSpec.hs
@@ -226,6 +226,9 @@ spec =
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      integer i; integer j")
           `shouldBe` resetSrcSpan [TType u "integer", TId u "i", TNewline u, TType u "integer", TId u "j", TEOF u]
 
+      it "does not lex ';' as a line-terminator in first 6 columns" $
+        safeLex66 "; integer i; integer j" `shouldBe` Nothing
+
       it "lexes subscripts in assignments" $
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      x(0,0) = 0")
           `shouldBe` resetSrcSpan [TId u "x", TLeftPar u, TInt u "0", TComma u, TInt u "0", TRightPar u, TOpAssign u, TInt u "0", TEOF u]


### PR DESCRIPTION
Fixes #148 .