### PR TITLE
Add support for array specs in fortran 77 cray pointers

### DIFF
--- a/src/Language/Fortran/Parser/Fixed/Fortran77.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran77.y
@@ -607,7 +607,9 @@ POINTER_LIST :: { [ Declarator A0 ] }
 | POINTER                  { [ $1 ] }
 
 POINTER :: { Declarator A0 }
-: '(' VARIABLE ',' VARIABLE ')'
+: '(' VARIABLE ',' VARIABLE '(' DIMENSION_DECLARATORS ')' ')'
+  { Declarator () (getTransSpan $1 $8) $2 (ArrayDecl (aReverse $6)) Nothing (Just $4) }
+| '(' VARIABLE ',' VARIABLE ')'
   { Declarator () (getTransSpan $1 $5) $2 ScalarDecl Nothing (Just $4) }
 
 COMMON_GROUPS :: { AList CommonGroup A0 }


### PR DESCRIPTION
This PR adds a parsing rule to handle array specs in cray pointers in fixed-form fortran. The spec is from https://docs.oracle.com/cd/E19957-01/805-4941/z40000a54ba7/index.html. Basic tests with a simple fortran 77 source with `-v f77l` passed.