### PR TITLE
Patch/fixup rewriter bug

### DIFF
--- a/test/Language/Fortran/Rewriter/InternalSpec.hs
+++ b/test/Language/Fortran/Rewriter/InternalSpec.hs
@@ -546,6 +546,18 @@ spec = do
         <>         BC.pack replS1
         <>         BC.pack replS2
         <>         BC.replicate 24 'a'
+    it "Apply replacement ('!' in a string literal)" $ do
+      let
+        source =
+          "      write(8, *) 'hi! this string is really long, overflowing even'"
+                                                                           -- ^ Column 68
+        range = SourceRange (SourceLocation 0 68) (SourceLocation 0 68)
+        replS = ", variableHello"
+        r     = Replacement range replS
+        res   = applyReplacements source [r]
+      res
+        `shouldBe`
+          "      write(8, *) 'hi! this string is really long, overflowing even'\n     +, variableHello"
     it "Apply replacements (overlapping)" $ do
       let source = BC.replicate 30 'a'
           range1 = SourceRange (SourceLocation 0 2) (SourceLocation 0 4)


### PR DESCRIPTION
Fixes #179 

[`evaluateChunks_`](https://github.com/camfort/fortran-src/blob/37fe7b2005ff1bc1f4abec1020a783ce50b10666/src/Language/Fortran/Rewriter/Internal.hs#L194-L237) is too eager in determining where an explicit comment starts.

This is due to using `(BC.elemIndex '!' chStr)` will trip up on `!` characters inside string literals, and report that Sourcelocation as the start of an explicit comment.

The right way to go about this would be:
1. Traverse each chunk, while maintaining state about whether a character is in a string literal or not
2.  Use this state  to locate a `!` outside a string literal

This PR fixes the above issue, and adds a failing test for detecting regressions.