### PR TITLE
Fix parsing DO 10 WHILE constructs

### DIFF
--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -222,7 +222,7 @@ tokens :-
 <0> "do"                                          { addSpan TDo }
 <scN> "do" / { followsColonP }                    { addSpan TDo }
 <0> "end"\ *"do"                                  { addSpan TEndDo }
-<scN> "while" / { followsDoP }                    { addSpan TWhile }
+<scN> "while" / { followsDoWithOptLabelP }        { addSpan TWhile }
 <0> "if"                                          { addSpan TIf }
 <scN> "if" / { followsColonP }                    { addSpan TIf }
 <scI> "then"                                      { addSpan TThen }
@@ -334,10 +334,17 @@ formatP _ _ _ ai
   | Just TFormat{} <- aiPreviousToken ai = True
   | otherwise = False
 
-followsDoP :: User -> AlexInput -> Int -> AlexInput -> Bool
-followsDoP _ _ _ ai
-  | Just TDo {} <- aiPreviousToken ai = True
+followsDoWithOptLabelP :: User -> AlexInput -> Int -> AlexInput -> Bool
+followsDoWithOptLabelP _ _ _ ai
+  -- DO ...
+  | Just TDo {} <- aiPreviousToken ai        = True
+
+  -- DO 10 ...
+  | TDo{}:TIntegerLiteral{}:[] <- prevTokens = True
+
   | otherwise = False
+  where
+    prevTokens = reverse . aiPreviousTokensInLine $ ai
 
 followsColonP :: User -> AlexInput -> Int -> AlexInput -> Bool
 followsColonP _ _ _ ai

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -529,9 +529,18 @@ spec =
         let st = StEnddo () u (Just "constructor")
         sParser "end do constructor" `shouldBe'` st
 
-      it "parses end do while statement" $ do
+    describe "DO WHILE" $ do
+      it "parses unnamed do while statement" $ do
+        let st = StDoWhile () u Nothing Nothing valTrue
+        sParser "do while (.true.)" `shouldBe'` st
+
+      it "parses named do while statement" $ do
         let st = StDoWhile () u (Just "name") Nothing valTrue
         sParser "name: do while (.true.)" `shouldBe'` st
+
+      it "parses unnamed labelled do while statement" $ do
+        let st = StDoWhile () u Nothing (Just (intGen 999)) valTrue
+        sParser "do 999 while (.true.)" `shouldBe'` st
 
     describe "Goto" $ do
       it "parses vanilla goto" $ do

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -578,9 +578,18 @@ spec =
         let st = StEnddo () u (Just "constructor")
         sParser "end do constructor" `shouldBe'` st
 
-      it "parses end do while statement" $ do
+    describe "DO WHILE" $ do
+      it "parses unnamed do while statement" $ do
+        let st = StDoWhile () u Nothing Nothing valTrue
+        sParser "do while (.true.)" `shouldBe'` st
+
+      it "parses named do while statement" $ do
         let st = StDoWhile () u (Just "name") Nothing valTrue
         sParser "name: do while (.true.)" `shouldBe'` st
+
+      it "parses unnamed labelled do while statement" $ do
+        let st = StDoWhile () u Nothing (Just (intGen 999)) valTrue
+        sParser "do 999 while (.true.)" `shouldBe'` st
 
     describe "Goto" $ do
       it "parses vanilla goto" $ do


### PR DESCRIPTION
Lexer couldn't pick up the WHILE as a TWhile in those cases. Fixed using
the same approach as other lookarounds.