### PR TITLE
add early BOZ constant parsing, separate constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,25 @@
     (thanks @envp) #179
   * CI builds on Mac; more release automation #181 #189
   * Handle nonstandard kind parameter in parsing & type analysis #188
+  * Fix renamer ambiguity resulting in unusual name-related breakages (e.g.
+    `ValVariable` not getting transformed to `ValIntrinsic`) #190
   * Fully parse logical literals early (don't leave as `String`) #185
     * Code that touches `ValLogical` will have to be updated -- it should mean
       removal of user-side parsing.
   * Explicitly parse integer literal kind parameter #191
     * The `String` representation stored should now always be safe to `read` to
       a Haskell `Integral`.
-  * Fix renamer ambiguity resulting in unusual name-related breakages (e.g.
-    `ValVariable` not getting transformed to `ValIntrinsic`) #190
   * Provide real literals in a semi-parsed "decomposed" format #193
     * Kind parameters are also made explicit.
     * Libraries with custom real literal parsing should be able to replace it
       with `readRealLit :: (Fractional a, Read a) => RealLit -> a`.
+  * Parse BOZ literal constants into their own `Value` constructor (instead of
+    together with integers) #194
+    * Also parse them to an intermediate data type and provide handling
+      functions.
 
 Note that kind parameters are disabled in fixed form parsers (F77, F66), so for
-codebases targeting older standards, most changes will be along the lines of
+codebases targeting older standards, many changes will be along the lines of
 `ValInteger x` -> `ValInteger x _`.
 
 ### 0.6.1 (Sep 17, 2021)

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -72,6 +72,7 @@ library
       Language.Fortran.AST
       Language.Fortran.AST.AList
       Language.Fortran.AST.RealLit
+      Language.Fortran.AST.Boz
       Language.Fortran.Version
       Language.Fortran.LValue
       Language.Fortran.Intrinsics
@@ -157,6 +158,7 @@ test-suite spec
       Language.Fortran.Analysis.SemanticTypesSpec
       Language.Fortran.Analysis.TypesSpec
       Language.Fortran.AnalysisSpec
+      Language.Fortran.AST.BozSpec
       Language.Fortran.AST.RealLitSpec
       Language.Fortran.Lexer.FixedFormSpec
       Language.Fortran.Lexer.FreeFormSpec

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ library:
   - Language.Fortran.AST
   - Language.Fortran.AST.AList
   - Language.Fortran.AST.RealLit
+  - Language.Fortran.AST.Boz
   - Language.Fortran.Version
   - Language.Fortran.LValue
   - Language.Fortran.Intrinsics

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -117,6 +117,7 @@ import Prelude hiding (init)
 
 import Language.Fortran.AST.AList
 import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Boz (Boz)
 import Language.Fortran.Util.Position
 import Language.Fortran.Util.FirstParameter
 import Language.Fortran.Util.SecondParameter
@@ -615,6 +616,8 @@ data Value a
   -- ^ The real and imaginary parts of a complex value
   | ValString            String
   -- ^ A string literal
+  | ValBoz               Boz
+  -- ^ A BOZ literal constant
   | ValHollerith         String
   -- ^ A Hollerith literal
   | ValVariable          Name

--- a/src/Language/Fortran/AST/Boz.hs
+++ b/src/Language/Fortran/AST/Boz.hs
@@ -1,0 +1,71 @@
+{- | Supporting code for handling Fortran BOZ literal constants.
+
+Using the definition from the latest Fortran standards (F2003, F2008), BOZ
+constants are bitstrings (untyped!) which have basically no implicit rules. How
+they're interpreted depends on context (they are generally limited to DATA
+statements and a small handful of intrinsic functions).
+-}
+
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveAnyClass #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Language.Fortran.AST.Boz where
+
+import           GHC.Generics
+import           Data.Data
+import           Control.DeepSeq                ( NFData )
+import           Text.PrettyPrint.GenericPretty ( Out )
+
+import qualified Data.List as List
+import qualified Data.Char as Char
+
+-- | A Fortran BOZ literal constant.
+--
+-- The prefix defines the characters allowed in the string:
+--
+--   * @B@: @[01]@
+--   * @O@: @[0-7]@
+--   * @Z@: @[0-9 a-f A-F]@
+data Boz = Boz
+  { bozPrefix :: BozPrefix
+  , bozString :: String
+  } deriving (Eq, Show, Data, Typeable, Generic, NFData, Out, Ord)
+
+data BozPrefix
+  = BozPrefixB
+  | BozPrefixO
+  | BozPrefixZ -- also @x@
+    deriving (Eq, Show, Data, Typeable, Generic, NFData, Out, Ord)
+
+-- | UNSAFE. Parses a BOZ literal constant string.
+--
+-- Looks for prefix or suffix. Strips the quotes from the string (single quotes
+-- only).
+parseBoz :: String -> Boz
+parseBoz s =
+    case List.uncons s of
+      Nothing -> errInvalid
+      Just (pc, ps) -> case parsePrefix pc of
+                         Just p -> Boz p (shave ps)
+                         Nothing -> case parsePrefix (List.last s) of
+                                      Just p -> Boz p (shave (init s))
+                                      Nothing -> errInvalid
+  where
+    parsePrefix p
+      | p' == 'b'            = Just BozPrefixB
+      | p' == 'o'            = Just BozPrefixO
+      | p' `elem` ['z', 'x'] = Just BozPrefixZ
+      | otherwise            = Nothing
+      where p' = Char.toLower p
+    errInvalid = error "Language.Fortran.AST.BOZ.parseBoz: invalid BOZ string"
+    -- | Remove the first and last elements in a list.
+    shave = tail . init
+
+-- | Pretty print a BOZ constant. Uses prefix style, and @z@ over nonstandard
+--   @x@ for hexadecimal.
+prettyBoz :: Boz -> String
+prettyBoz b = prettyBozPrefix (bozPrefix b) : '\'' : bozString b <> "'"
+  where prettyBozPrefix = \case
+          BozPrefixB -> 'b'
+          BozPrefixO -> 'o'
+          BozPrefixZ -> 'z'

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -1394,7 +1394,7 @@ INTEGER_LITERAL :: { Expression A0 }
 | int '_' KIND_PARAM
   { let TIntegerLiteral s i = $1
      in ExpValue () s $ ValInteger i (Just $3) }
-| boz { let TBozLiteral s i = $1 in ExpValue () s $ ValInteger i Nothing }
+| boz { let TBozLiteral s b = $1 in ExpValue () s $ ValBoz b }
 
 REAL_LITERAL :: { Expression A0 }
 : float

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -141,7 +141,7 @@ import Control.Exception
   format                { TFormat _ }
   blob                  { TBlob _ _ }
   int                   { TInt _ _ }
-  boz                   { TBozInt _ _ }
+  boz                   { TBozLiteral _ _ }
   exponent              { TExponent _ _ }
   bool                  { TBool _ _ }
   '+'                   { TOpPlus _ }
@@ -920,7 +920,7 @@ VARIABLE :: { Expression A0 }
 
 INTEGER_LITERAL :: { Expression A0 }
 : int { ExpValue () (getSpan $1) $ let (TInt _ i) = $1 in ValInteger i Nothing}
-| boz { let TBozInt s i = $1 in ExpValue () s $ ValInteger i Nothing}
+| boz { let TBozLiteral s b = $1 in ExpValue () s $ ValBoz b }
 
 REAL_LITERAL :: { Expression A0 }
 : int EXPONENT { makeReal (Just $1) Nothing Nothing (Just $2) }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -1135,7 +1135,7 @@ INTEGER_LITERAL :: { Expression A0 }
 | int '_' KIND_PARAM
   { let TIntegerLiteral s i = $1
      in ExpValue () s $ ValInteger i (Just $3) }
-| boz { let TBozLiteral s i = $1 in ExpValue () s $ ValInteger i Nothing }
+| boz { let TBozLiteral s b = $1 in ExpValue () s $ ValBoz b }
 
 REAL_LITERAL :: { Expression A0 }
 : float

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -1207,7 +1207,7 @@ INTEGER_LITERAL :: { Expression A0 }
 | int '_' KIND_PARAM
   { let TIntegerLiteral s i = $1
      in ExpValue () s $ ValInteger i (Just $3) }
-| boz { let TBozLiteral s i = $1 in ExpValue () s $ ValInteger i Nothing }
+| boz { let TBozLiteral s b = $1 in ExpValue () s $ ValBoz b }
 
 REAL_LITERAL :: { Expression A0 }
 : float

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -14,6 +14,7 @@ import Prelude hiding (EQ,LT,GT,pred,exp,(<>))
 
 import Language.Fortran.AST
 import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Boz
 import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 
@@ -970,6 +971,7 @@ instance Pretty (Value a) where
       where litStr = if b then ".true." else ".false."
     pprint' v (ValInteger i kp) = text i <> kpPretty v kp
     pprint' v (ValReal r kp) = text (prettyHsRealLit r) <> kpPretty v kp
+    pprint' _ (ValBoz b) = text $ prettyBoz b
     pprint' _ valLit = text . getFirstParameter $ valLit
 
 -- | Helper for pretty printing an optional kind parameter 'Expression'.

--- a/test/Language/Fortran/AST/BozSpec.hs
+++ b/test/Language/Fortran/AST/BozSpec.hs
@@ -9,3 +9,6 @@ spec = do
   describe "BOZ literal constants" $ do
     it "parses a prefix and suffix BOZ constant identically" $ do
       parseBoz "z'123abc'" `shouldBe` parseBoz "'123abc'z"
+
+    it "parses nonstandard X as Z (hex)" $ do
+      parseBoz "x'09af'" `shouldBe` parseBoz "z'09af'"

--- a/test/Language/Fortran/AST/BozSpec.hs
+++ b/test/Language/Fortran/AST/BozSpec.hs
@@ -1,0 +1,11 @@
+module Language.Fortran.AST.BozSpec where
+
+import Test.Hspec
+
+import Language.Fortran.AST.Boz
+
+spec :: Spec
+spec = do
+  describe "BOZ literal constants" $ do
+    it "parses a prefix and suffix BOZ constant identically" $ do
+      parseBoz "z'123abc'" `shouldBe` parseBoz "'123abc'z"

--- a/test/Language/Fortran/Lexer/FixedFormSpec.hs
+++ b/test/Language/Fortran/Lexer/FixedFormSpec.hs
@@ -1,7 +1,9 @@
 module Language.Fortran.Lexer.FixedFormSpec where
 
 import Language.Fortran.ParserMonad
+--import Language.Fortran.Version (required when ParserMonad stops exporting it)
 import Language.Fortran.Lexer.FixedForm
+import Language.Fortran.AST.Boz
 
 import Test.Hspec
 import Test.Hspec.QuickCheck
@@ -214,9 +216,12 @@ spec =
 
       it "lexes BOZ constants" $
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      integer i, j, k / b'0101', o'0755', z'ab01' /")
-          `shouldBe` resetSrcSpan [ TType u "integer", TId u "i", TComma u, TId u "j", TComma u, TId u"k"
-                                  , TSlash u, TBozInt u "b'0101'", TComma u, TBozInt u "o'0755'", TComma u, TBozInt u "z'ab01'", TSlash u
-                                  , TEOF u ]
+          `shouldBe` resetSrcSpan [ TType u "integer"
+                                  , TId u "i", TComma u, TId u "j", TComma u, TId u "k"
+                                  , TSlash u, TBozLiteral u (parseBoz "b'0101'")
+                                  , TComma u, TBozLiteral u (parseBoz "o'0755'")
+                                  , TComma u, TBozLiteral u (parseBoz "z'ab01'")
+                                  , TSlash u , TEOF u ]
 
       it "lexes non-standard identifiers" $
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      integer _this_is_a_long_identifier$")

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -11,6 +11,7 @@ import Data.Generics.Uniplate.Operations
 import Data.Maybe (catMaybes)
 
 import Language.Fortran.AST as LFA
+import Language.Fortran.AST.Boz
 import Language.Fortran.ParserMonad
 import Language.Fortran.PrettyPrint
 
@@ -107,6 +108,10 @@ spec =
         let lit    = ValLogical False (Just kpExpr)
             kpExpr = intGen 8
         pprint Fortran90 lit Nothing `shouldBe` ".false._8"
+
+      it "prints BOZ constant with prefix" $ do
+        let lit = ValBoz $ Boz BozPrefixZ "123abc"
+        pprint Fortran90 lit Nothing `shouldBe` "z'123abc'"
 
     describe "Statement" $ do
       describe "Declaration" $ do


### PR DESCRIPTION
In the same vein as #193 , we do what we can for BOZs as early as possible.

Thoughts and notes:

  * BOZs are now placed in their own constructor, but get parsed identically, which means they are alternatives in the `INTEGER_LITERAL` rule (in most of the parsers).
  * Could do a few more tests.
  * No special support for them in the rest of the codebase. If we're to follow the later Fortran standards, BOZ constants are untyped bitstrings, and their behaviour is pretty much all explicit rules like "works like this in this intrinsic function". Could check what fortran-vars deems useful if they have any relevant eval rules!