### PR TITLE
fix kind param parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Unreleased
+  * Fix parsing kind parameters like `a_1` on literals. Previously, that would
+    be parsed as a kind parameter on a kind parameter. Now we don't do that,
+    following gfortran's behaviour.
+    * Kind parameter representation is changed to explicitly say if it's an
+      integer kind or named constant kind, rather than reusing `Expression`.
+
 ### 0.9.0 (Feb 14, 2022)
   * Restructure parsing-related modules for code deduplication and better user
     experience.

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -35,6 +35,7 @@ module Language.Fortran.AST
   , Expression(..)
   , Index(..)
   , Value(..)
+  , KindParam(..)
   , UnaryOp(..)
   , BinaryOp(..)
 
@@ -618,9 +619,9 @@ data Index a =
 
 -- All recursive Values
 data Value a
-  = ValInteger           String (Maybe (Expression a))
+  = ValInteger           String (Maybe (KindParam a))
   -- ^ The string representation of an integer literal
-  | ValReal              RealLit (Maybe (Expression a))
+  | ValReal              RealLit (Maybe (KindParam a))
   -- ^ The string representation of a real literal
   | ValComplex           (Expression a) (Expression a)
   -- ^ The real and imaginary parts of a complex value
@@ -634,7 +635,7 @@ data Value a
   -- ^ The name of a variable
   | ValIntrinsic         Name
   -- ^ The name of a built-in function
-  | ValLogical           Bool (Maybe (Expression a))
+  | ValLogical           Bool (Maybe (KindParam a))
   -- ^ A boolean value
   | ValOperator          String
   -- ^ User-defined operators in interfaces
@@ -644,6 +645,12 @@ data Value a
   | ValStar
   | ValColon                   -- see R402 / C403 in Fortran2003 spec.
   deriving (Eq, Show, Data, Typeable, Generic, Functor)
+
+data KindParam a
+  = KindParamInt a SrcSpan String -- ^ @[0-9]+@
+  | KindParamVar a SrcSpan Name   -- ^ @[a-z][a-z0-9]+@ (case insensitive)
+    deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
+    deriving anyclass (NFData, Out)
 
 -- | Declarators. R505 entity-decl from F90 ISO spec.
 --

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -297,14 +297,14 @@ annotateProgramUnit pu                        = return pu
 --
 -- Logic taken from HP's F90 reference pg.33, written to gfortran's behaviour.
 -- Stays in the 'Infer' monad so it can report type errors
-deriveRealLiteralKind :: SrcSpan -> RealLit -> Maybe (Expression a) -> Infer Kind
+deriveRealLiteralKind :: SrcSpan -> RealLit -> Maybe (KindParam a) -> Infer Kind
 deriveRealLiteralKind ss r mkp =
     case mkp of
       Nothing -> case exponentLetter (realLitExponent r) of
                    ExpLetterE -> return  4
                    ExpLetterD -> return  8
                    ExpLetterQ -> return 16
-      Just _ {- kp -} -> case exponentLetter (realLitExponent r) of
+      Just _kp -> case exponentLetter (realLitExponent r) of
                    ExpLetterE -> return 0 -- TODO return k
                    _          -> do
                      -- badly formed literal, but we'll allow and use the

--- a/src/Language/Fortran/Parser/Free/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Free/Fortran2003.y
@@ -1403,9 +1403,12 @@ LOGICAL_LITERAL :: { Expression A0 }
   { let TLogicalLiteral s b = $1
      in ExpValue () s (ValLogical b (Just $3)) }
 
-KIND_PARAM :: { Expression A0 }
-: INTEGER_LITERAL { $1 }
-| VARIABLE        { $1 }
+KIND_PARAM :: { KindParam A0 }
+: INTEGER_LITERAL_PLAIN { let (i, ss)                        = $1 in KindParamInt () ss i }
+| VARIABLE              { let ExpValue () ss (ValVariable v) = $1 in KindParamVar () ss v }
+
+INTEGER_LITERAL_PLAIN :: { (String, SrcSpan) }
+: int { let TIntegerLiteral s i = $1 in (i, s) }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/Parser/Free/Fortran90.y
+++ b/src/Language/Fortran/Parser/Free/Fortran90.y
@@ -1147,9 +1147,12 @@ LOGICAL_LITERAL :: { Expression A0 }
   { let TLogicalLiteral s b = $1
      in ExpValue () s (ValLogical b (Just $3)) }
 
-KIND_PARAM :: { Expression A0 }
-: INTEGER_LITERAL { $1 }
-| VARIABLE        { $1 }
+KIND_PARAM :: { KindParam A0 }
+: INTEGER_LITERAL_PLAIN { let (i, ss)                        = $1 in KindParamInt () ss i }
+| VARIABLE              { let ExpValue () ss (ValVariable v) = $1 in KindParamVar () ss v }
+
+INTEGER_LITERAL_PLAIN :: { (String, SrcSpan) }
+: int { let TIntegerLiteral s i = $1 in (i, s) }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/Parser/Free/Fortran95.y
+++ b/src/Language/Fortran/Parser/Free/Fortran95.y
@@ -1217,9 +1217,12 @@ LOGICAL_LITERAL :: { Expression A0 }
   { let TLogicalLiteral s b = $1
      in ExpValue () s (ValLogical b (Just $3)) }
 
-KIND_PARAM :: { Expression A0 }
-: INTEGER_LITERAL { $1 }
-| VARIABLE        { $1 }
+KIND_PARAM :: { KindParam A0 }
+: INTEGER_LITERAL_PLAIN { let (i, ss)                        = $1 in KindParamInt () ss i }
+| VARIABLE              { let ExpValue () ss (ValVariable v) = $1 in KindParamVar () ss v }
+
+INTEGER_LITERAL_PLAIN :: { (String, SrcSpan) }
+: int { let TIntegerLiteral s i = $1 in (i, s) }
 
 STRING :: { Expression A0 }
 : string { let TString s c = $1 in ExpValue () s $ ValString c }

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -969,18 +969,17 @@ instance Pretty (Value a) where
       | otherwise = tooOld v "Operator" Fortran90
     pprint' v (ValComplex e1 e2) = parens $ commaSep [pprint' v e1, pprint' v e2]
     pprint' _ (ValString str) = quotes $ text str
-    pprint' v (ValLogical b kp) = text litStr <> kpPretty v kp
+    pprint' v (ValLogical b kp) = text litStr <> pprint' v kp
       where litStr = if b then ".true." else ".false."
-    pprint' v (ValInteger i kp) = text i <> kpPretty v kp
-    pprint' v (ValReal r kp) = text (prettyHsRealLit r) <> kpPretty v kp
+    pprint' v (ValInteger i kp) = text i <> pprint' v kp
+    pprint' v (ValReal r kp) = text (prettyHsRealLit r) <> pprint' v kp
     pprint' _ (ValBoz b) = text $ prettyBoz b
     pprint' _ valLit = text . getFirstParameter $ valLit
 
--- | Helper for pretty printing an optional kind parameter 'Expression'.
-kpPretty :: FortranVersion -> Maybe (Expression a) -> Doc
-kpPretty v = \case
-  Nothing -> empty
-  Just kp -> text "_" <> pprint' v kp
+instance Pretty (KindParam a) where
+    pprint' _ kp = text "_" <> text kp'
+      where kp' = case kp of KindParamInt _ _ i -> i
+                             KindParamVar _ _ v -> v
 
 instance IndentablePretty (StructureItem a) where
   pprint v (StructFields a s spec mAttrs decls) _ = pprint' v (StDeclaration a s spec mAttrs decls)

--- a/test/Language/Fortran/Parser/Free/Common.hs
+++ b/test/Language/Fortran/Parser/Free/Common.hs
@@ -23,7 +23,7 @@ specFreeCommon sParser eParser =
           eParser ".true." `shouldBe'` valTrue
 
         it "parses logical literal with kind parameter" $ do
-          let kp = ExpValue () u (ValVariable "kind")
+          let kp = KindParamVar () u "kind"
           eParser ".false._kind" `shouldBe'` valFalse' kp
 
         it "parses mixed-case logical literal" $ do
@@ -35,10 +35,26 @@ specFreeCommon sParser eParser =
         let realLitExp r mkp = ExpValue () u (ValReal (parseRealLit r) mkp)
         it "parses various REAL literals" $ do
           eParser "1."      `shouldBe'` realLitExp "1."    Nothing
-          eParser ".1e20_8" `shouldBe'` realLitExp ".1e20" (Just (intGen 8))
+          eParser ".1e20_8" `shouldBe'` realLitExp ".1e20" (Just (KindParamInt () u "8"))
 
         it "parses \"negative\" real literal (unary op)" $ do
-          eParser "-1.0d-1_k8" `shouldBe'` ExpUnary () u Minus (realLitExp "1.0d-1" (Just (varGen "k8")))
+          let lit = "-1.0d-1_k8"
+              kp  = KindParamVar () u "k8"
+           in eParser lit `shouldBe'` ExpUnary () u Minus (realLitExp "1.0d-1" (Just kp))
+
+      describe "Kind parameters" $ do
+        it "parses var kind parameter with underscore" $ do
+          let lit = "123_a_1"
+              kp  = KindParamVar () u "a_1"
+           in eParser lit `shouldBe'` ExpValue () u (ValInteger "123" (Just kp))
+
+        it "fails to parse invalid kind parameter with underscore after numeric" $ do
+          -- TODO can't test here because we push parse errors into runtime ones
+          {-
+          let lit = "123_4_8"
+           in eParser lit `shouldBe'` undefined -- should be "last parsed was the 2nd underscore"
+          -}
+          pending
 
     describe "Statement" $ do
       describe "Declaration" $ do

--- a/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
@@ -135,13 +135,6 @@ spec =
         in fParser fStr `shouldBe'` expected
 
     describe "Expression" $ do
-      it "parses logical literal without kind parameter" $ do
-        eParser ".true." `shouldBe'` valTrue
-
-      it "parses logical literal with kind parameter" $ do
-        let kp = ExpValue () u (ValVariable "kind")
-        eParser ".false._kind" `shouldBe'` valFalse' kp
-
       it "parses array initialisation exp" $ do
         let list = AList () u [ intGen 1, intGen 2, intGen 3, intGen 4 ]
         eParser "(/ 1, 2, 3, 4 /)" `shouldBe'` ExpInitialisation () u list

--- a/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
@@ -152,13 +152,6 @@ spec =
         fParser fStr `shouldBe'` expected
 
     describe "Expression" $ do
-      it "parses logical literal without kind parameter" $ do
-        eParser ".true." `shouldBe'` valTrue
-
-      it "parses logical literal with kind parameter" $ do
-        let kp = ExpValue () u (ValVariable "kind")
-        eParser ".false._kind" `shouldBe'` valFalse' kp
-
       it "parses array initialisation exp" $ do
         let list = AList () u [ intGen 1, intGen 2, intGen 3, intGen 4 ]
         eParser "(/ 1, 2, 3, 4 /)" `shouldBe'` ExpInitialisation () u list

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -104,8 +104,8 @@ spec =
         pprint Fortran77 lit Nothing `shouldBe` ".true."
 
       it "prints logical literal with kind parameter (>=F90)" $ do
-        let lit    = ValLogical False (Just kpExpr)
-            kpExpr = intGen 8
+        let lit = ValLogical False (Just kp)
+            kp  = KindParamInt () u "8"
         pprint Fortran90 lit Nothing `shouldBe` ".false._8"
 
       it "prints BOZ constant with prefix" $ do

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -31,7 +31,7 @@ valTrue, valFalse :: Expression ()
 valTrue  = ExpValue () u $ ValLogical True  Nothing
 valFalse = ExpValue () u $ ValLogical False Nothing
 
-valTrue', valFalse' :: Expression () -> Expression ()
+valTrue', valFalse' :: KindParam () -> Expression ()
 valTrue'  kp = ExpValue () u $ ValLogical True  (Just kp)
 valFalse' kp = ExpValue () u $ ValLogical False (Just kp)
 

--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -1,4 +1,13 @@
 # fortran-src upgrade guide
+## Unreleased
+### Kind parameter change
+Necessitates changes, but is a new feature. Where relevant, replace
+
+  * `ExpValue _ _ (ValVariable v)`  with `KindParamVar _ _ v`, and
+  * `ExpValue _ _ (ValInteger i _)` with `KindParamInt _ _ i`
+
+and you should be good.
+
 ## Release 0.9.0
 ### Parser restructure
 ***Necessitates changes.***


### PR DESCRIPTION
`1234_2_8` would incorrectly "recursively" parse 2 kind parameters.
Instead, it should fail to compile. Similarly, `123_a_1` should parses 2
kind parameters, but should parse a single kind parameter name of `a_1`.
The issue is fixed by changing the representation for kind parameters,
and updating the parsers.