### PR TITLE
put some syntactic info in BOZ record type

### DIFF
--- a/src/Language/Fortran/AST/Boz.hs
+++ b/src/Language/Fortran/AST/Boz.hs
@@ -13,6 +13,12 @@ bitstring "B" of BOZ, and only implement functions on that. For simple uses
 may be more sensible in the future. For now, you may retrieve a bitstring by
 converting to a numeric type and using something like 'showIntAtBase', or a
 'Bits' instance.
+
+This type carries _some_ syntactic information that doesn't change meaning. The
+expectation is that most users won't want to inspect 'Boz' values, usually just
+convert them, so we do it for convenience for checking syntax conformance. Note
+that not all info is retained -- which of single or double quotes were used is
+not recorded, for example.
 -}
 
 module Language.Fortran.AST.Boz where
@@ -36,47 +42,56 @@ import qualified Numeric   as Num
 data Boz = Boz
   { bozPrefix :: BozPrefix
   , bozString :: String
+
+  , bozPrefixWasPostfix :: Conforming
+  -- ^ Was the prefix actually postfix i.e. @'123'z@? This is non-standard
+  --   syntax, disabled by default in gfortran. Syntactic info.
   } deriving stock    (Eq, Show, Generic, Data, Typeable, Ord)
     deriving anyclass (NFData, Out)
 
 data BozPrefix
-  = BozPrefixB  -- ^ binary (bitstring)
-  | BozPrefixO  -- ^ octal
-  | BozPrefixZ  -- ^ hex (also with prefix @x@)
+  = BozPrefixB              -- ^ binary (bitstring)
+  | BozPrefixO              -- ^ octal
+  | BozPrefixZ Conforming   -- ^ hex, including nonstandard @x@
+    deriving stock    (Eq, Show, Generic, Data, Typeable, Ord)
+    deriving anyclass (NFData, Out)
+
+data Conforming = Conforming | Nonconforming
     deriving stock    (Eq, Show, Generic, Data, Typeable, Ord)
     deriving anyclass (NFData, Out)
 
 -- | UNSAFE. Parses a BOZ literal constant string.
 --
--- Looks for prefix or suffix. Strips the quotes from the string (single quotes
+-- Looks for prefix or postfix. Strips the quotes from the string (single quotes
 -- only).
 parseBoz :: String -> Boz
 parseBoz s =
     case List.uncons s of
       Nothing -> errInvalid
       Just (pc, ps) -> case parsePrefix pc of
-                         Just p -> Boz p (shave ps)
+                         Just p -> Boz p (shave ps) Conforming
                          Nothing -> case parsePrefix (List.last s) of
-                                      Just p -> Boz p (shave (init s))
+                                      Just p -> Boz p (shave (init s)) Nonconforming
                                       Nothing -> errInvalid
   where
     parsePrefix p
-      | p' == 'b'            = Just BozPrefixB
-      | p' == 'o'            = Just BozPrefixO
-      | p' `elem` ['z', 'x'] = Just BozPrefixZ
-      | otherwise            = Nothing
+      | p' == 'b' = Just $ BozPrefixB
+      | p' == 'o' = Just $ BozPrefixO
+      | p' == 'z' = Just $ BozPrefixZ Conforming
+      | p' == 'x' = Just $ BozPrefixZ Nonconforming
+      | otherwise = Nothing
       where p' = Char.toLower p
     errInvalid = error "Language.Fortran.AST.BOZ.parseBoz: invalid BOZ string"
     -- | Remove the first and last elements in a list.
     shave = tail . init
 
--- | Pretty print a BOZ constant. Uses prefix style, and @z@ over nonstandard
---   @x@ for hexadecimal.
+-- | Pretty print a BOZ constant. Uses prefix style (ignores the postfix field),
+--   and @z@ over nonstandard @x@ for hexadecimal.
 prettyBoz :: Boz -> String
 prettyBoz b = prettyBozPrefix (bozPrefix b) : '\'' : bozString b <> "'"
-  where prettyBozPrefix = \case BozPrefixB -> 'b'
-                                BozPrefixO -> 'o'
-                                BozPrefixZ -> 'z'
+  where prettyBozPrefix = \case BozPrefixB   -> 'b'
+                                BozPrefixO   -> 'o'
+                                BozPrefixZ{} -> 'z'
 
 -- | Resolve a BOZ constant as a natural (positive integer).
 --
@@ -85,13 +100,25 @@ prettyBoz b = prettyBozPrefix (bozPrefix b) : '\'' : bozString b <> "'"
 --
 -- We assume the 'Boz' is well-formed, thus don't bother with digit predicates.
 bozAsNatural :: (Num a, Eq a) => Boz -> a
-bozAsNatural (Boz pfx str) = runReadS $ parser str
+bozAsNatural (Boz pfx str _) = runReadS $ parser str
   where
     runReadS = fst . head
-    parser = case pfx of BozPrefixB -> Num.readInt 2 (const True) binDigitVal
+    parser = case pfx of BozPrefixB   -> Num.readInt 2 (const True) binDigitVal
                          -- (on GHC >=9.2, 'Num.readBin')
-                         BozPrefixO -> Num.readOct
-                         BozPrefixZ -> Num.readHex
+                         BozPrefixO   -> Num.readOct
+                         BozPrefixZ{} -> Num.readHex
     binDigitVal = \case '0' -> 0
                         '1' -> 1
                         _   -> error "Language.Fortran.AST.BOZ.bozAsNatural: invalid BOZ string"
+
+-- | Check if two 'Boz's are identical, ignoring differing syntax with no
+--   semantic meaning (nonconforming syntax). This doesn't test value equality:
+--   it tests that the prefix and strings each match.
+bozIdentical :: Boz -> Boz -> Bool
+bozIdentical b1 b2 =
+    bozPfxIdentical (bozPrefix b1) (bozPrefix b2) && bozString b1 == bozString b2
+  where bozPfxIdentical p1 p2 = case (p1, p2) of
+                                  (BozPrefixB,   BozPrefixB)   -> True
+                                  (BozPrefixO,   BozPrefixO)   -> True
+                                  (BozPrefixZ{}, BozPrefixZ{}) -> True
+                                  _                            -> False

--- a/test/Language/Fortran/AST/BozSpec.hs
+++ b/test/Language/Fortran/AST/BozSpec.hs
@@ -10,11 +10,17 @@ import Numeric.Natural ( Natural )
 spec :: Spec
 spec = do
   describe "BOZ literal constants" $ do
-    it "parses a prefix and suffix BOZ constant identically" $ do
-      parseBoz "z'123abc'" `shouldBe` parseBoz "'123abc'z"
+    it "parses single and double quotes identically" $ do
+      parseBoz "o'017'" `shouldBe` parseBoz "o\"017\""
+
+    it "parses postfix BOZ constant as explicitly nonconforming" $ do
+      parseBoz "'010'b" `shouldBe` Boz BozPrefixB "010" Nonconforming
+
+    it "parses a prefix and postfix BOZ constant identically" $ do
+      (parseBoz "z'123abc'" `bozIdentical` parseBoz "'123abc'z") `shouldBe` True
 
     it "parses nonstandard X as Z (hex)" $ do
-      parseBoz "x'09af'" `shouldBe` parseBoz "z'09af'"
+      (parseBoz "x'09af'" `bozIdentical` parseBoz "z'09af'") `shouldBe` True
 
     it "resolves a BOZ as a natural" $ do
       bozAsNatural @Natural (parseBoz "x'FF'") `shouldBe` 255

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -109,8 +109,17 @@ spec =
         pprint Fortran90 lit Nothing `shouldBe` ".false._8"
 
       it "prints BOZ constant with prefix" $ do
-        let lit = ValBoz $ Boz BozPrefixZ "123abc"
+        let lit = ValBoz $ Boz (BozPrefixZ Conforming) "123abc" Conforming
         pprint Fortran90 lit Nothing `shouldBe` "z'123abc'"
+
+      -- Note that we can't test printing nonconforming BOZs, because the
+      -- 'Boz.prettyBoz' that gets used in the 'Pretty' instance refuses to
+      -- pretty print nonconforming syntax.
+      {-
+      it "prints BOZ constant with nonconforming postfix" $ do
+        let lit = ValBoz $ Boz (BozPrefixZ Nonconforming) "123abc" Nonconforming
+        pprint Fortran90 lit Nothing `shouldBe` "'123abc'x"
+      -}
 
     describe "Statement" $ do
       describe "Declaration" $ do


### PR DESCRIPTION
Allows checking for syntax conformance. (It would be nice to do this
during parsing instead, but it would take much more work due to the code
generation nature of Alex and Happy.)