### PR TITLE
Add named constants to constant literal part

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -71,8 +71,12 @@ library
       Language.Fortran.Analysis.Types
       Language.Fortran.AST
       Language.Fortran.AST.AList
-      Language.Fortran.AST.Boz
-      Language.Fortran.AST.RealLit
+      Language.Fortran.AST.Annotated
+      Language.Fortran.AST.Common
+      Language.Fortran.AST.Literal
+      Language.Fortran.AST.Literal.Boz
+      Language.Fortran.AST.Literal.Complex
+      Language.Fortran.AST.Literal.Real
       Language.Fortran.Intrinsics
       Language.Fortran.LValue
       Language.Fortran.Parser
@@ -203,8 +207,8 @@ test-suite spec
       Language.Fortran.Analysis.SemanticTypesSpec
       Language.Fortran.Analysis.TypesSpec
       Language.Fortran.AnalysisSpec
-      Language.Fortran.AST.BozSpec
-      Language.Fortran.AST.RealLitSpec
+      Language.Fortran.AST.Literal.BozSpec
+      Language.Fortran.AST.Literal.RealSpec
       Language.Fortran.Parser.Fixed.Fortran66Spec
       Language.Fortran.Parser.Fixed.Fortran77.IncludeSpec
       Language.Fortran.Parser.Fixed.Fortran77.ParserSpec

--- a/src/Language/Fortran/AST/AList.hs
+++ b/src/Language/Fortran/AST/AList.hs
@@ -3,6 +3,7 @@ module Language.Fortran.AST.AList where
 import Language.Fortran.Util.FirstParameter
 import Language.Fortran.Util.SecondParameter
 import Language.Fortran.Util.Position (Spanned, SrcSpan(..), getSpan)
+import Language.Fortran.AST.Annotated ( Annotated )
 
 import Data.Data    (Data, Typeable)
 import GHC.Generics (Generic)
@@ -22,6 +23,7 @@ instance Functor t => Functor (AList t) where
 
 instance FirstParameter (AList t a) a
 instance SecondParameter (AList t a) SrcSpan
+instance Annotated (AList t)
 instance Spanned (AList t a)
 instance (Out a, Out (t a)) => Out (AList t a)
 instance (NFData a, NFData (t a)) => NFData (AList t a)

--- a/src/Language/Fortran/AST/Annotated.hs
+++ b/src/Language/Fortran/AST/Annotated.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+module Language.Fortran.AST.Annotated where
+
+import Language.Fortran.Util.FirstParameter
+
+-- Retrieving SrcSpan and Annotation from nodes
+class Annotated f where
+  getAnnotation :: f a -> a
+  setAnnotation :: a -> f a -> f a
+  modifyAnnotation :: (a -> a) -> f a -> f a
+  default getAnnotation :: (FirstParameter (f a) a) => f a -> a
+  getAnnotation = getFirstParameter
+
+  default setAnnotation :: (FirstParameter (f a) a) => a -> f a -> f a
+  setAnnotation = setFirstParameter
+
+  modifyAnnotation f x = setAnnotation (f (getAnnotation x)) x

--- a/src/Language/Fortran/AST/Common.hs
+++ b/src/Language/Fortran/AST/Common.hs
@@ -1,0 +1,3 @@
+module Language.Fortran.AST.Common where
+
+type Name = String

--- a/src/Language/Fortran/AST/Literal.hs
+++ b/src/Language/Fortran/AST/Literal.hs
@@ -1,0 +1,15 @@
+module Language.Fortran.AST.Literal where
+
+import Language.Fortran.AST.Common ( Name )
+import Language.Fortran.Util.Position ( SrcSpan )
+
+import           GHC.Generics                   ( Generic )
+import           Data.Data                      ( Data, Typeable )
+import           Control.DeepSeq                ( NFData )
+import           Text.PrettyPrint.GenericPretty ( Out )
+
+data KindParam a
+  = KindParamInt a SrcSpan String -- ^ @[0-9]+@
+  | KindParamVar a SrcSpan Name   -- ^ @[a-z][a-z0-9]+@ (case insensitive)
+    deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
+    deriving anyclass (NFData, Out)

--- a/src/Language/Fortran/AST/Literal/Boz.hs
+++ b/src/Language/Fortran/AST/Literal/Boz.hs
@@ -21,7 +21,7 @@ that not all info is retained -- which of single or double quotes were used is
 not recorded, for example.
 -}
 
-module Language.Fortran.AST.Boz where
+module Language.Fortran.AST.Literal.Boz where
 
 import           GHC.Generics
 import           Data.Data

--- a/src/Language/Fortran/AST/Literal/Complex.hs
+++ b/src/Language/Fortran/AST/Literal/Complex.hs
@@ -1,0 +1,54 @@
+-- | Supporting definitions for COMPLEX literals.
+
+module Language.Fortran.AST.Literal.Complex where
+
+import Language.Fortran.AST.Common ( Name )
+import Language.Fortran.AST.Literal ( KindParam )
+import Language.Fortran.AST.Literal.Real
+import Language.Fortran.Util.Position ( SrcSpan )
+
+import GHC.Generics                   ( Generic )
+import Data.Data                      ( Data, Typeable )
+import Control.DeepSeq                ( NFData )
+import Text.PrettyPrint.GenericPretty ( Out )
+import Language.Fortran.Util.FirstParameter  ( FirstParameter )
+import Language.Fortran.Util.SecondParameter ( SecondParameter )
+import Language.Fortran.AST.Annotated ( Annotated )
+
+-- | A COMPLEX literal, composed of a real part and an imaginary part.
+--
+-- Fortran has lots of rules on how COMPLEX literals are defined and used in
+-- various contexts. To support all that, we define the syntactic structure
+-- 'ComplexLit' to wrap all the parsing rules. Then during a analysis pass, you
+-- may (attempt to) convert these into a more regular type, like a Haskell
+-- @(Double, Double)@ tuple.
+data ComplexLit a = ComplexLit
+  { complexLitAnno     :: a
+  , complexLitPos      :: SrcSpan
+  , complexLitRealPart :: ComplexPart a
+  , complexLitImagPart :: ComplexPart a
+  } deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
+    deriving anyclass (NFData, Out)
+
+instance FirstParameter  (ComplexLit a) a
+instance SecondParameter (ComplexLit a) a
+instance Annotated       ComplexLit
+
+-- | A part (either real or imaginary) of a complex literal.
+--
+-- Since Fortran 2003, complex literal parts support named constants, which must
+-- be resolved in context at compile time (R422, R423).
+--
+-- Some compilers also allow constant expressions for the parts, and must
+-- evaluate at compile time. That's not allowed in any standard. Apparently,
+-- gfortran and ifort don't allow it, while nvfortran does. See:
+-- https://fortran-lang.discourse.group/t/complex-constants-and-variables/2909/3
+--
+-- We specifically avoid supporting that by defining complex parts without being
+-- mutually recursive with 'Expression'.
+data ComplexPart a
+  = ComplexPartReal   a SrcSpan RealLit (Maybe (KindParam a)) -- ^ signed real lit
+  | ComplexPartInt    a SrcSpan String  (Maybe (KindParam a)) -- ^ signed int  lit
+  | ComplexPartNamed  a SrcSpan Name                          -- ^ named constant
+    deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
+    deriving anyclass (NFData, Out)

--- a/src/Language/Fortran/AST/Literal/Real.hs
+++ b/src/Language/Fortran/AST/Literal/Real.hs
@@ -16,7 +16,7 @@ For example, the Fortran REAL literal @1D0@ will be parsed into @1.0D0@.
 
 {-# LANGUAGE RecordWildCards #-}
 
-module Language.Fortran.AST.RealLit where
+module Language.Fortran.AST.Literal.Real where
 
 import qualified Data.Char as Char
 import           GHC.Generics
@@ -94,4 +94,4 @@ parseRealLit r =
                                'e' -> ExpLetterE
                                'd' -> ExpLetterD
                                'q' -> ExpLetterQ
-                               _   -> error $ "Language.Fortran.AST.RealLit.parseRealLit: invalid exponent letter: " <> [ch]
+                               _   -> error $ "Language.Fortran.AST.Literal.Real.parseRealLit: invalid exponent letter: " <> [ch]

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -18,7 +18,7 @@ import Text.PrettyPrint.GenericPretty (pretty, Out)
 import Text.PrettyPrint               (render)
 import Language.Fortran.Analysis
 import Language.Fortran.AST hiding (setName)
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 import Language.Fortran.Util.Position
 import Language.Fortran.PrettyPrint
 import qualified Data.Map as M

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -33,7 +33,7 @@ import Text.PrettyPrint.GenericPretty (Out)
 import Language.Fortran.Analysis
 import Language.Fortran.Analysis.BBlocks (showBlock, ASTBlockNode, ASTExprNode)
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 import qualified Data.Map as M
 import qualified Data.IntMap.Lazy as IM
 import qualified Data.IntMap.Strict as IMS

--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -15,7 +15,8 @@ module Language.Fortran.Analysis.Types
   ) where
 
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
+import Language.Fortran.AST.Literal.Complex
 
 import Prelude hiding (lookup, EQ, LT, GT)
 import Data.Map (insert)
@@ -273,7 +274,7 @@ annotateExpression e@(ExpValue _ _ (ValIntrinsic _))   = maybe e (`setIDType` e)
 annotateExpression e@(ExpValue _ ss (ValReal r mkp))        = do
     k <- deriveRealLiteralKind ss r mkp
     return $ setSemType (TReal k) e
-annotateExpression e@(ExpValue _ _ (ValComplex _ss _cr _ci)) = do
+annotateExpression e@(ExpValue _ _ (ValComplex (ComplexLit _a _ss _cr _ci))) = do
     -- TODO check F90 standard for complex lit typing rules (kind params)
     return e
 annotateExpression e@(ExpValue _ _ ValInteger{})     =

--- a/src/Language/Fortran/Parser/Fixed/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran66.y
@@ -15,7 +15,7 @@ import Language.Fortran.Parser.ParserUtils
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.Parser.Fixed.Utils
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 
 import Prelude hiding ( EQ, LT, GT ) -- Same constructors exist in the AST
 

--- a/src/Language/Fortran/Parser/Fixed/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran77.y
@@ -16,7 +16,7 @@ import Language.Fortran.Parser.ParserUtils
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.Parser.Fixed.Utils
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 
 import Prelude hiding ( EQ, LT, GT ) -- Same constructors exist in the AST
 import Data.Maybe ( isNothing, fromJust )

--- a/src/Language/Fortran/Parser/Fixed/Lexer.x
+++ b/src/Language/Fortran/Parser/Fixed/Lexer.x
@@ -31,7 +31,7 @@ import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.LexerUtils ( readIntOrBoz )
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Boz
 
 }
 

--- a/src/Language/Fortran/Parser/Fixed/Utils.hs
+++ b/src/Language/Fortran/Parser/Fixed/Utils.hs
@@ -3,7 +3,7 @@ module Language.Fortran.Parser.Fixed.Utils where
 
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 import Language.Fortran.Util.Position
 import Language.Fortran.Parser.Monad
 import Control.Monad.State

--- a/src/Language/Fortran/Parser/Free/Lexer.x
+++ b/src/Language/Fortran/Parser/Free/Lexer.x
@@ -32,8 +32,8 @@ import Language.Fortran.Parser.Monad
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 import Language.Fortran.Util.FirstParameter
-import Language.Fortran.AST.RealLit (RealLit, parseRealLit)
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Real (RealLit, parseRealLit)
+import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.Parser.LexerUtils ( readIntOrBoz )
 
 }

--- a/src/Language/Fortran/Parser/LexerUtils.hs
+++ b/src/Language/Fortran/Parser/LexerUtils.hs
@@ -1,7 +1,7 @@
 {-| Utils for both lexers. -}
 module Language.Fortran.Parser.LexerUtils ( readIntOrBoz ) where
 
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Boz
 import Numeric
 
 -- | Read a string as either a signed integer, or a BOZ constant (positive).

--- a/test/Language/Fortran/AST/Literal/BozSpec.hs
+++ b/test/Language/Fortran/AST/Literal/BozSpec.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE TypeApplications #-}
 
-module Language.Fortran.AST.BozSpec where
+module Language.Fortran.AST.Literal.BozSpec where
 
 import Test.Hspec
 
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Boz
 import Numeric.Natural ( Natural )
 
 spec :: Spec

--- a/test/Language/Fortran/AST/Literal/RealSpec.hs
+++ b/test/Language/Fortran/AST/Literal/RealSpec.hs
@@ -1,10 +1,10 @@
-module Language.Fortran.AST.RealLitSpec where
+module Language.Fortran.AST.Literal.RealSpec where
 
-import           Prelude hiding ( exp )
+import Prelude hiding ( exp )
 
-import           Test.Hspec
+import Test.Hspec
 
-import           Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 
 spec :: Spec
 spec = do

--- a/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
@@ -7,7 +7,7 @@ import TestUtil
 import Language.Fortran.Parser.Fixed.Lexer
 import Language.Fortran.Parser
 import Language.Fortran.Parser.Monad ( ParseState, getAlex, evalParse )
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.Version
 
 import Data.List (isPrefixOf)

--- a/test/Language/Fortran/Parser/Free/Common.hs
+++ b/test/Language/Fortran/Parser/Free/Common.hs
@@ -12,7 +12,7 @@ import           TestUtil
 import           Test.Hspec
 
 import           Language.Fortran.AST
-import           Language.Fortran.AST.RealLit
+import           Language.Fortran.AST.Literal.Real
 
 specFreeCommon :: (String -> Statement A0) -> (String -> Expression A0) -> Spec
 specFreeCommon sParser eParser =
@@ -74,6 +74,10 @@ specFreeCommon sParser eParser =
           let cr = ComplexPartReal () u (parseRealLit "-1.2") (kp "8")
               ci = ComplexPartInt  () u "0"                    Nothing
           eParser "(-1.2_8, 0)" `shouldBe'` complexGen cr ci
+        it "parses a complex literal via named constants" $ do
+          let cr = ComplexPartNamed () u "a"
+              ci = ComplexPartNamed () u "b_something"
+          eParser "(a, b_something)" `shouldBe'` complexGen cr ci
 
     describe "Statement" $ do
       describe "Declaration" $ do

--- a/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
@@ -7,7 +7,7 @@ import TestUtil
 import Language.Fortran.Parser.Free.Common
 
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit ( parseRealLit )
+import Language.Fortran.AST.Literal.Real ( parseRealLit )
 import Language.Fortran.Version
 import Language.Fortran.Parser
 import Language.Fortran.Parser.Monad ( Parse )

--- a/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
@@ -7,7 +7,7 @@ import TestUtil
 import Language.Fortran.Parser.Free.Common
 
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit ( parseRealLit )
+import Language.Fortran.AST.Literal.Real ( parseRealLit )
 import Language.Fortran.Version
 import Language.Fortran.Parser
 import Language.Fortran.Parser.Monad ( Parse )

--- a/test/Language/Fortran/Parser/Free/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Free/LexerSpec.hs
@@ -6,7 +6,7 @@ import TestUtil
 import Language.Fortran.Parser.Free.Lexer ( Token(..), lexer' )
 import Language.Fortran.Parser ( collectTokens )
 import Language.Fortran.Parser ( initParseStateFree )
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
 import Language.Fortran.Version
 import Language.Fortran.Util.Position (SrcSpan)
 

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -10,7 +10,7 @@ import Data.Generics.Uniplate.Operations
 import Data.Maybe (catMaybes)
 
 import Language.Fortran.AST as LFA
-import Language.Fortran.AST.Boz
+import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.Version
 import Language.Fortran.PrettyPrint
 

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -5,7 +5,8 @@ import Data.Data
 import Data.Generics.Uniplate.Data
 
 import Language.Fortran.AST
-import Language.Fortran.AST.RealLit
+import Language.Fortran.AST.Literal.Real
+import Language.Fortran.AST.Literal.Complex
 import Language.Fortran.Version
 import Language.Fortran.Util.Position
 
@@ -54,7 +55,7 @@ realGen :: (Fractional a, Show a) => a -> Expression ()
 realGen i = ExpValue () u $ ValReal (parseRealLit (show i)) Nothing
 
 complexGen :: ComplexPart () -> ComplexPart () -> Expression ()
-complexGen cr ci = ExpValue () u $ ValComplex u cr ci
+complexGen cr ci = ExpValue () u $ ValComplex $ ComplexLit () u cr ci
 
 strGen :: String -> Expression ()
 strGen str = ExpValue () u $ ValString str


### PR DESCRIPTION
Explicitly added in F2003 standard. For now, we use the same parsing for
all versions - it seems to be one of those features that is silently
accepted by most compilers...

Also refactored some AST definitions: more definitions are placed in
their own module, and the literals have been grouped together. The AST
module is incredibly slow to compile, I imagine due to the volume of
instances generated. This should help.