### PR TITLE
Structure analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: stack --no-terminal test --only-dependencies
 
     - name: Build and run tests
-      run: stack --no-terminal haddock --test --no-haddock-deps
+      run: stack --no-terminal haddock --test --no-haddock-deps --pedantic
 
     - name: Install (to place executable at a known location)
       run: stack --no-terminal install

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -49,13 +49,13 @@ instance Out    SemType
 -- TypeSpec?
 instance Pretty SemType where
   pprint' v = \case
-    TInteger k -> "integer"
-    TReal k    -> "real"
-    TComplex k -> "complex"
-    TLogical k -> "logical"
-    TByte k    -> "byte"
-    TCharacter len k -> "character"
-    TArray st dims -> pprint' v st <+> parens "(A)"
+    TInteger _ -> "integer"
+    TReal _    -> "real"
+    TComplex _ -> "complex"
+    TLogical _ -> "logical"
+    TByte _    -> "byte"
+    TCharacter _ _ -> "character"
+    TArray st _ -> pprint' v st <+> parens "(A)"
     TCustom str -> pprint' v (TypeCustom str)
 
 -- | The declared dimensions of a staticically typed array variable

--- a/test/Language/Fortran/Parser/UtilsSpec.hs
+++ b/test/Language/Fortran/Parser/UtilsSpec.hs
@@ -77,4 +77,4 @@ spec =
         jExp a b c = Just (Exponent a b c)
         expE = ExpLetterE
         expD = ExpLetterD
-        fails test = return test `shouldThrow` anyException
+        -- fails test = return test `shouldThrow` anyException


### PR DESCRIPTION
This adds some support of structure analysis during the type analysis phase, based on a commit @burz wrote a while ago, but was never upstreamed as we didn't encounter any issues with unions or nested structures needed for full support. I've redone it to use the new SemanticTypes and related functions and included the tests that have examples of code that would fail at the analysis phase before.

If we're to move over to using the type information gathered in this phase for type checking arbitrary expressions this does want to be fully supported eventually, and this change only supports fields of structures, not unions or nested structures so I've raised it as a draft. I also think the `getExprRecordedType` I've added could be made more general, and then used in the `annotateExpression`. If it's exposed this could be the basis for the type checker.
I should get time to work on this further, but it might make sense for this to go in if someone else wants to pick up the rest of the work sooner.

I've also fixed some pedantic warnings and added it to CI so there aren't regressions, but if for some reason you don't want that I can remove that commit.