### PR TITLE
Handle nonstandard kind parameter in type analysis

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -162,6 +162,7 @@ test-suite spec
       Language.Fortran.Parser.Fortran66Spec
       Language.Fortran.Parser.Fortran77.IncludeSpec
       Language.Fortran.Parser.Fortran77.ParserSpec
+      Language.Fortran.Parser.Fortran90PlusCommon
       Language.Fortran.Parser.Fortran90Spec
       Language.Fortran.Parser.Fortran95Spec
       Language.Fortran.Parser.UtilsSpec

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -655,10 +655,10 @@ data Value a =
 -- Syntax note: length is set like @character :: str*10@, dimensions are set
 -- like @integer :: arr(10)@. Careful to not get confused.
 --
--- Note that according to HP's F90 spec, lengths may only be specified for
--- CHARACTER types. So for any declarations that aren't 'TypeCharacter' in the
--- outer 'TypeSpec', the length expression should be Nothing. However, this is
--- not enforced by the AST or parser, so be warned.
+-- Note that lengths may only be specified for CHARACTER types. However, a
+-- nonstandard syntax feature is to use this as a kind parameter for non
+-- CHARACTERs. So we parse length for all 'Declarator's, handle the nonstandard
+-- feature and print a warning during our type analysis.
 data Declarator a =
     DeclVariable a SrcSpan
                  (Expression a)             -- ^ Variable

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1105,6 +1105,10 @@ DECLARATOR :: { Declarator A0 }
   { DeclArray () (getTransSpan $1 $4) $1 (aReverse $3) Nothing Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
   { DeclArray () (getTransSpan $1 $6) $1 (aReverse $3) (Just $6) Nothing }
+-- nonstandard char array syntax (wrong order for dimensions & charlen)
+ | VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
+   { let star = ExpValue () (getSpan $4) ValStar
+    in DeclArray () (getTransSpan $1 $6) $1 (aReverse $5) (Just $3) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
     in DeclArray () (getTransSpan $1 $8) $1 (aReverse $3) (Just star) Nothing }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -909,10 +909,7 @@ DECLARATOR :: { Declarator A0 }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
   { DeclArray () (getTransSpan $1 $6) $1 (aReverse $3) (Just $6) Nothing }
 -- nonstandard char array syntax (wrong order for dimensions & charlen)
--- TODO: adds 2 S/R conflicts. but all tests pass...
 | VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
--- alternatively, limiting to integer lits avoids the S/R conflicts
--- | VARIABLE '*' INTEGER_LITERAL '(' DIMENSION_DECLARATORS ')'
   { let star = ExpValue () (getSpan $4) ValStar
     in DeclArray () (getTransSpan $1 $6) $1 (aReverse $5) (Just $3) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -908,6 +908,13 @@ DECLARATOR :: { Declarator A0 }
   { DeclArray () (getTransSpan $1 $4) $1 (aReverse $3) Nothing Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
   { DeclArray () (getTransSpan $1 $6) $1 (aReverse $3) (Just $6) Nothing }
+-- nonstandard char array syntax (wrong order for dimensions & charlen)
+-- TODO: adds 2 S/R conflicts. but all tests pass...
+| VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
+-- alternatively, limiting to integer lits avoids the S/R conflicts
+-- | VARIABLE '*' INTEGER_LITERAL '(' DIMENSION_DECLARATORS ')'
+  { let star = ExpValue () (getSpan $4) ValStar
+    in DeclArray () (getTransSpan $1 $6) $1 (aReverse $5) (Just $3) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
     in DeclArray () (getTransSpan $1 $8) $1 (aReverse $3) (Just star) Nothing }

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -925,6 +925,10 @@ DECLARATOR :: { Declarator A0 }
   { DeclArray () (getTransSpan $1 $4) $1 (aReverse $3) Nothing Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
   { DeclArray () (getTransSpan $1 $6) $1 (aReverse $3) (Just $6) Nothing }
+-- nonstandard char array syntax (wrong order for dimensions & charlen)
+| VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
+  { let star = ExpValue () (getSpan $4) ValStar
+    in DeclArray () (getTransSpan $1 $6) $1 (aReverse $5) (Just $3) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
     in DeclArray () (getTransSpan $1 $8) $1 (aReverse $3) (Just star) Nothing }

--- a/test/Language/Fortran/Parser/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran2003Spec.hs
@@ -3,8 +3,9 @@ module Language.Fortran.Parser.Fortran2003Spec where
 
 import Prelude hiding (GT, EQ, exp, pred)
 
-import TestUtil
 import Test.Hspec
+import TestUtil
+import Language.Fortran.Parser.Fortran90PlusCommon
 
 import Language.Fortran.AST
 import Language.Fortran.ParserMonad
@@ -175,3 +176,5 @@ spec =
             expValVar x = ExpValue () u (ValVariable x)
             expBinVars op x1 x2 = ExpBinary () u op (expValVar x1) (expValVar x2)
         bParser text `shouldBe'` expected
+
+    specF90PlusCommon sParser

--- a/test/Language/Fortran/Parser/Fortran90PlusCommon.hs
+++ b/test/Language/Fortran/Parser/Fortran90PlusCommon.hs
@@ -1,0 +1,39 @@
+module Language.Fortran.Parser.Fortran90PlusCommon ( specF90PlusCommon ) where
+
+import TestUtil
+import Test.Hspec
+
+import Language.Fortran.AST
+
+specF90PlusCommon :: (String -> Statement A0) -> Spec
+specF90PlusCommon sParser =
+  describe "Common Fortran 90+ tests" $ do
+    describe "Statement" $ do
+      describe "Declaration" $ do
+        it "parses scalar declaration with nonstandard kind param (non-CHAR)" $ do
+          let stStr    = "integer x*8"
+              expected = StDeclaration () u typeSpec Nothing decls
+              typeSpec = TypeSpec () u TypeInteger Nothing
+              decls    = AList () u
+                [ DeclVariable () u (varGen "x") (Just (intGen 8)) Nothing ]
+          sParser stStr `shouldBe'` expected
+
+        it "parses array declaration with nonstandard kind param (non-CHAR)" $ do
+          let stStr    = "integer x(2)*8"
+              expected = StDeclaration () u typeSpec Nothing decls
+              typeSpec = TypeSpec () u TypeInteger Nothing
+              decls    = AList () u
+                [ DeclArray () u (varGen "x") dims (Just (intGen 8)) Nothing ]
+              dims     = AList () u
+                [ DimensionDeclarator () u Nothing (Just (intGen 2)) ]
+          sParser stStr `shouldBe'` expected
+
+        it "parses array declaration with nonstandard kind param (non-CHAR) and nonstandard dimension/charlen order" $ do
+          let stStr    = "integer x*8(2)"
+              expected = StDeclaration () u typeSpec Nothing decls
+              typeSpec = TypeSpec () u TypeInteger Nothing
+              decls    = AList () u
+                [ DeclArray () u (varGen "x") dims (Just (intGen 8)) Nothing ]
+              dims     = AList () u
+                [ DimensionDeclarator () u Nothing (Just (intGen 2)) ]
+          sParser stStr `shouldBe'` expected

--- a/test/Language/Fortran/Parser/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran90Spec.hs
@@ -2,8 +2,9 @@ module Language.Fortran.Parser.Fortran90Spec (spec) where
 
 import Prelude hiding (GT, exp, pred)
 
-import TestUtil
 import Test.Hspec
+import TestUtil
+import Language.Fortran.Parser.Fortran90PlusCommon
 
 import Language.Fortran.AST
 import Language.Fortran.ParserMonad
@@ -592,3 +593,5 @@ spec =
             , UseID () u (ExpValue () u ValAssignment) ]
       let st = StUse () u (varGen "stats_lib") Nothing Exclusive (Just onlys)
       sParser "use stats_lib, only: a, b => c, operator(+), assignment(=)" `shouldBe'` st
+
+    specF90PlusCommon sParser

--- a/test/Language/Fortran/Parser/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran95Spec.hs
@@ -2,8 +2,10 @@ module Language.Fortran.Parser.Fortran95Spec (spec) where
 
 import Prelude hiding (GT, EQ, exp, pred)
 
-import TestUtil
 import Test.Hspec
+import TestUtil
+import Language.Fortran.Parser.Fortran90PlusCommon
+
 import Control.Exception (evaluate)
 
 import Language.Fortran.AST
@@ -655,3 +657,5 @@ spec =
       let attrs = [AttrVolatile () u]
       let st = StDeclaration () u ty (Just (AList () u attrs)) (AList () u decls)
       sParser "integer, volatile :: a, b" `shouldBe'` st
+
+    specF90PlusCommon sParser


### PR DESCRIPTION
Re note made by @poppysingleton earlier today.

There's some nonstandard syntax for defining a type's kind:

```fortran-free-form
INTEGER x*8
```

That's actually syntax that should only be used for `CHARACTER`s, and indicates their length. It should be invalid syntax for non-`CHARACTER` types. I'm unsure how nonstandard it is -- gfortran supports many nonstandard syntactic features, but I can't get it to accept this one.

Previously we prompted with a warning during type analysis. With this changeset, we assume it's the nonstandard kind syntax and prompt with an altered warning, then continue with it replacing any other kind parameter. Also adds a bunch of tests covering the main cases too.