### PR TITLE
Add more SemType utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
   * Introduce a second-stage type representation including kind info alongside
     types, and resolving some types to semantic type with preset kinds (e.g.
     `DOUBLE PRECISION` -> `REAL(8)`).
+    * Module is at Language.Fortran.Analysis.SemanticTypes . Includes utils and
+      instances.
     * The type analysis in Language.Fortran.Analysis.Types uses this
       representation now (`IDType` stores a `SemType` instead of a `BaseType`).
   * Move `CharacterLen` from parsing to type analysis.

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -116,6 +116,7 @@ test-suite spec
       Language.Fortran.Analysis.BBlocksSpec
       Language.Fortran.Analysis.DataFlowSpec
       Language.Fortran.Analysis.RenamingSpec
+      Language.Fortran.Analysis.SemanticTypesSpec
       Language.Fortran.Analysis.TypesSpec
       Language.Fortran.AnalysisSpec
       Language.Fortran.Lexer.FixedFormSpec

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -141,6 +141,9 @@ charLenConcat l1 l2 = case (l1, l2) of
 -- combinations, @DOUBLE PRECISION@ and @DOUBLE COMPLEX@ are used instead.
 -- However, we otherwise don't shy away from adding kind info regardless of
 -- theoretical version support.
+--
+-- Array types don't work properly, due to array type info being in a parent
+-- node that holds individual elements.
 recoverSemTypeTypeSpec :: forall a. a -> SrcSpan
                        -> FortranVersion -> SemType -> TypeSpec a
 recoverSemTypeTypeSpec a ss v = \case
@@ -150,7 +153,6 @@ recoverSemTypeTypeSpec a ss v = \case
 
   TCustom str -> ts (TypeCustom str) Nothing
 
-  -- TODO how do we do array decls in syntax again?
   TArray     st  _   -> recoverSemTypeTypeSpec a ss v st
 
   TReal    k ->

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Fortran.Analysis.SemanticTypes where
 
@@ -18,6 +19,8 @@ import           Language.Fortran.Util.Position ( SrcSpan(..) )
 import           Language.Fortran.Version       ( FortranVersion(..) )
 import           Data.Binary                    ( Binary )
 import           Text.PrettyPrint.GenericPretty ( Out(..) )
+import           Text.PrettyPrint               ( (<+>), parens )
+import           Language.Fortran.PrettyPrint   ( Pretty(..) )
 
 -- | Semantic type assigned to variables.
 --
@@ -39,6 +42,21 @@ data SemType
 
 instance Binary SemType
 instance Out    SemType
+
+-- TODO placeholder, not final or tested
+-- should really attempt to print with kind info, and change to DOUBLE PRECISION
+-- etc. for <F90. Maybe cheat, use 'recoverSemTypeTypeSpec' and print resulting
+-- TypeSpec?
+instance Pretty SemType where
+  pprint' v = \case
+    TInteger k -> "integer"
+    TReal k    -> "real"
+    TComplex k -> "complex"
+    TLogical k -> "logical"
+    TByte k    -> "byte"
+    TCharacter len k -> "character"
+    TArray st dims -> pprint' v st <+> parens "(A)"
+    TCustom str -> pprint' v (TypeCustom str)
 
 -- | The declared dimensions of a staticically typed array variable
 -- type is of the form [(dim1_lower, dim1_upper), (dim2_lower, dim2_upper)]

--- a/test/Language/Fortran/Analysis/SemanticTypesSpec.hs
+++ b/test/Language/Fortran/Analysis/SemanticTypesSpec.hs
@@ -1,0 +1,31 @@
+module Language.Fortran.Analysis.SemanticTypesSpec where
+
+import Test.Hspec
+import TestUtil
+
+import Language.Fortran.Analysis.SemanticTypes
+import Language.Fortran.AST
+import Language.Fortran.Version
+
+spec :: Spec
+spec = do
+  describe "Semantic types" $ do
+    it "recovers DOUBLE PRECISION for REAL(8) in Fortran 77" $ do
+      let semtype  = TReal 8
+          typespec = TypeSpec () u TypeDoublePrecision Nothing
+       in recoverSemTypeTypeSpec () u Fortran77 semtype `shouldBe` typespec
+
+    it "recovers DOUBLE COMPLEX for COMPLEX(16) in Fortran 77" $ do
+      let semtype  = TComplex 16
+          typespec = TypeSpec () u TypeDoubleComplex Nothing
+       in recoverSemTypeTypeSpec () u Fortran77 semtype `shouldBe` typespec
+
+    it "recovers REAL(8) for REAL(8) in Fortran 90" $ do
+      let semtype  = TReal 8
+          typespec = TypeSpec () u TypeReal (Just (Selector () u Nothing (Just (ExpValue () u (ValInteger "8")))))
+       in recoverSemTypeTypeSpec () u Fortran90 semtype `shouldBe` typespec
+
+    it "recovers CHARACTER(*)" $ do
+      let semtype  = TCharacter CharLenStar 1
+          typespec = TypeSpec () u TypeCharacter (Just (Selector () u (Just (ExpValue () u ValStar)) Nothing))
+       in recoverSemTypeTypeSpec () u Fortran90 semtype `shouldBe` typespec


### PR DESCRIPTION
A module in CamFort uses `Analysis` results and finishes by generating a fresh AST, so as it stands it needs to convert a `SemType` back down to a `BaseType`. It's a potentially useful utility, so I've added it here.