### PR TITLE
AST: ScalarDeclarator -> ScalarDecl

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -660,8 +660,8 @@ data Declarator a
   deriving (Eq, Show, Data, Typeable, Generic, Functor)
 
 data DeclaratorType a
-  = ScalarDeclarator
-  | ArrayDeclarator (AList DimensionDeclarator a)
+  = ScalarDecl
+  | ArrayDecl (AList DimensionDeclarator a)
   deriving (Eq, Show, Data, Typeable, Generic, Functor)
 
 declaratorType :: Declarator a -> DeclaratorType a

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -892,8 +892,8 @@ showBaseType (ClassCustom s)     = "class(" ++ s ++ ")"
 showDecl :: Declarator a -> String
 showDecl (Declarator _ _ e mAdims length' initial) =
     let partDims = case mAdims of
-                     ScalarDeclarator -> mempty
-                     ArrayDeclarator dims ->
+                     ScalarDecl -> mempty
+                     ArrayDecl dims ->
                        "(" ++ aIntercalate "," showDim dims ++ ")"
      in  showExpr e
            ++ partDims

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -392,10 +392,10 @@ genConstExpMap pf = ceMap
       [ (varName v, getE e)
       | st@(StDeclaration _ _ (TypeSpec _ _ _ _) _ _) <- universeBi pf :: [Statement (Analysis a)]
       , AttrParameter _ _ <- universeBi st :: [Attribute (Analysis a)]
-      , (Declarator _ _ v ScalarDeclarator _ (Just e)) <- universeBi st ] ++
+      , (Declarator _ _ v ScalarDecl _ (Just e)) <- universeBi st ] ++
       [ (varName v, getE e)
       | st@StParameter{} <- universeBi pf :: [Statement (Analysis a)]
-      , (Declarator _ _ v ScalarDeclarator _ (Just e)) <- universeBi st ]
+      , (Declarator _ _ v ScalarDecl _ (Just e)) <- universeBi st ]
     getV :: Expression (Analysis a) -> Maybe Constant
     getV e = constExp (getAnnotation e) `mplus` (join . flip M.lookup pvMap . varName $ e)
 

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -97,7 +97,7 @@ analyseTypesWithEnv' env pf@(ProgramFile mi _) = runInfer (miVersion mi) env $ d
   -- Gather information.
   mapM_ intrinsicsExp (allExpressions pf)
   mapM_ programUnit (allProgramUnits pf)
-  mapM_ recordArrayDeclarator (allDeclarators pf)
+  mapM_ recordArrayDecl (allDeclarators pf)
   mapM_ statement (allStatements pf)
 
   -- Gather types for known entry points.
@@ -174,10 +174,10 @@ programUnit _                                           = return ()
 --   Note that 'ConstructType' is rewritten for 'Declarator's in
 --   'handleDeclaration' later. TODO how does this assist exactly? disabling
 --   apparently doesn't impact tests
-recordArrayDeclarator :: Data a => InferFunc (Declarator (Analysis a))
-recordArrayDeclarator (Declarator _ _ v (ArrayDeclarator ddAList) _ _) =
+recordArrayDecl :: Data a => InferFunc (Declarator (Analysis a))
+recordArrayDecl (Declarator _ _ v (ArrayDecl ddAList) _ _) =
     recordCType (CTArray $ dimDeclarator ddAList) (varName v)
-recordArrayDeclarator _ = return ()
+recordArrayDecl _ = return ()
 
 dimDeclarator :: AList DimensionDeclarator a -> [(Maybe Int, Maybe Int)]
 dimDeclarator ddAList = [ (lb, ub) | DimensionDeclarator _ _ lbExp ubExp <- aStrip ddAList
@@ -209,8 +209,8 @@ handleDeclaration env stmtSs ts mAttrAList declAList
             st <- deriveSemTypeFromDeclaration stmtSs declSs ts mLenExpr
             let n  = varName v
                 ct = case mDdAList of
-                       ScalarDeclarator -> cType n
-                       ArrayDeclarator dims -> CTArray $ dimDeclarator dims
+                       ScalarDecl -> cType n
+                       ArrayDecl dims -> CTArray $ dimDeclarator dims
             pure $ (n, st, ct) : rs
     in foldM handler [] decls
 
@@ -259,7 +259,7 @@ statement (StExpressionAssign _ _ (ExpFunctionCall _ _ v Nothing) _) = recordCTy
 statement (StDimension _ _ declAList) = do
   let decls = aStrip declAList
   forM_ decls $ \ decl -> case decl of
-    Declarator _ _ v (ArrayDeclarator ddAList) _ _ ->
+    Declarator _ _ v (ArrayDecl ddAList) _ _ ->
       recordCType (CTArray $ dimDeclarator ddAList) (varName v)
     _ -> return ()
 

--- a/src/Language/Fortran/Parser/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Fortran2003.y
@@ -674,7 +674,7 @@ ENUMERATOR_LIST :: { [Declarator A0] }
 -- R463
 ENUMERATOR :: { Declarator A0 }
 : PARAMETER_ASSIGNMENT { $1 }
-| VARIABLE { Declarator () (getSpan $1) $1 ScalarDeclarator Nothing Nothing }
+| VARIABLE { Declarator () (getSpan $1) $1 ScalarDecl Nothing Nothing }
 
 MAYBE_PROC_INTERFACE :: { Maybe (ProcInterface A0) }
 : TYPE_SPEC             { Just $ ProcInterfaceType () (getSpan $1) $1 }
@@ -1018,7 +1018,7 @@ PARAMETER_ASSIGNMENTS :: { [ Declarator A0 ] }
 
 PARAMETER_ASSIGNMENT :: { Declarator A0 }
 : VARIABLE '=' EXPRESSION
-  { Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator Nothing (Just $3) }
+  { Declarator () (getTransSpan $1 $3) $1 ScalarDecl Nothing (Just $3) }
 
 DECLARATION_STATEMENT :: { Statement A0 }
 : TYPE_SPEC ATTRIBUTE_LIST '::' INITIALIZED_DECLARATOR_LIST
@@ -1097,22 +1097,22 @@ INITIALIZED_DECLARATOR :: { Declarator A0 }
 
 DECLARATOR :: { Declarator A0 }
 : VARIABLE
-  {     Declarator () (getSpan $1)         $1 ScalarDeclarator                Nothing     Nothing }
+  {     Declarator () (getSpan $1)         $1 ScalarDecl                Nothing     Nothing }
 | VARIABLE '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator                (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $3) $1 ScalarDecl                (Just $3)   Nothing }
 | VARIABLE '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $4) ValStar
-     in Declarator () (getTransSpan $1 $5) $1 ScalarDeclarator                (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $5) $1 ScalarDecl                (Just star) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDeclarator (aReverse $3)) Nothing     Nothing }
+  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDecl (aReverse $3)) Nothing     Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $3)) (Just $6)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $3)) (Just $6)   Nothing }
 -- nonstandard char array syntax (wrong order for dimensions & charlen)
 | VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $5)) (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $5)) (Just $3)   Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
-     in Declarator () (getTransSpan $1 $8) $1 (ArrayDeclarator (aReverse $3)) (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $8) $1 (ArrayDecl (aReverse $3)) (Just star) Nothing }
 
 DIMENSION_DECLARATORS :: { AList DimensionDeclarator A0 }
 : DIMENSION_DECLARATORS ',' DIMENSION_DECLARATOR

--- a/src/Language/Fortran/Parser/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fortran66.y
@@ -316,7 +316,7 @@ ARRAY_DECLARATORS :: { AList Declarator A0 }
 
 ARRAY_DECLARATOR :: { Declarator A0 }
 : VARIABLE '(' DIMENSION_DECLARATORS ')'
-  { Declarator () (getTransSpan $1 $4) $1 (ArrayDeclarator (aReverse $3)) Nothing Nothing }
+  { Declarator () (getTransSpan $1 $4) $1 (ArrayDecl (aReverse $3)) Nothing Nothing }
 
 DIMENSION_DECLARATORS :: { AList DimensionDeclarator A0 }
 : DIMENSION_DECLARATORS ',' DIMENSION_DECLARATOR
@@ -328,7 +328,7 @@ DIMENSION_DECLARATOR :: { DimensionDeclarator A0 }
 : EXPRESSION { DimensionDeclarator () (getSpan $1) Nothing (Just $1) }
 
 VARIABLE_DECLARATOR :: { Declarator A0 }
-: VARIABLE { Declarator () (getSpan $1) $1 ScalarDeclarator Nothing Nothing }
+: VARIABLE { Declarator () (getSpan $1) $1 ScalarDecl Nothing Nothing }
 
 -- Here the procedure should be either a function or subroutine name, but
 -- since they are syntactically identical at this stage subroutine names

--- a/src/Language/Fortran/Parser/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fortran77.y
@@ -556,7 +556,7 @@ PARAMETER_ASSIGNMENTS :: { [ Declarator A0 ] }
 
 PARAMETER_ASSIGNMENT :: { Declarator A0 }
 : VARIABLE '=' CONSTANT_EXPRESSION
-  { Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator Nothing (Just $3) }
+  { Declarator () (getTransSpan $1 $3) $1 ScalarDecl Nothing (Just $3) }
 
 DECLARATION_STATEMENT :: { Statement A0 }
 : TYPE_SPEC maybe(',') INITIALIZED_DECLARATORS
@@ -631,7 +631,7 @@ POINTER_LIST :: { [ Declarator A0 ] }
 
 POINTER :: { Declarator A0 }
 : '(' VARIABLE ',' VARIABLE ')'
-  { Declarator () (getTransSpan $1 $5) $2 ScalarDeclarator Nothing (Just $4) }
+  { Declarator () (getTransSpan $1 $5) $2 ScalarDecl Nothing (Just $4) }
 
 COMMON_GROUPS :: { AList CommonGroup A0 }
 : COMMON_GROUPS COMMON_GROUP { setSpan (getTransSpan $1 $2) $ $2 `aCons` $1 }
@@ -664,17 +664,17 @@ UNINITIALIZED_DECLARATOR :: { Declarator A0 }
 
 UNINITIALIZED_ARRAY_DECLARATOR :: { Declarator A0 }
 : VARIABLE '(' DIMENSION_DECLARATORS ')'
-  { Declarator () (getTransSpan $1 $4) $1 (ArrayDeclarator (aReverse $3)) Nothing   Nothing }
+  { Declarator () (getTransSpan $1 $4) $1 (ArrayDecl (aReverse $3)) Nothing   Nothing }
 | VARIABLE '*' SIMPLE_EXPRESSION '(' DIMENSION_DECLARATORS ')'
-  { Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $5)) (Just $3) Nothing }
+  { Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $5)) (Just $3) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' SIMPLE_EXPRESSION
-  { Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $3)) (Just $6) Nothing }
+  { Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $3)) (Just $6) Nothing }
 
 UNINITIALIZED_VARIABLE_DECLARATOR :: { Declarator A0 }
 : VARIABLE
-  { Declarator () (getSpan $1)         $1 ScalarDeclarator Nothing   Nothing }
+  { Declarator () (getSpan $1)         $1 ScalarDecl Nothing   Nothing }
 | VARIABLE '*' SIMPLE_EXPRESSION
-  { Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator (Just $3) Nothing }
+  { Declarator () (getTransSpan $1 $3) $1 ScalarDecl (Just $3) Nothing }
 
 INITIALIZED_DECLARATORS :: { AList Declarator A0 }
 : INITIALIZED_DECLARATORS ',' INITIALIZED_DECLARATOR { setSpan (getTransSpan $1 $3) $ $3 `aCons` $1 }
@@ -692,21 +692,21 @@ INITIALIZED_ARRAY_DECLARATORS :: { AList Declarator A0 }
 INITIALIZED_ARRAY_DECLARATOR :: { Declarator A0 }
 : UNINITIALIZED_ARRAY_DECLARATOR { $1 }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '/' SIMPLE_EXPRESSION_LIST '/'
-  { Declarator () (getTransSpan $1 $7) $1 (ArrayDeclarator (aReverse $3))  Nothing
+  { Declarator () (getTransSpan $1 $7) $1 (ArrayDecl (aReverse $3))  Nothing
     (Just (ExpInitialisation () (getSpan $6) (fromReverseList $6))) }
 | VARIABLE '*' SIMPLE_EXPRESSION '(' DIMENSION_DECLARATORS ')' '/' SIMPLE_EXPRESSION_LIST '/'
-  { Declarator () (getTransSpan $1 $9) $1 (ArrayDeclarator (aReverse $5)) (Just $3)
+  { Declarator () (getTransSpan $1 $9) $1 (ArrayDecl (aReverse $5)) (Just $3)
     (Just (ExpInitialisation () (getSpan $8) (fromReverseList $8))) }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' SIMPLE_EXPRESSION '/' SIMPLE_EXPRESSION_LIST '/'
-  { Declarator () (getTransSpan $1 $9) $1 (ArrayDeclarator (aReverse $3)) (Just $6)
+  { Declarator () (getTransSpan $1 $9) $1 (ArrayDecl (aReverse $3)) (Just $6)
     (Just (ExpInitialisation () (getSpan $8) (fromReverseList $8))) }
 
 INITIALIZED_VARIABLE_DECLARATOR :: { Declarator A0 }
 : UNINITIALIZED_VARIABLE_DECLARATOR { $1 }
 | VARIABLE '/' SIMPLE_EXPRESSION '/'
-  { Declarator () (getTransSpan $1 $4) $1 ScalarDeclarator Nothing   (Just $3) }
+  { Declarator () (getTransSpan $1 $4) $1 ScalarDecl Nothing   (Just $3) }
 | VARIABLE '*' SIMPLE_EXPRESSION '/' SIMPLE_EXPRESSION '/'
-  { Declarator () (getTransSpan $1 $6) $1 ScalarDeclarator (Just $3) (Just $5) }
+  { Declarator () (getTransSpan $1 $6) $1 ScalarDecl (Just $3) (Just $5) }
 
 SIMPLE_EXPRESSION_LIST :: { [Expression A0] }
 : SIMPLE_EXPRESSION_LIST ',' SIMPLE_EXPRESSION  { $3 : $1 }

--- a/src/Language/Fortran/Parser/Fortran90.y
+++ b/src/Language/Fortran/Parser/Fortran90.y
@@ -826,7 +826,7 @@ PARAMETER_ASSIGNMENTS :: { [ Declarator A0 ] }
 
 PARAMETER_ASSIGNMENT :: { Declarator A0 }
 : VARIABLE '=' EXPRESSION
-  { Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator Nothing (Just $3) }
+  { Declarator () (getTransSpan $1 $3) $1 ScalarDecl Nothing (Just $3) }
 
 DECLARATION_STATEMENT :: { Statement A0 }
 : TYPE_SPEC ATTRIBUTE_LIST '::' INITIALIZED_DECLARATOR_LIST
@@ -900,22 +900,22 @@ INITIALIZED_DECLARATOR :: { Declarator A0 }
 
 DECLARATOR :: { Declarator A0 }
 : VARIABLE
-  {     Declarator () (getSpan $1)         $1 ScalarDeclarator                Nothing     Nothing }
+  {     Declarator () (getSpan $1)         $1 ScalarDecl                Nothing     Nothing }
 | VARIABLE '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator                (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $3) $1 ScalarDecl                (Just $3)   Nothing }
 | VARIABLE '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $4) ValStar
-     in Declarator () (getTransSpan $1 $5) $1 ScalarDeclarator                (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $5) $1 ScalarDecl                (Just star) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDeclarator (aReverse $3)) Nothing     Nothing }
+  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDecl (aReverse $3)) Nothing     Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $3)) (Just $6)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $3)) (Just $6)   Nothing }
 -- nonstandard char array syntax (wrong order for dimensions & charlen)
 | VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $5)) (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $5)) (Just $3)   Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
-     in Declarator () (getTransSpan $1 $8) $1 (ArrayDeclarator (aReverse $3)) (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $8) $1 (ArrayDecl (aReverse $3)) (Just star) Nothing }
 
 DIMENSION_DECLARATORS :: { AList DimensionDeclarator A0 }
 : DIMENSION_DECLARATORS ',' DIMENSION_DECLARATOR

--- a/src/Language/Fortran/Parser/Fortran95.y
+++ b/src/Language/Fortran/Parser/Fortran95.y
@@ -841,7 +841,7 @@ PARAMETER_ASSIGNMENTS :: { [ Declarator A0 ] }
 
 PARAMETER_ASSIGNMENT :: { Declarator A0 }
 : VARIABLE '=' EXPRESSION
-  { Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator Nothing (Just $3) }
+  { Declarator () (getTransSpan $1 $3) $1 ScalarDecl Nothing (Just $3) }
 
 DECLARATION_STATEMENT :: { Statement A0 }
 : TYPE_SPEC ATTRIBUTE_LIST '::' INITIALIZED_DECLARATOR_LIST
@@ -917,22 +917,22 @@ INITIALIZED_DECLARATOR :: { Declarator A0 }
 
 DECLARATOR :: { Declarator A0 }
 : VARIABLE
-  {     Declarator () (getSpan $1)         $1 ScalarDeclarator                Nothing     Nothing }
+  {     Declarator () (getSpan $1)         $1 ScalarDecl                Nothing     Nothing }
 | VARIABLE '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $3) $1 ScalarDeclarator                (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $3) $1 ScalarDecl                (Just $3)   Nothing }
 | VARIABLE '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $4) ValStar
-     in Declarator () (getTransSpan $1 $5) $1 ScalarDeclarator                (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $5) $1 ScalarDecl                (Just star) Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDeclarator (aReverse $3)) Nothing     Nothing }
+  {     Declarator () (getTransSpan $1 $4) $1 (ArrayDecl (aReverse $3)) Nothing     Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' EXPRESSION
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $3)) (Just $6)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $3)) (Just $6)   Nothing }
 -- nonstandard char array syntax (wrong order for dimensions & charlen)
 | VARIABLE '*' EXPRESSION '(' DIMENSION_DECLARATORS ')'
-  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDeclarator (aReverse $5)) (Just $3)   Nothing }
+  {     Declarator () (getTransSpan $1 $6) $1 (ArrayDecl (aReverse $5)) (Just $3)   Nothing }
 | VARIABLE '(' DIMENSION_DECLARATORS ')' '*' '(' '*' ')'
   { let star = ExpValue () (getSpan $7) ValStar
-     in Declarator () (getTransSpan $1 $8) $1 (ArrayDeclarator (aReverse $3)) (Just star) Nothing }
+     in Declarator () (getTransSpan $1 $8) $1 (ArrayDecl (aReverse $3)) (Just star) Nothing }
 
 DIMENSION_DECLARATORS :: { AList DimensionDeclarator A0 }
 : DIMENSION_DECLARATORS ',' DIMENSION_DECLARATOR

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -995,13 +995,13 @@ instance IndentablePretty (UnionMap a) where
     "end map"
 
 instance Pretty (Declarator a) where
-    pprint' v (Declarator _ _ e ScalarDeclarator mLen mInit)
+    pprint' v (Declarator _ _ e ScalarDecl mLen mInit)
       | v >= Fortran90 =
         pprint' v e <>
         char '*' <?> pprint' v mLen <+>
         char '=' <?+> pprint' v mInit
 
-    pprint' v (Declarator _ _ e ScalarDeclarator mLen mInit)
+    pprint' v (Declarator _ _ e ScalarDecl mLen mInit)
       | v >= Fortran77 =
         case mInit of
           Nothing -> pprint' v e <>
@@ -1010,19 +1010,19 @@ instance Pretty (Declarator a) where
                        char '*' <?> pprint' v mLen <>
                        char '/' <> pprint' v initial <> char '/'
 
-    pprint' v (Declarator _ _ e ScalarDeclarator mLen mInit)
+    pprint' v (Declarator _ _ e ScalarDecl mLen mInit)
       | Nothing <- mLen
       , Nothing <- mInit = pprint' v e
       | Just _ <- mInit = tooOld v "Variable initialisation" Fortran90
       | Just _ <- mLen = tooOld v "Variable width" Fortran77
 
-    pprint' v (Declarator _ _ e (ArrayDeclarator dims) mLen mInit)
+    pprint' v (Declarator _ _ e (ArrayDecl dims) mLen mInit)
       | v >= Fortran90 =
         pprint' v e <> parens (pprint' v dims) <+>
         "*" <?> pprint' v mLen <+>
         equals <?> pprint' v mInit
 
-    pprint' v (Declarator _ _ e (ArrayDeclarator dims) mLen mInit)
+    pprint' v (Declarator _ _ e (ArrayDecl dims) mLen mInit)
       | v >= Fortran77 =
         case mInit of
           Nothing -> pprint' v e <> parens (pprint' v dims) <>
@@ -1035,7 +1035,7 @@ instance Pretty (Declarator a) where
             in pprint' v e <> parens (pprint' v dims) <>
                "*" <?> pprint' v mLen <> initDoc
 
-    pprint' v (Declarator _ _ e (ArrayDeclarator dims) mLen mInit)
+    pprint' v (Declarator _ _ e (ArrayDecl dims) mLen mInit)
       | Nothing <- mLen
       , Nothing <- mInit = pprint' v e <> parens (pprint' v dims)
       | Just _ <- mInit = tooOld v "Variable initialisation" Fortran90

--- a/src/Language/Fortran/Util/ModFile.hs
+++ b/src/Language/Fortran/Util/ModFile.hs
@@ -297,12 +297,12 @@ extractParamVarMap pf = M.fromList cvm
           | F.PUModule _ _ _ bs _                             <- universeBi pf' :: [F.ProgramUnit (FA.Analysis a)]
           , st@(F.StDeclaration _ _ (F.TypeSpec _ _ _ _) _ _) <- universeBi bs  :: [F.Statement (FA.Analysis a)]
           , F.AttrParameter _ _                               <- universeBi st  :: [F.Attribute (FA.Analysis a)]
-          , (F.Declarator _ _ v F.ScalarDeclarator _ _)       <- universeBi st  :: [F.Declarator (FA.Analysis a)]
+          , (F.Declarator _ _ v F.ScalarDecl _ _)       <- universeBi st  :: [F.Declarator (FA.Analysis a)]
           , Just con                                          <- [FA.constExp (F.getAnnotation v)] ] ++
           [ (FA.varName v, con)
           | F.PUModule _ _ _ bs _                             <- universeBi pf' :: [F.ProgramUnit (FA.Analysis a)]
           , st@F.StParameter {}                               <- universeBi bs  :: [F.Statement (FA.Analysis a)]
-          , (F.Declarator _ _ v F.ScalarDeclarator _ _)       <- universeBi st  :: [F.Declarator (FA.Analysis a)]
+          , (F.Declarator _ _ v F.ScalarDecl _ _)       <- universeBi st  :: [F.Declarator (FA.Analysis a)]
           , Just con                                          <- [FA.constExp (F.getAnnotation v)] ]
 
 -- | Status of mod-file compared to Fortran file.

--- a/test/Language/Fortran/Analysis/RenamingSpec.hs
+++ b/test/Language/Fortran/Analysis/RenamingSpec.hs
@@ -156,11 +156,11 @@ ex2pu1bs :: [Block ()]
 ex2pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "a"
-      , Declarator () u (varGen "b") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
+      , Declarator () u (varGen "b") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
       , declVarGen "c"
       , declVarGen "d" ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "a") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "a") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StExpressionAssign () u
       (ExpSubscript () u (varGen "a") (AList () u [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
@@ -178,11 +178,11 @@ ex3pu1bs :: [Block ()]
 ex3pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "a"
-      , Declarator () u (varGen "b") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
+      , Declarator () u (varGen "b") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
       , declVarGen "c"
       , declVarGen "d" ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "a") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "a") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "c" ]))
   , BlStatement () u Nothing (StExpressionAssign () u

--- a/test/Language/Fortran/Analysis/TypesSpec.hs
+++ b/test/Language/Fortran/Analysis/TypesSpec.hs
@@ -237,7 +237,7 @@ ex4pu1bs =
       (AList () u
         [ declVarGen "x"
         , Declarator () u (varGen "y")
-            (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ])) Nothing Nothing ]))
+            (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeCharacter Nothing) Nothing
       (AList () u [ declVarGen "c" ]))
   , BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeLogical Nothing) Nothing
@@ -271,10 +271,10 @@ ex6pu1bs :: [Block ()]
 ex6pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "a"
-      , Declarator () u (varGen "b") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
+      , Declarator () u (varGen "b") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
       , declVarGen "c" ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "a") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1 ) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "a") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1 ) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StExpressionAssign () u
       (ExpSubscript () u (varGen "a") (fromList () [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u

--- a/test/Language/Fortran/Parser/Fortran66Spec.hs
+++ b/test/Language/Fortran/Parser/Fortran66Spec.hs
@@ -136,9 +136,9 @@ spec =
 
       it "parses 'integer i, j(2,2), k'" $ do
         let dimDecls = replicate 2 $ DimensionDeclarator () u Nothing (Just $ intGen 2)
-            declarators = [ Declarator () u (varGen "i") ScalarDeclarator Nothing Nothing
-                          , Declarator () u (varGen "j") (ArrayDeclarator (AList () u dimDecls)) Nothing Nothing
-                          , Declarator () u (varGen "k") ScalarDeclarator Nothing Nothing ]
+            declarators = [ Declarator () u (varGen "i") ScalarDecl Nothing Nothing
+                          , Declarator () u (varGen "j") (ArrayDecl (AList () u dimDecls)) Nothing Nothing
+                          , Declarator () u (varGen "k") ScalarDecl Nothing Nothing ]
             st = StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing $ AList () u declarators
         sParser "      integer i, j(2,2), k" `shouldBe'` st
 

--- a/test/Language/Fortran/Parser/Fortran77/IncludeSpec.hs
+++ b/test/Language/Fortran/Parser/Fortran77/IncludeSpec.hs
@@ -42,7 +42,7 @@ spec =
 
         pu = PUMain () puSpan (Just name) blocks Nothing
         blocks = [bl1]
-        decl = Declarator () blockSpan (varGen' "a") ScalarDeclarator Nothing Nothing
+        decl = Declarator () blockSpan (varGen' "a") ScalarDecl Nothing Nothing
         typeSpec = TypeSpec () typeSpan TypeInteger Nothing
         st2 = StDeclaration () st2Span typeSpec Nothing (AList () blockSpan [decl])
         bl1 = BlStatement () st1Span Nothing st1

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -120,8 +120,8 @@ spec =
           let typeSpec = TypeSpec () u TypeCharacter (Just sel)
           let attrs = [ AttrIntent () u In , AttrPointer () u ]
           let declList =
-                [ Declarator () u (varGen "x") ScalarDeclarator Nothing (Just $ intGen 42)
-                , Declarator () u (varGen "y") ScalarDeclarator (Just $ intGen 3) Nothing ]
+                [ Declarator () u (varGen "x") ScalarDecl Nothing (Just $ intGen 42)
+                , Declarator () u (varGen "y") ScalarDecl (Just $ intGen 3) Nothing ]
           let st = StDeclaration () u typeSpec
                                       (Just $ AList () u attrs)
                                       (AList () u declList)
@@ -132,7 +132,7 @@ spec =
           let typeSpec = TypeSpec () u TypeInteger Nothing
           let dds = [ DimensionDeclarator () u Nothing (Just $ intGen 5) ]
           let declList =
-                [ Declarator () u (varGen "x") (ArrayDeclarator (AList () u dds)) Nothing
+                [ Declarator () u (varGen "x") (ArrayDecl (AList () u dds)) Nothing
                             (Just . initGen $ map intGen [1..5])
                 ]
           let st = StDeclaration () u typeSpec Nothing (AList () u declList)
@@ -173,8 +173,8 @@ spec =
 
       describe "Parameter" $
         it "prints vanilla statement" $ do
-          let decls = [ Declarator () u (varGen "x") ScalarDeclarator Nothing (Just $ intGen 42)
-                      , Declarator () u (varGen "y") ScalarDeclarator Nothing (Just $ intGen 24)
+          let decls = [ Declarator () u (varGen "x") ScalarDecl Nothing (Just $ intGen 42)
+                      , Declarator () u (varGen "y") ScalarDecl Nothing (Just $ intGen 24)
                       ]
           let st = StParameter () u (AList () u decls)
           pprint Fortran90 st Nothing `shouldBe` "parameter (x = 42, y = 24)"

--- a/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
+++ b/test/Language/Fortran/Transformation/Disambiguation/FunctionSpec.hs
@@ -60,10 +60,10 @@ ex1pu1bs :: [Block ()]
 ex1pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "a"
-      , Declarator () u (varGen "b") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
+      , Declarator () u (varGen "b") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
       , declVarGen "c" ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "a") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "a") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StExpressionAssign () u
       (ExpSubscript () u (varGen "a") (AList () u [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
@@ -83,10 +83,10 @@ expectedEx1pu1bs :: [Block ()]
 expectedEx1pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
       [ declVarGen "a"
-      , Declarator () u (varGen "b") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
+      , Declarator () u (varGen "b") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing
       , declVarGen "c" ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "a") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "a") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 1) ])) Nothing Nothing ]))
   , BlStatement () u Nothing (StExpressionAssign () u
       (ExpSubscript () u (varGen "a") (AList () u [ ixSinGen 1 ])) (intGen 1))
   , BlStatement () u Nothing (StExpressionAssign () u
@@ -273,7 +273,7 @@ ex6pu1bs =
       [ declVarGen "a"
       ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "f") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "f") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10) ])) Nothing Nothing ]))
   , BlStatement () u Nothing
       (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
 
@@ -285,9 +285,9 @@ expectedEx6pu1 = PUMain () u (Just "main") expectedEx6pu1bs Nothing
 expectedEx6pu1bs :: [Block ()]
 expectedEx6pu1bs =
   [ BlStatement () u Nothing (StDeclaration () u (TypeSpec () u TypeInteger Nothing) Nothing (AList () u
-      [ Declarator () u (varGen "a") ScalarDeclarator Nothing Nothing ]))
+      [ Declarator () u (varGen "a") ScalarDecl Nothing Nothing ]))
   , BlStatement () u Nothing (StDimension () u (AList () u
-      [ Declarator () u (varGen "f") (ArrayDeclarator (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10 ) ])) Nothing Nothing ]))
+      [ Declarator () u (varGen "f") (ArrayDecl (AList () u [ DimensionDeclarator () u Nothing (Just $ intGen 10 ) ])) Nothing Nothing ]))
   , BlStatement () u Nothing
       (StExpressionAssign () u (varGen "a") (ExpSubscript () u (varGen "f") (AList () u [ ixSinGen 1 ]))) ]
 

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -37,7 +37,7 @@ varGen :: String -> Expression ()
 varGen str = ExpValue () u $ ValVariable str
 
 declVarGen :: String -> Declarator ()
-declVarGen str = Declarator () u (varGen str) ScalarDeclarator Nothing Nothing
+declVarGen str = Declarator () u (varGen str) ScalarDecl Nothing Nothing
 
 intGen :: Integer -> Expression ()
 intGen i = ExpValue () u $ ValInteger (show i) Nothing
@@ -64,10 +64,10 @@ assVal :: Expression ()
 assVal = ExpValue () u ValAssignment
 
 declVariable :: a -> SrcSpan -> Expression a -> Maybe (Expression a) -> Maybe (Expression a) -> Declarator a
-declVariable a ss v mLen mVal = Declarator a ss v ScalarDeclarator mLen mVal
+declVariable a ss v mLen mVal = Declarator a ss v ScalarDecl mLen mVal
 
 declArray :: a -> SrcSpan -> Expression a -> AList DimensionDeclarator a -> Maybe (Expression a) -> Maybe (Expression a) -> Declarator a
-declArray a ss v dims mLen mVal = Declarator a ss v (ArrayDeclarator dims) mLen mVal
+declArray a ss v dims mLen mVal = Declarator a ss v (ArrayDecl dims) mLen mVal
 
 ixSinGen :: Integer -> Index ()
 ixSinGen i = IxSingle () u Nothing (intGen i)


### PR DESCRIPTION
Quickly disagreed with my naming scheme once I had used them a bit. "declarator" is an annoying word, "decl" isn't ambiguous and the type name remains the same (just shortening the constructors).