### PR TITLE
Parse logical literals early

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -619,7 +619,7 @@ data Value a =
   -- ^ The name of a variable
   | ValIntrinsic         Name
   -- ^ The name of a built-in function
-  | ValLogical           String
+  | ValLogical           Bool (Maybe (Expression a))
   -- ^ A boolean value
   | ValOperator          String
   -- ^ User-defined operators in interfaces

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -270,11 +270,11 @@ annotateExpression e@(ExpValue _ ss (ValReal r))        = do
 annotateExpression e@(ExpValue _ ss (ValComplex e1 e2)) = do
     st <- complexLiteralType ss e1 e2
     return $ setSemType st e
-annotateExpression e@(ExpValue _ _ (ValInteger _))     =
+annotateExpression e@(ExpValue _ _ (ValInteger{}))     =
     -- FIXME: in >F90, int lits can have kind info on end @_8@, same as real
     -- lits. We do parse this into the lit string, it is available to us.
     return $ setSemType (deriveSemTypeFromBaseType TypeInteger) e
-annotateExpression e@(ExpValue _ _ (ValLogical _))     =
+annotateExpression e@(ExpValue _ _ (ValLogical{}))     =
     return $ setSemType (deriveSemTypeFromBaseType TypeLogical) e
 
 annotateExpression e@(ExpBinary _ _ op e1 e2)          = flip setIDType e `fmap` binaryOpType (getSpan e) op e1 e2

--- a/src/Language/Fortran/Lexer/FixedForm.x
+++ b/src/Language/Fortran/Lexer/FixedForm.x
@@ -217,7 +217,8 @@ tokens :-
   <st,iif> \" / { legacy77P }                 { strAutomaton '"'  0 }
 
   -- Logicals
-  <st,iif> (".true."|".false.")               { addSpanAndMatch TBool  }
+  <st,iif> ".true."                           { addSpan (\s -> TBool s True)  }
+  <st,iif> ".false."                          { addSpan (\s -> TBool s False) }
 
   -- Arithmetic operators
   <st,iif> "+"                                { addSpan TOpPlus  }
@@ -804,7 +805,7 @@ data Token = TLeftPar             SrcSpan
            | TInt                 SrcSpan String
            | TBozInt              SrcSpan String
            | TExponent            SrcSpan String
-           | TBool                SrcSpan String
+           | TBool                SrcSpan Bool
            | TOpPlus              SrcSpan
            | TOpMinus             SrcSpan
            | TOpExp               SrcSpan

--- a/src/Language/Fortran/Lexer/FreeForm.x
+++ b/src/Language/Fortran/Lexer/FreeForm.x
@@ -302,7 +302,9 @@ tokens :-
 
 <scN,scC> @characterLiteralBeg                    { lexCharacter }
 
-<scN> @logicalLiteral                             { addSpanAndMatch TLogicalLiteral }
+<scN> ".true."  { addSpan (\s -> TLogicalLiteral s True)  }
+<scN> ".false." { addSpan (\s -> TLogicalLiteral s False) }
+<scN> "_"       { addSpan TUnderscore            }
 
 -- Operators
 <scN> ("."$letter+"."|"**"|\*|\/|\+|\-) / { opP } { addSpanAndMatch TOpCustom }
@@ -1189,7 +1191,8 @@ data Token =
   | TOpNE               SrcSpan
   | TOpGT               SrcSpan
   | TOpGE               SrcSpan
-  | TLogicalLiteral     SrcSpan String
+  | TLogicalLiteral     SrcSpan Bool
+  | TUnderscore         SrcSpan
   -- Keywords
   -- Program unit related
   | TProgram            SrcSpan

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -50,6 +50,7 @@ import Debug.Trace
   int                         { TIntegerLiteral _ _ }
   float                       { TRealLiteral _ _ }
   boz                         { TBozLiteral _ _ }
+  '_'                         { TUnderscore _ }
   ','                         { TComma _ }
   ',2'                        { TComma2 _ }
   ';'                         { TSemiColon _ }
@@ -1394,7 +1395,16 @@ REAL_LITERAL :: { Expression A0 }
 : float { let TRealLiteral s r = $1 in ExpValue () s $ ValReal r }
 
 LOGICAL_LITERAL :: { Expression A0 }
-: bool { let TLogicalLiteral s b = $1 in ExpValue () s $ ValLogical b }
+: bool
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b Nothing) }
+| bool '_' KIND_PARAM
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b (Just $3)) }
+
+KIND_PARAM :: { Expression A0 }
+: INTEGER_LITERAL { $1 }
+| VARIABLE        { $1 }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/Parser/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fortran66.y
@@ -467,7 +467,7 @@ COMPLEX_LITERAL
 :  '(' SIGNED_NUMERIC_LITERAL ',' SIGNED_NUMERIC_LITERAL ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
 
 LOGICAL_LITERAL :: { Expression A0 }
-LOGICAL_LITERAL : bool { let TBool s b = $1 in ExpValue () s $ ValLogical b }
+LOGICAL_LITERAL : bool { let TBool s b = $1 in ExpValue () s $ ValLogical b Nothing }
 
 HOLLERITH :: { Expression A0 } : hollerith { ExpValue () (getSpan $1) $ let (THollerith _ h) = $1 in ValHollerith h }
 

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -942,7 +942,7 @@ NUMERIC_LITERAL :: { Expression A0 }
 | REAL_LITERAL { $1 }
 
 LOGICAL_LITERAL :: { Expression A0 }
-: bool { let TBool s b = $1 in ExpValue () s $ ValLogical b }
+: bool { let TBool s b = $1 in ExpValue () s $ ValLogical b Nothing }
 
 HOLLERITH :: { Expression A0 } : hollerith { ExpValue () (getSpan $1) $ let (THollerith _ h) = $1 in ValHollerith h }
 

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -47,6 +47,7 @@ import Debug.Trace
   int                         { TIntegerLiteral _ _ }
   float                       { TRealLiteral _ _ }
   boz                         { TBozLiteral _ _ }
+  '_'                         { TUnderscore _ }
   ','                         { TComma _ }
   ',2'                        { TComma2 _ }
   ';'                         { TSemiColon _ }
@@ -1135,7 +1136,16 @@ REAL_LITERAL :: { Expression A0 }
 : float { let TRealLiteral s r = $1 in ExpValue () s $ ValReal r }
 
 LOGICAL_LITERAL :: { Expression A0 }
-: bool { let TLogicalLiteral s b = $1 in ExpValue () s $ ValLogical b }
+: bool
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b Nothing) }
+| bool '_' KIND_PARAM
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b (Just $3)) }
+
+KIND_PARAM :: { Expression A0 }
+: INTEGER_LITERAL { $1 }
+| VARIABLE        { $1 }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -49,6 +49,7 @@ import Debug.Trace
   int                         { TIntegerLiteral _ _ }
   float                       { TRealLiteral _ _ }
   boz                         { TBozLiteral _ _ }
+  '_'                         { TUnderscore _ }
   ','                         { TComma _ }
   ',2'                        { TComma2 _ }
   ';'                         { TSemiColon _ }
@@ -1207,7 +1208,16 @@ REAL_LITERAL :: { Expression A0 }
 : float { let TRealLiteral s r = $1 in ExpValue () s $ ValReal r }
 
 LOGICAL_LITERAL :: { Expression A0 }
-: bool { let TLogicalLiteral s b = $1 in ExpValue () s $ ValLogical b }
+: bool
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b Nothing) }
+| bool '_' KIND_PARAM
+  { let TLogicalLiteral s b = $1
+     in ExpValue () s (ValLogical b (Just $3)) }
+
+KIND_PARAM :: { Expression A0 }
+: INTEGER_LITERAL { $1 }
+| VARIABLE        { $1 }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -964,6 +964,13 @@ instance Pretty (Value a) where
       | otherwise = tooOld v "Operator" Fortran90
     pprint' v (ValComplex e1 e2) = parens $ commaSep [pprint' v e1, pprint' v e2]
     pprint' _ (ValString str) = quotes $ text str
+    pprint' v (ValLogical b kp) = text litStr <> kpPretty
+      where
+        litStr   = if b then ".true." else ".false."
+        kpPretty =
+            case kp of
+              Nothing  -> empty
+              Just kp' -> text "_" <> pprint' v kp'
     pprint' _ valLit = text . getFirstParameter $ valLit
 
 instance IndentablePretty (StructureItem a) where

--- a/test/Language/Fortran/Lexer/FixedFormSpec.hs
+++ b/test/Language/Fortran/Lexer/FixedFormSpec.hs
@@ -235,8 +235,7 @@ spec =
 
       it "lexes labeled DO WHILE blocks" $
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      do 10 while (.true.)")
-          `shouldBe` resetSrcSpan [TDo u, TInt u "10", TWhile u, TLeftPar u, TBool u ".true.", TRightPar u, TEOF u]
-
+          `shouldBe` resetSrcSpan [TDo u, TInt u "10", TWhile u, TLeftPar u, TBool u True, TRightPar u, TEOF u]
 
       it "lexes structure/union/map blocks" $ do
         let src = unlines [ "      structure /foo/"

--- a/test/Language/Fortran/Lexer/FreeFormSpec.hs
+++ b/test/Language/Fortran/Lexer/FreeFormSpec.hs
@@ -193,7 +193,7 @@ spec =
       describe "Conditional" $ do
         it "lexes logical if with array assignment" $
           shouldBe' (collectF90 "if (.true.) a(1) = 42") $
-                    fmap ($u) [ TIf, TLeftPar, flip TLogicalLiteral ".true."
+                    fmap ($u) [ TIf, TLeftPar, flip TLogicalLiteral True
                               , TRightPar, flip TId "a", TLeftPar
                               , flip TIntegerLiteral "1", TRightPar, TOpAssign
                               , flip TIntegerLiteral "42", TEOF ]

--- a/test/Language/Fortran/Parser/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran2003Spec.hs
@@ -177,4 +177,4 @@ spec =
             expBinVars op x1 x2 = ExpBinary () u op (expValVar x1) (expValVar x2)
         bParser text `shouldBe'` expected
 
-    specF90PlusCommon sParser
+    specF90PlusCommon sParser eParser

--- a/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/ParserSpec.hs
@@ -228,9 +228,8 @@ spec =
       let printArgs  = Just $ AList () u [ExpValue () u $ ValString "foo"]
           printStmt  = StPrint () u (ExpValue () u ValStar) printArgs
           printBlock = BlStatement () u Nothing printStmt
-          trueLit = ExpValue () u $ ValLogical ".true."
       it "unlabelled" $ do
-        let bl = BlIf () u Nothing Nothing [ Just trueLit, Nothing ] [[printBlock], [printBlock]]  Nothing
+        let bl = BlIf () u Nothing Nothing [ Just valTrue, Nothing ] [[printBlock], [printBlock]]  Nothing
             src = unlines [ "      if (.true.) then ! comment if"
                           , "        print *, 'foo'"
                           , "      else ! comment else"
@@ -240,7 +239,7 @@ spec =
         blParser src `shouldBe'` bl
       it "labelled" $ do
         let label str = Just $ ExpValue () u $ ValInteger str
-            bl = BlIf () u (label "10")  Nothing [Just trueLit, Nothing] [[printBlock], [printBlock]] (label "30")
+            bl = BlIf () u (label "10")  Nothing [Just valTrue, Nothing] [[printBlock], [printBlock]] (label "30")
             src = unlines [ "10    if (.true.) then ! comment if"
                           , "        print *, 'foo'"
                           , "20    else ! comment else"

--- a/test/Language/Fortran/Parser/Fortran90PlusCommon.hs
+++ b/test/Language/Fortran/Parser/Fortran90PlusCommon.hs
@@ -1,3 +1,8 @@
+-- | Fortran standards F90 and beyond are a lot more consistent than the
+--   previous 2. As such, there is lots of shared parsing, and lots of shared
+--   tests. This module encodes such shared/common tests, where no difference
+--   in behaviour between parsers is be expected.
+
 module Language.Fortran.Parser.Fortran90PlusCommon ( specF90PlusCommon ) where
 
 import TestUtil
@@ -5,8 +10,8 @@ import Test.Hspec
 
 import Language.Fortran.AST
 
-specF90PlusCommon :: (String -> Statement A0) -> Spec
-specF90PlusCommon sParser =
+specF90PlusCommon :: (String -> Statement A0) -> (String -> Expression A0) -> Spec
+specF90PlusCommon sParser eParser =
   describe "Common Fortran 90+ tests" $ do
     describe "Statement" $ do
       describe "Declaration" $ do
@@ -37,3 +42,14 @@ specF90PlusCommon sParser =
               dims     = AList () u
                 [ DimensionDeclarator () u Nothing (Just (intGen 2)) ]
           sParser stStr `shouldBe'` expected
+
+      describe "Expression" $ do
+        it "parses logical literal without kind parameter" $ do
+          eParser ".true." `shouldBe'` valTrue
+
+        it "parses logical literal with kind parameter" $ do
+          let kp = ExpValue () u (ValVariable "kind")
+          eParser ".false._kind" `shouldBe'` valFalse' kp
+
+        it "parses mixed-case logical literal" $ do
+          eParser ".tRUe." `shouldBe'` valTrue

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -594,4 +594,4 @@ spec =
       let st = StUse () u (varGen "stats_lib") Nothing Exclusive (Just onlys)
       sParser "use stats_lib, only: a, b => c, operator(+), assignment(=)" `shouldBe'` st
 
-    specF90PlusCommon sParser
+    specF90PlusCommon sParser eParser

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -139,9 +139,12 @@ spec =
         in fParser fStr `shouldBe'` expected
 
     describe "Expression" $ do
-      it "parses logial literals with kind" $ do
-        let expected = ExpValue () u (ValLogical ".true._kind")
-        eParser ".true._kind" `shouldBe'` expected
+      it "parses logical literal without kind parameter" $ do
+        eParser ".true." `shouldBe'` valTrue
+
+      it "parses logical literal with kind parameter" $ do
+        let kp = ExpValue () u (ValVariable "kind")
+        eParser ".false._kind" `shouldBe'` valFalse' kp
 
       it "parses array initialisation exp" $ do
         let list = AList () u [ intGen 1, intGen 2, intGen 3, intGen 4 ]
@@ -443,19 +446,16 @@ spec =
       let stPrint = StPrint () u starVal (Just $ fromList () [ ExpValue () u (ValString "foo")])
       it "parser if block" $
         let ifBlockSrc = unlines [ "if (.false.) then", "print *, 'foo'", "end if"]
-            falseLit = ExpValue () u (ValLogical ".false.")
-        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just falseLit] [[BlStatement () u Nothing stPrint]] Nothing
+        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse] [[BlStatement () u Nothing stPrint]] Nothing
 
       it "parses named if block" $ do
         let ifBlockSrc = unlines [ "mylabel : if (.true.) then", "print *, 'foo'", "end if mylabel"]
-            trueLit = ExpValue () u (ValLogical ".true.")
-            ifBlock = BlIf () u Nothing (Just "mylabel") [Just trueLit] [[BlStatement () u Nothing stPrint]] Nothing
+            ifBlock = BlIf () u Nothing (Just "mylabel") [Just valTrue] [[BlStatement () u Nothing stPrint]] Nothing
         blParser ifBlockSrc `shouldBe'` ifBlock
 
       it "parses if-else block with inline comments (stripped)" $
         let ifBlockSrc = unlines [ "if (.false.) then ! comment if", "print *, 'foo'", "else ! comment else", "print *, 'foo'", "end if ! comment end"]
-            falseLit = ExpValue () u (ValLogical ".false.")
-        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just falseLit, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
+        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
 
       it "parses logical if statement" $ do
         let assignment = StExpressionAssign () u (varGen "a") (varGen "b")

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -157,9 +157,12 @@ spec =
         fParser fStr `shouldBe'` expected
 
     describe "Expression" $ do
-      it "parses logial literals with kind" $ do
-        let expected = ExpValue () u (ValLogical ".true._kind")
-        eParser ".true._kind" `shouldBe'` expected
+      it "parses logical literal without kind parameter" $ do
+        eParser ".true." `shouldBe'` valTrue
+
+      it "parses logical literal with kind parameter" $ do
+        let kp = ExpValue () u (ValVariable "kind")
+        eParser ".false._kind" `shouldBe'` valFalse' kp
 
       it "parses array initialisation exp" $ do
         let list = AList () u [ intGen 1, intGen 2, intGen 3, intGen 4 ]
@@ -493,19 +496,16 @@ spec =
       let stPrint = StPrint () u starVal (Just $ fromList () [ ExpValue () u (ValString "foo")])
       it "parser if block" $
         let ifBlockSrc = unlines [ "if (.false.) then", "print *, 'foo'", "end if"]
-            falseLit = ExpValue () u (ValLogical ".false.")
-        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just falseLit] [[BlStatement () u Nothing stPrint]] Nothing
+        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse] [[BlStatement () u Nothing stPrint]] Nothing
 
       it "parses named if block" $ do
         let ifBlockSrc = unlines [ "mylabel : if (.true.) then", "print *, 'foo'", "end if mylabel"]
-            trueLit = ExpValue () u (ValLogical ".true.")
-            ifBlock = BlIf () u Nothing (Just "mylabel") [Just trueLit] [[BlStatement () u Nothing stPrint]] Nothing
+            ifBlock = BlIf () u Nothing (Just "mylabel") [Just valTrue] [[BlStatement () u Nothing stPrint]] Nothing
         blParser ifBlockSrc `shouldBe'` ifBlock
 
       it "parses if-else block with inline comments (stripped)" $
         let ifBlockSrc = unlines [ "if (.false.) then ! comment if", "print *, 'foo'", "else ! comment else", "print *, 'foo'", "end if ! comment end"]
-            falseLit = ExpValue () u (ValLogical ".false.")
-        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just falseLit, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
+        in blParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
 
       it "parses logical if statement" $ do
         let assignment = StExpressionAssign () u (varGen "a") (varGen "b")

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -658,4 +658,4 @@ spec =
       let st = StDeclaration () u ty (Just (AList () u attrs)) (AList () u decls)
       sParser "integer, volatile :: a, b" `shouldBe'` st
 
-    specF90PlusCommon sParser
+    specF90PlusCommon sParser eParser

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -98,6 +98,16 @@ spec =
                                          , FSIOMsg () u (varGen "y"), FSErr () u (varGen "z") ])
         pprint Fortran2003 f Nothing `shouldBe` "flush (unit=1, iostat=x, iomsg=y, err=z)"
 
+    describe "Value" $ do
+      it "prints logical literal with no kind parameter" $ do
+        let lit = ValLogical True Nothing
+        pprint Fortran77 lit Nothing `shouldBe` ".true."
+
+      it "prints logical literal with kind parameter (>=F90)" $ do
+        let lit    = ValLogical False (Just kpExpr)
+            kpExpr = ExpValue () u (ValInteger "8")
+        pprint Fortran90 lit Nothing `shouldBe` ".false._8"
+
     describe "Statement" $ do
       describe "Declaration" $ do
         it "prints 90 style with attributes" $ do

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -24,10 +24,13 @@ mi77 = MetaInfo { miVersion = Fortran77, miFilename = "<unknown>" }
 mi90 :: MetaInfo
 mi90 = MetaInfo { miVersion = Fortran90, miFilename = "<unknown>" }
 
-valTrue :: Expression ()
-valTrue = ExpValue () u $ ValLogical ".true."
-valFalse :: Expression ()
-valFalse = ExpValue () u $ ValLogical ".false."
+valTrue, valFalse :: Expression ()
+valTrue  = ExpValue () u $ ValLogical True  Nothing
+valFalse = ExpValue () u $ ValLogical False Nothing
+
+valTrue', valFalse' :: Expression () -> Expression ()
+valTrue'  kp = ExpValue () u $ ValLogical True  (Just kp)
+valFalse' kp = ExpValue () u $ ValLogical False (Just kp)
 
 varGen :: String -> Expression ()
 varGen str = ExpValue () u $ ValVariable str


### PR DESCRIPTION
Fortran values (including literals) are encoded in `AST.Value`. All the constructors store `String`s, which are the stringy representations of the values. For some literals this is agreeable, because the semantics of Fortran values probably differ from Haskell (mainly thinking of floats here). For others I don't think that's a worry, and fully parsing early means we don't have to perform "delayed parsing" later on when we need those values.

This changeset replaces `ValLogical String` with

```haskell
ValLogical
  { bool :: Bool
  , kindParameter :: Maybe (Expression a) }
```

and adds tests for logical literals with kind parameters (e.g. `.true._8`).

Previously the lexer matched a longer regex and kept the result as a string. Now it tokenizes more precisely, and the parser essentially replaces that regex.

*Only the free form lexer parses kind parameters, fixed form always inserts a `Nothing` (matching previous operation).