### PR TITLE
fix renaming edge case ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Explicitly parse integer literal kind parameter #191
     * The `String` representation stored should now always be safe to `read` to
       a Haskell `Integral`.
+  * Fix renamer ambiguity resulting in unusual name-related breakages #190
 
 ### 0.6.1 (Sep 17, 2021)
   * Properly include test data in package dist (in preparation for placing on

--- a/src/Language/Fortran/Analysis/Renaming.hs
+++ b/src/Language/Fortran/Analysis/Renaming.hs
@@ -201,12 +201,26 @@ getUniqNum = do
   modify $ \ s -> s { uniqNums = drop 1 (uniqNums s) }
   return uniqNum
 
--- Concat a scope, a variable, and a freshly generated number together
--- to generate a "unique name".
+-- | Concat a scope, a variable, and a freshly generated number together to
+--   generate a "unique name".
+--
+-- GitHub issue #190 showed it was possible to generate the same unique name for
+-- two different variables, if using the following unique name schema:
+--
+--     scope "_" var n
+--     n=3:  int1 -> func_int13
+--     n=13: int  -> func_int13
+--
+-- Instead, we now insert another underscore between the variable and the fresh
+-- number, to disambiguate where the fresh number starts.
+--
+--     scope "_" var "_" n
+--     n=3:  int1 -> func_int1_3
+--     n=13: int  -> func_int_13
 uniquify :: String -> String -> Renamer String
 uniquify scope var = do
   n <- getUniqNum
-  return $ scope ++ "_" ++ var ++ show n
+  return $ scope ++ "_" ++ var ++ "_" ++ show n
 
 --isModule :: ProgramUnit a -> Bool
 --isModule (PUModule {}) = True; isModule _             = False

--- a/test/Language/Fortran/Analysis/BBlocksSpec.hs
+++ b/test/Language/Fortran/Analysis/BBlocksSpec.hs
@@ -62,7 +62,7 @@ spec =
         reached `shouldBe` nodeSet
     describe "gotos" $ do
       let pf = pParser programGotos
-          gr = fromJust . M.lookup (Named "_gotos1") $ genBBlockMap pf
+          gr = fromJust . M.lookup (Named "_gotos_1") $ genBBlockMap pf
           ns = nodes $ bbgrGr gr
           es = edges $ bbgrGr gr
           nodeSet = IS.fromList ns


### PR DESCRIPTION
Previously, symbols like int and int1 could have the same unique name
generated for them, depending on the fresh number used e.g. n=12: int ->
int12; n=2: int1 -> int12. This can break things further up that expect
unique names to be, well, unique. Adding a separator between the
variable and the fresh number prevents this type of edge case from
occurring.

Also see the GitHub discussion for further info:
https://github.com/camfort/fortran-src/issues/190