### PR TITLE
export BOZ as sized two's complement integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
     following gfortran's behaviour.
     * Kind parameter representation is changed to explicitly say if it's an
       integer kind or named constant kind, rather than reusing `Expression`.
-  * put some syntactic info in BOZ record type (to enable checking standards
-    conformance)
+  * BOZ literals
+    * add some syntactic info (to enable checking standards conformance)
+    * export `bozAsTwosComp` function for reading as two's complement integer
   * allow named constants in complex literals
   * document `FirstParameter`, `SecondParameter` behaviour/safety, fix erroneous
     instances

--- a/test/Language/Fortran/AST/Literal/BozSpec.hs
+++ b/test/Language/Fortran/AST/Literal/BozSpec.hs
@@ -6,6 +6,7 @@ import Test.Hspec
 
 import Language.Fortran.AST.Literal.Boz
 import Numeric.Natural ( Natural )
+import Data.Int ( Int8, Int16, Int32 )
 
 spec :: Spec
 spec = do
@@ -16,11 +17,32 @@ spec = do
     it "parses postfix BOZ constant as explicitly nonconforming" $ do
       parseBoz "'010'b" `shouldBe` Boz BozPrefixB "010" Nonconforming
 
-    it "parses a prefix and postfix BOZ constant identically" $ do
-      (parseBoz "z'123abc'" `bozIdentical` parseBoz "'123abc'z") `shouldBe` True
+    it "parses a prefix and postfix BOZ constant identically (ignoring conformance flags)" $ do
+      parseBoz "z'123abc'" `shouldBe` parseBoz "'123abc'z"
 
     it "parses nonstandard X as Z (hex)" $ do
-      (parseBoz "x'09af'" `bozIdentical` parseBoz "z'09af'") `shouldBe` True
+      parseBoz "x'09af'" `shouldBe` parseBoz "z'09af'"
 
     it "resolves a BOZ as a natural" $ do
+      bozAsNatural @Natural (parseBoz "x'00'") `shouldBe` 0
+      bozAsNatural @Natural (parseBoz "x'7F'") `shouldBe` 127
+      bozAsNatural @Natural (parseBoz "x'80'") `shouldBe` 128
       bozAsNatural @Natural (parseBoz "x'FF'") `shouldBe` 255
+
+    it "resolves a BOZ as a two's complement integer (INT(1))" $ do
+      bozAsTwosComp @Int8  (parseBoz "x'00'") `shouldBe` 0
+      bozAsTwosComp @Int8  (parseBoz "x'7F'") `shouldBe` 127
+      bozAsTwosComp @Int8  (parseBoz "x'80'") `shouldBe` (-128)
+      bozAsTwosComp @Int8  (parseBoz "x'FF'") `shouldBe` (-1)
+
+    it "resolves a BOZ as a two's complement integer (INT(2))" $ do
+      bozAsTwosComp @Int16 (parseBoz "x'00'")   `shouldBe` 0
+      bozAsTwosComp @Int16 (parseBoz "x'7F'")   `shouldBe` 127
+      bozAsTwosComp @Int16 (parseBoz "x'80'")   `shouldBe` 128
+      bozAsTwosComp @Int16 (parseBoz "x'FF'")   `shouldBe` 255
+      bozAsTwosComp @Int16 (parseBoz "x'7FFF'") `shouldBe` 32767
+      bozAsTwosComp @Int16 (parseBoz "x'8000'") `shouldBe` (-32768)
+      bozAsTwosComp @Int16 (parseBoz "x'FFFF'") `shouldBe` (-1)
+
+    it "resolves a BOZ as a two's complement integer (INT(4))" $ do
+      bozAsTwosComp @Int32 (parseBoz "x'FFFFFFFF'") `shouldBe` (-1)


### PR DESCRIPTION
Fortran integers are stored in two's complement (in my understanding),
so this is a useful definition for converting BOZ strings to numeric
types.

Also clarified Boz equality by shoving the "check equality while
ignoring conformance flags" into the Eq instance. It's for testing
syntactic equality and shouldn't get used much in the first place, so
fewer definitions seems sensible.