### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 0.4.3 (May 25, 2021)
+
+  * Add Haddock documentation to AST module. Many parts of the AST now have
+    commentary on meaning and usage, and the Haddock page is sectioned.
+  * Add STATIC statement (should be similar/identical to SAVE attribute) to
+    fixed-form lexer, support in Fortran 77 Extended parser.
+  * Rewrite post-parse transformation handling. Parser modules now export more
+    parsers which allow you to select post-parse transformations to apply,
+    intended to enable quicker parsing if you know you don't need to certain
+    transformations.
+  * Support percent data references in fixed-form lexer, enable in Fortran 77
+    parser
+  * Now also testing on GHC 9.0
+  * Cache INCLUDE-ed files to avoid unnecessary re-parsing
+
 ### 0.4.2 (March 03, 2021)
 
   * `FortranVersion` from `ParserMonad` moved to its own module

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ resolver: ...
 
 extra-deps:
 - ...
-- fortran-src-0.4.2
+- fortran-src-$VERSION
 ```
 
 ### As a CLI tool

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 859eadbf578a446779b4602ab015d0a4d996ec983f0265dcf81b31aafd01c137
+-- hash: f5d7e99716015530592de9c1b2546f0d2ad31a230d0574adb8385118e8bdba1f
 
 name:           fortran-src
-version:        0.4.2
+version:        0.4.3
 synopsis:       Parsers and analyses for Fortran standards 66, 77, 90 and 95.
 description:    Provides lexing, parsing, and basic analyses of Fortran code covering standards: FORTRAN 66, FORTRAN 77, Fortran 90, and Fortran 95 and some legacy extensions. Includes data flow and basic block analysis, a renamer, and type analysis. For example usage, see the 'camfort' project, which uses fortran-src as its front end.
 category:       Language

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fortran-src
-version: '0.4.2'
+version: '0.4.3'
 synopsis: Parsers and analyses for Fortran standards 66, 77, 90 and 95.
 description: ! 'Provides lexing, parsing, and basic analyses of Fortran code covering
   standards: FORTRAN 66, FORTRAN 77, Fortran 90, and Fortran 95 and some legacy extensions.


### PR DESCRIPTION
Relevant changelog entry:

  * Add Haddock documentation to AST module. Many parts of the AST now have
    commentary on meaning and usage, and the Haddock page is sectioned.
  * Add STATIC statement (should be similar/identical to SAVE attribute) to
    fixed-form lexer, support in Fortran 77 Extended parser.
  * Rewrite post-parse transformation handling. Parser modules now export more
    parsers which allow you to select post-parse transformations to apply,
    intended to enable quicker parsing if you know you don't need to certain
    transformations.
  * Support percent data references in fixed-form lexer, enable in Fortran 77
    parser
  * Now also testing on GHC 9.0
  * Cache INCLUDE-ed files to avoid unnecessary re-parsing