### PR TITLE
better restrict COMPLEX literal parsing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -104,7 +104,9 @@ main = do
       contents <- flexReadFile path
       mods <- decodeModFiles' $ includeDirs opts
       let version   = fromMaybe (deduceFortranVersion path) (fortranVersion opts)
-          parsedPF  = fromRight' $ (Parser.byVerWithMods mods version) path contents
+          parsedPF  = case (Parser.byVerWithMods mods version) path contents of
+                        Left  a -> error $ show a
+                        Right a -> a
           outfmt    = outputFormat opts
           mmap      = combinedModuleMap mods
           tenv      = combinedTypeEnv mods

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -87,6 +87,7 @@ library
       Language.Fortran.Parser.Free.Utils
       Language.Fortran.Parser.LexerUtils
       Language.Fortran.Parser.Monad
+      Language.Fortran.Parser.ParserUtils
       Language.Fortran.PrettyPrint
       Language.Fortran.Rewriter
       Language.Fortran.Rewriter.Internal

--- a/src/Language/Fortran/AST/RealLit.hs
+++ b/src/Language/Fortran/AST/RealLit.hs
@@ -10,6 +10,8 @@ that can be easily exported with full precision later. Things we do:
   * Make exponent explicit by adding the default exponent @E0@ if not present.
   * Make implicit zeroes explicit. @.123 -> 0.123@, @123. -> 123.0@. (Again,
     Haskell literals do not support this.)
+
+For example, the Fortran REAL literal @1D0@ will be parsed into @1.0D0@.
 -}
 
 {-# LANGUAGE RecordWildCards #-}

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -15,10 +15,12 @@ import Control.Monad
 import Control.Monad.State.Lazy hiding (fix)
 import Control.Monad.Writer hiding (fix)
 import Text.PrettyPrint.GenericPretty (pretty, Out)
+import Text.PrettyPrint               (render)
 import Language.Fortran.Analysis
 import Language.Fortran.AST hiding (setName)
 import Language.Fortran.AST.RealLit
 import Language.Fortran.Util.Position
+import Language.Fortran.PrettyPrint
 import qualified Data.Map as M
 import qualified Data.IntMap as IM
 import Data.Graph.Inductive
@@ -824,12 +826,12 @@ showLab a =
     Just (ExpValue _ _ (ValInteger l _)) -> ' ':l ++ replicate (5 - length l) ' '
     _ -> error "unhandled showLab"
 
-showValue :: Value a -> Name
+showValue :: Value a -> String
 showValue (ValVariable v)       = v
 showValue (ValIntrinsic v)      = v
 showValue (ValInteger v _)      = v
 showValue (ValReal v _)         = prettyHsRealLit v
-showValue (ValComplex e1 e2)    = "( " ++ showExpr e1 ++ " , " ++ showExpr e2 ++ " )"
+showValue v@ValComplex{}        = render $ pprint' undefined v
 showValue (ValString s)         = "\\\"" ++ escapeStr s ++ "\\\""
 showValue v                     = "<unhandled value: " ++ show (toConstr (fmap (const ()) v)) ++ ">"
 

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -273,9 +273,9 @@ annotateExpression e@(ExpValue _ _ (ValIntrinsic _))   = maybe e (`setIDType` e)
 annotateExpression e@(ExpValue _ ss (ValReal r mkp))        = do
     k <- deriveRealLiteralKind ss r mkp
     return $ setSemType (TReal k) e
-annotateExpression e@(ExpValue _ ss (ValComplex e1 e2)) = do
-    st <- complexLiteralType ss e1 e2
-    return $ setSemType st e
+annotateExpression e@(ExpValue _ _ (ValComplex _ss _cr _ci)) = do
+    -- TODO check F90 standard for complex lit typing rules (kind params)
+    return e
 annotateExpression e@(ExpValue _ _ ValInteger{})     =
     -- FIXME: in >F90, int lits can have kind info on end @_8@, same as real
     -- lits. We do parse this into the lit string, it is available to us.
@@ -312,15 +312,6 @@ deriveRealLiteralKind ss r mkp =
                      typeError ("only real literals with exponent letter 'e'"
                              <> "can specify explicit kind parameter") ss
                      return 0 -- TODO return k
-
--- | Get the type of a COMPLEX literal constant.
---
--- The kind is derived only from the first expression, the second is ignored.
-complexLiteralType :: SrcSpan -> Expression a -> Expression a -> Infer SemType
-complexLiteralType ss (ExpValue _ _ (ValReal r mkp)) _ = do
-    k1 <- deriveRealLiteralKind ss r mkp
-    return $ TComplex k1
-complexLiteralType _ _ _ = return $ deriveSemTypeFromBaseType TypeComplex
 
 binaryOpType :: Data a => SrcSpan -> BinaryOp -> Expression (Analysis a) -> Expression (Analysis a) -> Infer IDType
 binaryOpType ss op e1 e2 = do

--- a/src/Language/Fortran/Parser/Fixed/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran66.y
@@ -11,6 +11,7 @@ module Language.Fortran.Parser.Fixed.Fortran66
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
+import Language.Fortran.Parser.ParserUtils
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.Parser.Fixed.Utils
 import Language.Fortran.AST
@@ -434,7 +435,8 @@ SIGNED_NUMERIC_LITERAL :: { Expression A0 }
 | SIGNED_REAL_LITERAL    { $1 }
 
 COMPLEX_LITERAL :: { Expression A0 }
-:  '(' SIGNED_NUMERIC_LITERAL ',' SIGNED_NUMERIC_LITERAL ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
+: '(' SIGNED_NUMERIC_LITERAL ',' SIGNED_NUMERIC_LITERAL ')'
+  {% complexLit (getTransSpan $1 $5) $2 $4 }
 
 LOGICAL_LITERAL :: { Expression A0 }
 : bool { let TBool s b = $1 in ExpValue () s $ ValLogical b Nothing }

--- a/src/Language/Fortran/Parser/Fixed/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran77.y
@@ -12,6 +12,7 @@ module Language.Fortran.Parser.Fixed.Fortran77
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
+import Language.Fortran.Parser.ParserUtils
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.Parser.Fixed.Utils
 import Language.Fortran.AST
@@ -591,7 +592,8 @@ DATA_ITEM_LEVEL1 :: { Expression A0 }
 : SIGNED_NUMERIC_LITERAL  { $1 }
 -- | COMPLEX_LITERAL         { $1 }
 | VARIABLE                { $1 }
-| '(' SIGNED_NUMERIC_LITERAL ',' SIGNED_NUMERIC_LITERAL ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
+| '(' SIGNED_NUMERIC_LITERAL ',' SIGNED_NUMERIC_LITERAL ')'
+  {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL         { $1 }
 | STRING                  { $1 }
 | HOLLERITH               { $1 }
@@ -765,7 +767,7 @@ EXPRESSION :: { Expression A0 }
 | EXPRESSION RELATIONAL_OPERATOR EXPRESSION %prec RELATIONAL { ExpBinary () (getTransSpan $1 $3) $2 $1 $3 }
 | '(' EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL                   { $1 }
-| '(' EXPRESSION ',' EXPRESSION ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4) }
+| '(' EXPRESSION ',' EXPRESSION ')' {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL                   { $1 }
 | HOLLERITH                         { $1 }
 -- There should be FUNCTION_CALL here but as far as the parser is concerned it is same as SUBSCRIPT,
@@ -816,7 +818,8 @@ CONSTANT_EXPRESSION :: { Expression A0 }
 | CONSTANT_EXPRESSION RELATIONAL_OPERATOR CONSTANT_EXPRESSION %prec RELATIONAL { ExpBinary () (getTransSpan $1 $3) $2 $1 $3 }
 | '(' CONSTANT_EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL               { $1 }
-| '(' CONSTANT_EXPRESSION ',' CONSTANT_EXPRESSION ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
+| '(' CONSTANT_EXPRESSION ',' CONSTANT_EXPRESSION ')'
+  {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL               { $1 }
 | SUBSCRIPT                    { $1 }
 | HOLLERITH                    { $1 }
@@ -835,7 +838,8 @@ ARITHMETIC_CONSTANT_EXPRESSION :: { Expression A0 }
 | ARITHMETIC_SIGN ARITHMETIC_CONSTANT_EXPRESSION %prec NEGATION { ExpUnary () (getTransSpan (fst $1) $2) (snd $1) $2 }
 | '(' ARITHMETIC_CONSTANT_EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL               { $1 }
-| '(' ARITHMETIC_CONSTANT_EXPRESSION ',' ARITHMETIC_CONSTANT_EXPRESSION ')' { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4)}
+| '(' ARITHMETIC_CONSTANT_EXPRESSION ',' ARITHMETIC_CONSTANT_EXPRESSION ')'
+  {% complexLit (getTransSpan $1 $5) $2 $4 }
 | VARIABLE                     { $1 }
 | SUBSCRIPT                    { $1 }
 

--- a/src/Language/Fortran/Parser/Free/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Free/Fortran2003.y
@@ -12,6 +12,7 @@ module Language.Fortran.Parser.Free.Fortran2003
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
+import Language.Fortran.Parser.ParserUtils ( complexLit )
 import Language.Fortran.Parser.Free.Lexer
 import Language.Fortran.Parser.Free.Utils
 import Language.Fortran.AST
@@ -1228,8 +1229,7 @@ EXPRESSION :: { Expression A0 }
     in ExpBinary () (getTransSpan $1 $3) (BinCustom str) $1 $3 }
 | '(' EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL                   { $1 }
-| '(' EXPRESSION ',' EXPRESSION ')'
-  { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4) }
+| '(' EXPRESSION ',' EXPRESSION ')' {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL                   { $1 }
 | STRING                            { $1 }
 | DATA_REF                          { $1 }

--- a/src/Language/Fortran/Parser/Free/Fortran90.y
+++ b/src/Language/Fortran/Parser/Free/Fortran90.y
@@ -12,6 +12,7 @@ module Language.Fortran.Parser.Free.Fortran90
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
+import Language.Fortran.Parser.ParserUtils ( complexLit )
 import Language.Fortran.Parser.Free.Lexer
 import Language.Fortran.Parser.Free.Utils
 import Language.Fortran.AST
@@ -1020,8 +1021,7 @@ EXPRESSION :: { Expression A0 }
     in ExpBinary () (getTransSpan $1 $3) (BinCustom str) $1 $3 }
 | '(' EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL                   { $1 }
-| '(' EXPRESSION ',' EXPRESSION ')'
-  { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4) }
+| '(' EXPRESSION ',' EXPRESSION ')' {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL                   { $1 }
 | STRING                            { $1 }
 | DATA_REF                          { $1 }

--- a/src/Language/Fortran/Parser/Free/Fortran95.y
+++ b/src/Language/Fortran/Parser/Free/Fortran95.y
@@ -12,6 +12,7 @@ module Language.Fortran.Parser.Free.Fortran95
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
+import Language.Fortran.Parser.ParserUtils ( complexLit )
 import Language.Fortran.Parser.Free.Lexer
 import Language.Fortran.Parser.Free.Utils
 import Language.Fortran.AST
@@ -1035,8 +1036,7 @@ EXPRESSION :: { Expression A0 }
     in ExpBinary () (getTransSpan $1 $3) (BinCustom str) $1 $3 }
 | '(' EXPRESSION ')' { setSpan (getTransSpan $1 $3) $2 }
 | NUMERIC_LITERAL                   { $1 }
-| '(' EXPRESSION ',' EXPRESSION ')'
-  { ExpValue () (getTransSpan $1 $5) (ValComplex $2 $4) }
+| '(' EXPRESSION ',' EXPRESSION ')' {% complexLit (getTransSpan $1 $5) $2 $4 }
 | LOGICAL_LITERAL                   { $1 }
 | STRING                            { $1 }
 | DATA_REF                          { $1 }

--- a/src/Language/Fortran/Parser/ParserUtils.hs
+++ b/src/Language/Fortran/Parser/ParserUtils.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE CPP #-}
+
+{-| Utils for various parsers (beyond token level).
+
+We can sometimes work around there being free-form and fixed-form versions of
+the @LexAction@ monad by requesting the underlying instances instances. We place
+such utilities that match that form here.
+
+-}
+module Language.Fortran.Parser.ParserUtils where
+
+import Language.Fortran.AST
+import Language.Fortran.AST.RealLit
+import Language.Fortran.Util.Position
+
+#if !MIN_VERSION_base(4,13,0)
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+import Control.Monad.Fail ( MonadFail )
+#endif
+
+{- $complex-lit-parsing
+
+Complex literals use a potentially misleading tuple syntax. The things allowed
+in each part are highly restricted, where you might otherwise be used to writing
+expressions. The actual allowed forms (taken from the F90 standard and
+gfortran's behaviour) are specified by the structure, but parsing them
+unambiguously is a pain.
+
+We parse any @(expr, expr)@, then case on each expression to determine where it
+was in fact valid for a complex literal -- and if so, push it into a
+'ComplexPart' constructor. This may cause unexpected behaviour if more
+bracketing/tuple rules are added!
+-}
+
+-- | Try to validate an expression as a COMPLEX literal part.
+--
+-- $complex-lit-parsing
+exprToComplexLitPart :: MonadFail m => Expression a -> m (ComplexPart a)
+exprToComplexLitPart e =
+    case e' of
+      ExpValue a ss v ->
+        case v of
+          ValReal    r mkp ->
+            let r' = r { realLitSignificand = sign <> realLitSignificand r }
+             in return $ ComplexPartReal a ss r' mkp
+          ValInteger i mkp -> return $ ComplexPartInt a ss (sign<>i) mkp
+          _                -> fail $ "Invalid COMPLEX literal @ " <> show ss
+      _ -> fail $ "Invalid COMPLEX literal @ " <> show (getSpan e')
+  where
+    (sign, e') = case e of ExpUnary _ _ Minus e'' -> ("-", e'')
+                           ExpUnary _ _ Plus  e'' -> ("", e'')
+                           _                      -> ("", e)
+
+-- | Helper for forming COMPLEX literals.
+complexLit
+    :: MonadFail m => SrcSpan -> Expression A0 -> Expression A0
+    -> m (Expression A0)
+complexLit ss e1 e2 = do
+    compReal <- exprToComplexLitPart e1
+    compImag <- exprToComplexLitPart e2
+    return $ ExpValue () ss $ ValComplex ss compReal compImag

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -967,12 +967,12 @@ instance Pretty (Value a) where
       | v >= Fortran90 = "operator" <+> parens (text op)
       -- TODO better error message is needed. Operator is too vague.
       | otherwise = tooOld v "Operator" Fortran90
-    pprint' v (ValComplex e1 e2) = parens $ commaSep [pprint' v e1, pprint' v e2]
+    pprint' v (ValComplex _ e1 e2) = parens $ commaSep [pprint' v e1, pprint' v e2]
     pprint' _ (ValString str) = quotes $ text str
-    pprint' v (ValLogical b kp) = text litStr <> pprint' v kp
+    pprint' v (ValLogical b mkp) = text litStr <> pprint' v mkp
       where litStr = if b then ".true." else ".false."
-    pprint' v (ValInteger i kp) = text i <> pprint' v kp
-    pprint' v (ValReal r kp) = text (prettyHsRealLit r) <> pprint' v kp
+    pprint' v (ValInteger i mkp) = text i <> pprint' v mkp
+    pprint' v (ValReal rl mkp) = text (prettyHsRealLit rl) <> pprint' v mkp
     pprint' _ (ValBoz b) = text $ prettyBoz b
     pprint' _ valLit = text . getFirstParameter $ valLit
 
@@ -980,6 +980,11 @@ instance Pretty (KindParam a) where
     pprint' _ kp = text "_" <> text kp'
       where kp' = case kp of KindParamInt _ _ i -> i
                              KindParamVar _ _ v -> v
+
+instance Pretty (ComplexPart a) where
+    pprint' v = \case
+      ComplexPartReal _ _ rl mkp -> pprint' v (ValReal    rl mkp)
+      ComplexPartInt  _ _ i  mkp -> pprint' v (ValInteger i  mkp)
 
 instance IndentablePretty (StructureItem a) where
   pprint v (StructFields a s spec mAttrs decls) _ = pprint' v (StDeclaration a s spec mAttrs decls)

--- a/test/Language/Fortran/Parser/Free/Common.hs
+++ b/test/Language/Fortran/Parser/Free/Common.hs
@@ -55,11 +55,25 @@ specFreeCommon sParser eParser =
           -}
           pending
 
+      -- Check various real/int literal forms and some kind parameters.
       describe "Complex" $ do
-        it "parses a basic complex literal" $ do
-          let cr = ComplexPartReal () u (parseRealLit "1.0")  Nothing
-              ci = ComplexPartReal () u (parseRealLit "-1.0") Nothing
-          eParser "(1.0, -1.0)" `shouldBe'` complexGen cr ci
+        let kp = Just . KindParamInt () u
+        it "parses a complex literal via positive reals" $ do
+          let cr = ComplexPartReal () u (parseRealLit "1.0E0") (kp "8")
+              ci = ComplexPartReal () u (parseRealLit "0.2E1") Nothing
+          eParser "(1.0E0_8, 0.2E1)" `shouldBe'` complexGen cr ci
+        it "parses a complex literal via positive mixed lits" $ do
+          let cr = ComplexPartInt  () u "1"                  Nothing
+              ci = ComplexPartReal () u (parseRealLit "2D0") Nothing
+          eParser "(1, 2D0)" `shouldBe'` complexGen cr ci
+        it "parses a complex literal via negative ints" $ do
+          let cr = ComplexPartInt  () u "-1" Nothing
+              ci = ComplexPartInt  () u "-2" Nothing
+          eParser "(-1, -2)" `shouldBe'` complexGen cr ci
+        it "parses a complex literal via mixed sign mixed lits with kind parameters" $ do
+          let cr = ComplexPartReal () u (parseRealLit "-1.2") (kp "8")
+              ci = ComplexPartInt  () u "0"                    Nothing
+          eParser "(-1.2_8, 0)" `shouldBe'` complexGen cr ci
 
     describe "Statement" $ do
       describe "Declaration" $ do

--- a/test/Language/Fortran/Parser/Free/Common.hs
+++ b/test/Language/Fortran/Parser/Free/Common.hs
@@ -49,12 +49,17 @@ specFreeCommon sParser eParser =
            in eParser lit `shouldBe'` ExpValue () u (ValInteger "123" (Just kp))
 
         it "fails to parse invalid kind parameter with underscore after numeric" $ do
-          -- TODO can't test here because we push parse errors into runtime ones
-          {-
+          {- TODO can't test here because we push parse errors into runtime ones
           let lit = "123_4_8"
-           in eParser lit `shouldBe'` undefined -- should be "last parsed was the 2nd underscore"
+           in eParser lit `shouldBe'` undefined -- should error "last parsed was the 2nd underscore"
           -}
           pending
+
+      describe "Complex" $ do
+        it "parses a basic complex literal" $ do
+          let cr = ComplexPartReal () u (parseRealLit "1.0")  Nothing
+              ci = ComplexPartReal () u (parseRealLit "-1.0") Nothing
+          eParser "(1.0, -1.0)" `shouldBe'` complexGen cr ci
 
     describe "Statement" $ do
       describe "Declaration" $ do

--- a/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
@@ -7,6 +7,7 @@ import TestUtil
 import Language.Fortran.Parser.Free.Common
 
 import Language.Fortran.AST
+import Language.Fortran.AST.RealLit ( parseRealLit )
 import Language.Fortran.Version
 import Language.Fortran.Parser
 import Language.Fortran.Parser.Monad ( Parse )
@@ -210,7 +211,8 @@ spec =
 
       it "parses declaration with initialisation" $
         let typeSpec = TypeSpec () u TypeComplex Nothing
-            init' = ExpValue () u (ValComplex (intGen 24) (realGen (42.0::Double)))
+            init' = complexGen (ComplexPartInt () u "24" Nothing)
+                               (ComplexPartReal () u (parseRealLit "42.0") Nothing)
             declarators = AList () u
               [ declVariable () u (varGen "x") Nothing (Just init') ]
             expected = StDeclaration () u typeSpec Nothing declarators

--- a/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
@@ -7,6 +7,7 @@ import TestUtil
 import Language.Fortran.Parser.Free.Common
 
 import Language.Fortran.AST
+import Language.Fortran.AST.RealLit ( parseRealLit )
 import Language.Fortran.Version
 import Language.Fortran.Parser
 import Language.Fortran.Parser.Monad ( Parse )
@@ -233,7 +234,8 @@ spec =
 
       it "parses declaration with initialisation" $ do
         let typeSpec = TypeSpec () u TypeComplex Nothing
-            init' = ExpValue () u (ValComplex (intGen 24) (realGen (42.0::Double)))
+            init' = complexGen (ComplexPartInt () u "24" Nothing)
+                               (ComplexPartReal () u (parseRealLit "42.0") Nothing)
             declarators = AList () u
               [ declVariable () u (varGen "x") Nothing (Just init') ]
             expected = StDeclaration () u typeSpec Nothing declarators

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -53,6 +53,9 @@ initGen es = ExpInitialisation () u $ fromList () es
 realGen :: (Fractional a, Show a) => a -> Expression ()
 realGen i = ExpValue () u $ ValReal (parseRealLit (show i)) Nothing
 
+complexGen :: ComplexPart () -> ComplexPart () -> Expression ()
+complexGen cr ci = ExpValue () u $ ValComplex u cr ci
+
 strGen :: String -> Expression ()
 strGen str = ExpValue () u $ ValString str
 


### PR DESCRIPTION
COMPLEX literals were previously stored as `ValComplex (Expression a) (Expression a)` and parsed similarly, like an expression tuple. The F90 and F77 standards both state the constituent parts are literals, with F77 allowing reals only and F90 allowing both integer and real literals (and apparently performing delayed casting). This change reflects the F90 form in the constructor in every parser. Should make it easier to use COMPLEX values.