### PR TITLE
Add associate block

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -347,7 +347,7 @@ data Block a =
   | BlAssociate a SrcSpan
                 (Maybe (Expression a))       -- Label
                 (Maybe String)               -- Construct name
-                [(Expression a, Expression a)] -- Expression abbreviations
+                (AList (ATuple Expression Expression) a) -- Expression abbreviations
                 [ Block a ]                  -- Body
                 (Maybe (Expression a))       -- Label to END IF
   -- ^ The first 'Expression' in the abbreviation tuple is always an

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -344,6 +344,15 @@ data Block a =
                 [ Block a ]                  -- ^ Body
                 (Maybe (Expression a))       -- ^ Label to END DO
 
+  | BlAssociate a SrcSpan
+                (Maybe (Expression a))       -- Label
+                (Maybe String)               -- Construct name
+                [(Expression a, Expression a)] -- Expression abbreviations
+                [ Block a ]                  -- Body
+                (Maybe (Expression a))       -- Label to END IF
+  -- ^ The first 'Expression' in the abbreviation tuple is always an
+  --   @ExpValue _ _ (ValVariable id)@. Also guaranteed nonempty.
+
   | BlInterface a SrcSpan
                 (Maybe (Expression a))       -- ^ label
                 Bool                         -- ^ abstract?

--- a/src/Language/Fortran/AST/AList.hs
+++ b/src/Language/Fortran/AST/AList.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 module Language.Fortran.AST.AList where
 
@@ -63,3 +64,14 @@ aStrip' (Just a) = aStrip a
 
 aMap :: (t a -> r a) -> AList t a -> AList r a
 aMap f (AList a s xs) = AList a s (map f xs)
+
+--------------------------------------------------------------------------------
+
+data ATuple t1 t2 a = ATuple a SrcSpan (t1 a) (t2 a)
+    deriving (Eq, Show, Data, Typeable, Generic, Functor)
+
+instance FirstParameter (ATuple t1 t2 a) a
+instance SecondParameter (ATuple t1 t2 a) SrcSpan
+instance Spanned (ATuple t1 t2 a)
+instance (Out a, Out (t1 a), Out (t2 a)) => Out (ATuple t1 t2 a)
+instance (NFData a, NFData (t1 a), NFData (t2 a)) => NFData (ATuple t1 t2 a)

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -244,6 +244,8 @@ tokens :-
 <0,scI> "pause"                                   { addSpan TPause }
 <0> "forall"                                      { addSpan TForall }
 <0> "end"\ *"forall"                              { addSpan TEndForall }
+<0> "associate"                                   { addSpan TAssociate }
+<0> "end"\ *"associate"                           { addSpan TEndAssociate }
 
 
 -- Where construct
@@ -1283,6 +1285,8 @@ data Token =
   | TExit               SrcSpan
   | TForall             SrcSpan
   | TEndForall          SrcSpan
+  | TAssociate          SrcSpan
+  | TEndAssociate       SrcSpan
   -- Where construct
   | TWhere              SrcSpan
   | TElsewhere          SrcSpan

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -245,6 +245,7 @@ tokens :-
 <0> "forall"                                      { addSpan TForall }
 <0> "end"\ *"forall"                              { addSpan TEndForall }
 <0> "associate"                                   { addSpan TAssociate }
+<scN> "associate" / { followsColonP }             { addSpan TAssociate }
 <0> "end"\ *"associate"                           { addSpan TEndAssociate }
 
 

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -158,6 +158,8 @@ import Debug.Trace
   case                        { TCase _ }
   selectcase                  { TSelectCase _ }
   endselect                   { TEndSelect _ }
+  associate                   { TAssociate _ }
+  endassociate                { TEndAssociate _ }
   default                     { TDefault _ }
   cycle                       { TCycle _ }
   exit                        { TExit _ }
@@ -358,6 +360,7 @@ BLOCKS :: { [ Block A0 ] } : BLOCKS BLOCK { $2 : $1 } | {- EMPTY -} { [ ] }
 BLOCK :: { Block A0 }
 : IF_BLOCK MAYBE_COMMENT NEWLINE { $1 }
 | CASE_BLOCK MAYBE_COMMENT NEWLINE { $1 }
+| ASSOCIATE_BLOCK MAYBE_COMMENT NEWLINE { $1 }
 | INTEGER_LITERAL STATEMENT MAYBE_COMMENT NEWLINE
   { BlStatement () (getTransSpan $1 $2) (Just $1) $2 }
 | STATEMENT MAYBE_COMMENT NEWLINE { BlStatement () (getSpan $1) Nothing $1 }
@@ -453,6 +456,60 @@ CASES_ :: { ([Maybe (AList Index A0)], [[Block A0]], Maybe (Expression A0), SrcS
 END_SELECT :: { (Maybe (Expression A0), SrcSpan) }
 : maybe(INTEGER_LITERAL) endselect maybe(id)
   { ($1, maybe (getSpan $2) getSpan $3) }
+
+ASSOCIATE_BLOCK :: { Block A0 }
+: INTEGER_LITERAL id ':' associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          mLabel     = Just $1;
+          TId _ name = $2;
+          mName      = Just name;
+          abbrevs    = fromReverseList $6;
+          body       = reverse $10;
+          (endSpan, mEndLabel) = $11;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
+| INTEGER_LITERAL        associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          mLabel     = Just $1;
+          mName      = Nothing;
+          abbrevs    = fromReverseList $4;
+          body       = reverse $8;
+          (endSpan, mEndLabel) = $9;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
+|                 id ':' associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          TId _ name = $1;
+          mLabel     = Nothing;
+          mName      = Just name;
+          abbrevs    = fromReverseList $5;
+          body       = reverse $9;
+          (endSpan, mEndLabel) = $10;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
+|                        associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          mLabel     = Nothing;
+          mName      = Nothing;
+          abbrevs    = fromReverseList $3;
+          body       = reverse $7;
+          (endSpan, mEndLabel) = $8;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
+
+-- TODO: Copied verbatim from END_IF. Should attempt to functionalise.
+END_ASSOCIATE :: { (SrcSpan, Maybe (Expression A0)) }
+: endassociate { (getSpan $1, Nothing) }
+| endassociate id { (getSpan $2, Nothing) }
+| INTEGER_LITERAL endassociate { (getSpan $2, Just $1) }
+| INTEGER_LITERAL endassociate id { (getSpan $3, Just $1) }
+
+-- (var (ExpValue (ValVariable)), assoc. expr)
+ABBREVIATIONS :: { [(ATuple Expression Expression A0)] }
+: ABBREVIATIONS ',' ABBREVIATION { $3 : $1 }
+|                   ABBREVIATION { [ $1 ]  }
+ABBREVIATION :: { ATuple Expression Expression A0 }
+: VARIABLE '=>' EXPRESSION { ATuple () (getTransSpan $1 $3) $1 $3 }
 
 ABSTRACTP :: { Bool }
 : abstract { True }

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1,8 +1,10 @@
 -- -*- Mode: Haskell -*-
+-- vim: ft=haskell
 {
 -- Incomplete work-in-progress.
 module Language.Fortran.Parser.Fortran2003 ( functionParser
                                            , statementParser
+                                           , blockParser
                                            , fortran2003Parser
                                            , fortran2003ParserWithTransforms
                                            , fortran2003ParserWithModFiles
@@ -32,9 +34,10 @@ import Debug.Trace
 
 }
 
-%name programParser PROGRAM
+%name programParser   PROGRAM
+%name functionParser  SUBPROGRAM_UNIT
+%name blockParser     BLOCK
 %name statementParser STATEMENT
-%name functionParser SUBPROGRAM_UNIT
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
 %tokentype { Token }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -416,8 +416,25 @@ ASSOCIATE_BLOCK :: { Block A0 }
           (endSpan, mEndLabel) = $11;
           span       = getTransSpan startSpan endSpan }
      in BlAssociate () span mLabel mName abbrevs body mEndLabel }
--- | INTEGER_LITERAL        associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
--- |                 id ':' associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+| INTEGER_LITERAL        associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          mLabel     = Just $1;
+          mName      = Nothing;
+          abbrevs    = $4;
+          body       = $8;
+          (endSpan, mEndLabel) = $9;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
+|                 id ':' associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
+  { let { startSpan  = getSpan $1;
+          TId _ name = $1;
+          mLabel     = Nothing;
+          mName      = Just name;
+          abbrevs    = $5;
+          body       = $9;
+          (endSpan, mEndLabel) = $10;
+          span       = getTransSpan startSpan endSpan }
+     in BlAssociate () span mLabel mName abbrevs body mEndLabel }
 |                        associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
   { let { startSpan  = getSpan $1;
           mLabel     = Nothing;

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -411,8 +411,8 @@ ASSOCIATE_BLOCK :: { Block A0 }
           mLabel     = Just $1;
           TId _ name = $2;
           mName      = Just name;
-          abbrevs    = $6;
-          body       = $10;
+          abbrevs    = fromReverseList $6;
+          body       = reverse $10;
           (endSpan, mEndLabel) = $11;
           span       = getTransSpan startSpan endSpan }
      in BlAssociate () span mLabel mName abbrevs body mEndLabel }
@@ -420,8 +420,8 @@ ASSOCIATE_BLOCK :: { Block A0 }
   { let { startSpan  = getSpan $1;
           mLabel     = Just $1;
           mName      = Nothing;
-          abbrevs    = $4;
-          body       = $8;
+          abbrevs    = fromReverseList $4;
+          body       = reverse $8;
           (endSpan, mEndLabel) = $9;
           span       = getTransSpan startSpan endSpan }
      in BlAssociate () span mLabel mName abbrevs body mEndLabel }
@@ -430,8 +430,8 @@ ASSOCIATE_BLOCK :: { Block A0 }
           TId _ name = $1;
           mLabel     = Nothing;
           mName      = Just name;
-          abbrevs    = $5;
-          body       = $9;
+          abbrevs    = fromReverseList $5;
+          body       = reverse $9;
           (endSpan, mEndLabel) = $10;
           span       = getTransSpan startSpan endSpan }
      in BlAssociate () span mLabel mName abbrevs body mEndLabel }
@@ -439,8 +439,8 @@ ASSOCIATE_BLOCK :: { Block A0 }
   { let { startSpan  = getSpan $1;
           mLabel     = Nothing;
           mName      = Nothing;
-          abbrevs    = $3;
-          body       = $7;
+          abbrevs    = fromReverseList $3;
+          body       = reverse $7;
           (endSpan, mEndLabel) = $8;
           span       = getTransSpan startSpan endSpan }
      in BlAssociate () span mLabel mName abbrevs body mEndLabel }
@@ -453,11 +453,11 @@ END_ASSOCIATE :: { (SrcSpan, Maybe (Expression A0)) }
 | INTEGER_LITERAL endassociate id { (getSpan $3, Just $1) }
 
 -- (var (ExpValue (ValVariable)), assoc. expr)
-ABBREVIATIONS :: { [(Expression A0, Expression A0)] }
+ABBREVIATIONS :: { [(ATuple Expression Expression A0)] }
 : ABBREVIATIONS ',' ABBREVIATION { $3 : $1 }
 |                   ABBREVIATION { [ $1 ]  }
-ABBREVIATION :: { (Expression A0, Expression A0) }
-: VARIABLE '=>' EXPRESSION { ($1, $3) }
+ABBREVIATION :: { ATuple Expression Expression A0 }
+: VARIABLE '=>' EXPRESSION { ATuple () (getTransSpan $1 $3) $1 $3 }
 
 MAYBE_EXPRESSION :: { Maybe (Expression A0) }
 : EXPRESSION { Just $1 }

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -327,14 +327,16 @@ instance IndentablePretty (Block a) where
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
 
+    -- Note that binary expressions such as @a*b@ will always be wrapped in
+    -- brackets. It appears to be built into 'Expression''s 'Pretty' instance.
     pprint v (BlAssociate _ _ mLabel mName abbrevs bodies mEndLabel) i
-      | v >= Fortran90 =
+      | v >= Fortran2003 =
         labeledIndent mLabel
           $  pprint' v mName <?> colon
                 <+> ("associate" <+> "(" <> pprint' v abbrevs <> ")" <> newline)
           <> pprint v bodies nextI
           <> labeledIndent mEndLabel ("end associate" <+> pprint' v mName <> newline)
-      | otherwise = tooOld v "Associate block" Fortran90
+      | otherwise = tooOld v "Associate block" Fortran2003
       where
         nextI = incIndentation i
         labeledIndent label stDoc =
@@ -359,7 +361,6 @@ instance Pretty String where
 instance Pretty (e a) => Pretty (AList e a) where
     pprint' v es = commaSep (map (pprint' v) (aStrip es))
 
--- TODO associate
 instance (Pretty (t1 a), Pretty (t2 a)) => Pretty (ATuple t1 t2 a) where
     pprint' v (ATuple _ _ t1 t2) = pprint' v t1 <+> "=>" <+> pprint' v t2
 

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -327,6 +327,15 @@ instance IndentablePretty (Block a) where
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
 
+    pprint v (BlAssociate _ _ mLabel mName abbrevs bodies mEndLabel) i
+      | v >= Fortran90 =
+        indent i ("associate" <+> "ABBREVS" <> newline) <>
+        pprint v bodies nextI <>
+        indent i ("end associate" <> newline)
+      | otherwise = tooOld v "Associate block" Fortran90
+      where
+        nextI = incIndentation i
+
     pprint v (BlComment _ _ (Comment comment)) i
       | v >= Fortran90 = indent i (char '!' <> text comment <> newline)
       | otherwise = char 'c' <> text comment <> newline

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -327,7 +327,6 @@ instance IndentablePretty (Block a) where
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
 
-    -- TODO associate
     pprint v (BlAssociate _ _ mLabel mName abbrevs bodies mEndLabel) i
       | v >= Fortran90 =
         labeledIndent mLabel
@@ -342,31 +341,6 @@ instance IndentablePretty (Block a) where
           if v >= Fortran90
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
-{-
-    pprint v (BlIf _ _ mLabel mName conds bodies el) i
-      | v >= Fortran77 =
-        labeledIndent mLabel
-          $  (pprint' v mName <?> colon
-                <+> "if" <+> parens (pprint' v firstCond) <+> "then" <> newline)
-          <> pprint v firstBody nextI
-          <> foldl' (<>) empty (map displayCondBlock restCondsBodies)
-          <> labeledIndent el ("end if" <+> pprint' v mName <> newline)
-      | otherwise = tooOld v "Structured if" Fortran77
-      where
-        ((firstCond, firstBody): restCondsBodies) = zip conds bodies
-        displayCondBlock (mCond, block) =
-          indent i
-            (case mCond of {
-              Just cond -> "else if" <+> parens (pprint' v cond) <+> "then";
-              Nothing -> "else"
-            } <> newline) <>
-          pprint v block nextI
-        nextI = incIndentation i
-        labeledIndent label stDoc =
-          if v >= Fortran90
-            then indent i (pprint' v label <+> stDoc)
-            else pprint' v mLabel `overlay` indent i stDoc
--}
 
     pprint v (BlComment _ _ (Comment comment)) i
       | v >= Fortran90 = indent i (char '!' <> text comment <> newline)

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -193,29 +193,35 @@ containsGroups :: Block (Analysis a) -> Bool
 containsGroups b =
   case b of
     BlStatement{} -> False
-    BlIf{} -> True
-    BlCase{} -> True
-    BlDo{} -> True
-    BlDoWhile{} -> True
+    BlIf{}        -> True
+    BlCase{}      -> True
+    BlDo{}        -> True
+    BlDoWhile{}   -> True
     BlInterface{} -> False
-    BlComment{} -> False
-    BlForall{}  -> True
+    BlComment{}   -> False
+    BlForall{}    -> True
+    BlAssociate{} -> True
 
 applyGroupingToSubblocks :: (ABlocks a -> ABlocks a) -> Block (Analysis a) -> Block (Analysis a)
 applyGroupingToSubblocks f b
   | BlStatement{} <- b =
       error "Individual statements do not have subblocks. Must not occur."
-  | BlIf a s l mn conds blocks el <- b = BlIf a s l mn conds (map f blocks) el
-  | BlCase a s l mn scrutinee conds blocks el <- b =
-      BlCase a s l mn scrutinee conds (map f blocks) el
-  | BlDo a s l n tl doSpec blocks el <- b = BlDo a s l n tl doSpec (f blocks) el
-  | BlDoWhile a s l n tl doSpec blocks el <- b = BlDoWhile a s l n tl doSpec (f blocks) el
+  | BlIf a s l mn conds blocks         el <- b =
+    BlIf a s l mn conds (map f blocks) el
+  | BlCase a s l mn scrutinee conds blocks         el <- b =
+    BlCase a s l mn scrutinee conds (map f blocks) el
+  | BlDo a s l n tl doSpec blocks     el <- b =
+    BlDo a s l n tl doSpec (f blocks) el
+  | BlDoWhile a s l n tl doSpec blocks     el <- b =
+    BlDoWhile a s l n tl doSpec (f blocks) el
   | BlInterface{} <- b =
       error "Interface blocks do not have groupable subblocks. Must not occur."
   | BlComment{} <- b =
       error "Comment statements do not have subblocks. Must not occur."
   | BlForall a s ml mn h blocks mel <- b =
-     BlForall a s ml mn h (f blocks) mel
+    BlForall a s ml mn h (f blocks) mel
+  | BlAssociate a s ml mn abbrevs blocks     mel <- b =
+    BlAssociate a s ml mn abbrevs (f blocks) mel
 
 --------------------------------------------------
 


### PR DESCRIPTION
Added in Fortran2003, some projects appear to use it with otherwise Fortran90 code (e.g. hande-qmc/hande on GitHub). It's a nice and simple block construct.

TODO:

  * [x] finish pretty printing and get that reviewed
  * [x] allow parsing in >=F90 parsers
  * [x] parse tests
  * [x] print tests