### PR TITLE
pair IF/CASE conditions with their blocks

### DIFF
--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-} -- for Out (NonEmpty a)
+
 -- |
 --
 -- This module holds the data types used to represent Fortran code of various
@@ -110,6 +112,9 @@ module Language.Fortran.AST
   , updateProgramUnitBody
   , programUnitSubprograms
 
+  -- * Re-exports
+  , NonEmpty(..)
+
   ) where
 
 import Prelude hiding ( init )
@@ -130,6 +135,7 @@ import Data.Data
 import Data.Binary
 import Control.DeepSeq
 import Text.PrettyPrint.GenericPretty
+import Data.List.NonEmpty ( NonEmpty(..) )
 
 -- | The empty annotation.
 type A0 = ()
@@ -318,16 +324,16 @@ data Block a =
   | BlIf        a SrcSpan
                 (Maybe (Expression a))       -- ^ Label
                 (Maybe String)               -- ^ Construct name
-                [ Maybe (Expression a) ]     -- ^ Conditions
-                [ [ Block a ] ]              -- ^ Bodies
+                (NonEmpty (Expression a, [Block a])) -- ^ IF, ELSE IF clauses
+                (Maybe [Block a])            -- ^ ELSE block
                 (Maybe (Expression a))       -- ^ Label to END IF
 
   | BlCase      a SrcSpan
                 (Maybe (Expression a))       -- ^ Label
                 (Maybe String)               -- ^ Construct name
                 (Expression a)               -- ^ Scrutinee
-                [ Maybe (AList Index a) ]    -- ^ Case ranges
-                [ [ Block a ] ]              -- ^ Bodies
+                [(AList Index a, [Block a])] -- ^ CASE clauses
+                (Maybe [Block a])            -- ^ CASE default
                 (Maybe (Expression a))       -- ^ Label to END SELECT
 
   | BlDo        a SrcSpan
@@ -864,7 +870,7 @@ instance Labeled Block where
   getLastLabel _ = Nothing
 
   setLabel (BlStatement a s _ st) l = BlStatement a s (Just l) st
-  setLabel (BlIf a s _ mn conds bs el) l = BlIf a s (Just l) mn conds bs el
+  setLabel (BlIf a s _ mn clauses elseBlock el) l = BlIf a s (Just l) mn clauses elseBlock el
   setLabel (BlDo a s _ mn tl spec bs el) l = BlDo a s (Just l) mn tl spec bs el
   setLabel (BlDoWhile a s _ n tl spec bs el) l = BlDoWhile a s (Just l) n tl spec bs el
   setLabel b _ = b
@@ -1038,3 +1044,5 @@ instance NFData BinaryOp
 instance NFData Only
 instance NFData ModuleNature
 instance NFData Intent
+
+instance Out a => Out (NonEmpty a)

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -368,7 +368,8 @@ blockVarUses (BlStatement _ _ _ (StCall _ _ f@(ExpValue _ _ (ValIntrinsic _)) _)
   | Just uses <- intrinsicUses f = uses
 blockVarUses (BlStatement _ _ _ (StCall _ _ _ (Just aexps))) = allVars aexps
 blockVarUses (BlDoWhile _ _ e1 _ _ e2 _ _) = maybe [] allVars e1 ++ allVars e2
-blockVarUses (BlIf _ _ e1 _ e2 _ _)        = maybe [] allVars e1 ++ concatMap (maybe [] allVars) e2
+blockVarUses (BlIf _ _ eLabel _ clauses _ _) =
+    maybe [] allVars eLabel ++ concatMap allVars (fmap fst clauses)
 blockVarUses b                             = allVars b
 
 -- | Set of names defined by an AST-block.

--- a/src/Language/Fortran/Parser/Free/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Free/Fortran2003.y
@@ -364,87 +364,93 @@ BLOCK :: { Block A0 }
 | COMMENT_BLOCK { $1 }
 
 IF_BLOCK :: { Block A0 }
+IF_BLOCK
 :                        if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
-          (endSpan, conds, blocks, endLabel) = $9;
+          (clauses, elseBlock, endSpan, endLabel) = $9;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span Nothing Nothing ((Just $3):conds) ((reverse $8):blocks) endLabel }
+     in BlIf () span Nothing    Nothing          (($3, reverse $8)  :| clauses) elseBlock endLabel }
 |                 id ':' if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { TId startSpan startName = $1;
-          (endSpan, conds, blocks, endLabel) = $11;
+          (clauses, elseBlock, endSpan, endLabel) = $11;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span Nothing (Just startName) ((Just $5):conds) ((reverse $10):blocks) endLabel }
+     in BlIf () span Nothing    (Just startName) (($5, reverse $10) :| clauses) elseBlock endLabel }
 | INTEGER_LITERAL        if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
           startLabel = Just $1;
-          (endSpan, conds, blocks, endLabel) = $10;
+          (clauses, elseBlock, endSpan, endLabel) = $10;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span startLabel Nothing ((Just $4):conds) ((reverse $9):blocks) endLabel }
+     in BlIf () span startLabel Nothing          (($4, reverse $9)  :| clauses) elseBlock endLabel }
 | INTEGER_LITERAL id ':' if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
           startLabel = Just $1;
           TId _ startName = $2;
-          (endSpan, conds, blocks, endLabel) = $12;
+          (clauses, elseBlock, endSpan, endLabel) = $12;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span startLabel (Just startName) ((Just $6):conds) ((reverse $11):blocks) endLabel }
+     in BlIf () span startLabel (Just startName) (($6, reverse $11) :| clauses) elseBlock endLabel }
 
-ELSE_BLOCKS :: { (SrcSpan, [Maybe (Expression A0)], [[Block A0]], Maybe (Expression A0)) }
+ELSE_BLOCKS :: { ([(Expression A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
+ELSE_BLOCKS
 : maybe(INTEGER_LITERAL) elsif '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
-  { let (endSpan, conds, blocks, endLabel) = $10
-    in (endSpan, Just $4 : conds, reverse $9 : blocks, endLabel) }
+  { let (clauses, elseBlock, endSpan, endLabel) = $10
+    in  (($4, reverse $9) : clauses, elseBlock, endSpan, endLabel) }
 | maybe(INTEGER_LITERAL) else                          MAYBE_COMMENT NEWLINE BLOCKS END_IF
   { let (endSpan, endLabel) = $6
-    in (endSpan, [Nothing], [reverse $5], endLabel) }
-| END_IF { let (endSpan, endLabel) = $1 in (endSpan, [], [], endLabel) }
+    in  ([], Just (reverse $5), endSpan, endLabel) }
+| END_IF
+  { let (endSpan, endLabel) = $1
+    in  ([], Nothing,           endSpan, endLabel) }
 
 END_IF :: { (SrcSpan, Maybe (Expression A0)) }
+END_IF
 : endif { (getSpan $1, Nothing) }
 | endif id { (getSpan $2, Nothing) }
 | INTEGER_LITERAL endif { (getSpan $2, Just $1) }
 | INTEGER_LITERAL endif id { (getSpan $3, Just $1) }
 
 CASE_BLOCK :: { Block A0 }
+CASE_BLOCK
 :                        selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $7;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $7;
           span = getTransSpan $1 endSpan }
-    in BlCase () span Nothing Nothing $3 caseRanges blocks endLabel }
+    in BlCase () span Nothing   Nothing          $3 clauses defaultCase endLabel }
 | INTEGER_LITERAL        selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $8;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $8;
           span = getTransSpan $1 endSpan }
-    in BlCase () span (Just $1) Nothing $4 caseRanges blocks endLabel }
+    in BlCase () span (Just $1) Nothing          $4 clauses defaultCase endLabel }
 |                 id ':' selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $9;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $9;
           TId s startName = $1;
           span = getTransSpan s endSpan }
-    in BlCase () span Nothing (Just startName) $5 caseRanges blocks endLabel }
+    in BlCase () span Nothing   (Just startName) $5 clauses defaultCase endLabel }
 | INTEGER_LITERAL id ':' selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $10;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $10;
           TId s startName = $2;
           span = getTransSpan s endSpan }
-    in BlCase () span (Just $1) (Just startName) $6 caseRanges blocks endLabel }
+    in BlCase () span (Just $1) (Just startName) $6 clauses defaultCase endLabel }
 
 -- We store line comments as statements, but this raises an issue: we have
 -- nowhere to place comments after a SELECT CASE but before a CASE. So we drop
 -- them. The inner CASES_ rule does /not/ use this, because comments can always
 -- be parsed as belonging to to the above CASE block.
-CASES :: { ([Maybe (AList Index A0)], [[Block A0]], Maybe (Expression A0), SrcSpan) }
+CASES  :: { ([(AList Index A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
 : COMMENT_BLOCK CASES_ { $2 }
 |               CASES_ { $1 }
 
-CASES_ :: { ([Maybe (AList Index A0)], [[Block A0]], Maybe (Expression A0), SrcSpan) }
+CASES_ :: { ([(AList Index A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
 : maybe(INTEGER_LITERAL) case '(' INDICIES ')' MAYBE_COMMENT NEWLINE BLOCKS CASES_
-  { let (scrutinees, blocks, endLabel, endSpan) = $9
-    in  (Just (fromReverseList $4) : scrutinees, reverse $8 : blocks, endLabel, endSpan) }
+  { let (clauses, defaultCase, endSpan, endLabel) = $9
+    in  ((fromReverseList $4, reverse $8) : clauses, defaultCase, endSpan, endLabel) }
 | maybe(INTEGER_LITERAL) case default          MAYBE_COMMENT NEWLINE BLOCKS END_SELECT
-  { let (endLabel, endSpan) = $7
-    in ([Nothing], [$6], endLabel, endSpan) }
+  { let (endSpan, endLabel) = $7
+    in ([], Just $6, endSpan, endLabel) }
 | END_SELECT
-  { let (endLabel, endSpan) = $1
-    in ([], [], endLabel, endSpan) }
+  { let (endSpan, endLabel) = $1
+    in ([], Nothing, endSpan, endLabel) }
 
-END_SELECT :: { (Maybe (Expression A0), SrcSpan) }
+END_SELECT :: { (SrcSpan, Maybe (Expression A0)) }
 : maybe(INTEGER_LITERAL) endselect maybe(id)
-  { ($1, maybe (getSpan $2) getSpan $3) }
+  { (maybe (getSpan $2) getSpan $3, $1) }
 
 ASSOCIATE_BLOCK :: { Block A0 }
 : INTEGER_LITERAL id ':' associate '(' ABBREVIATIONS ')' MAYBE_COMMENT NEWLINE BLOCKS END_ASSOCIATE
@@ -506,11 +512,11 @@ ABSTRACTP :: { Bool }
 | {- EMPTY -} { False }
 
 MAYBE_EXPRESSION :: { Maybe (Expression A0) }
-: EXPRESSION { Just $1 }
+: EXPRESSION  { Just $1 }
 | {- EMPTY -} { Nothing }
 
 MAYBE_COMMENT :: { Maybe Token }
-: comment { Just $1 }
+: comment     { Just $1 }
 | {- EMPTY -} { Nothing }
 
 SUBPROGRAM_UNITS2 :: { [ ProgramUnit A0 ] }

--- a/src/Language/Fortran/Parser/Free/Fortran90.y
+++ b/src/Language/Fortran/Parser/Free/Fortran90.y
@@ -310,94 +310,100 @@ BLOCK :: { Block A0 }
 | COMMENT_BLOCK { $1 }
 
 IF_BLOCK :: { Block A0 }
+IF_BLOCK
 :                        if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
-          (endSpan, conds, blocks, endLabel) = $9;
+          (clauses, elseBlock, endSpan, endLabel) = $9;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span Nothing Nothing ((Just $3):conds) ((reverse $8):blocks) endLabel }
+     in BlIf () span Nothing    Nothing          (($3, reverse $8)  :| clauses) elseBlock endLabel }
 |                 id ':' if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { TId startSpan startName = $1;
-          (endSpan, conds, blocks, endLabel) = $11;
+          (clauses, elseBlock, endSpan, endLabel) = $11;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span Nothing (Just startName) ((Just $5):conds) ((reverse $10):blocks) endLabel }
+     in BlIf () span Nothing    (Just startName) (($5, reverse $10) :| clauses) elseBlock endLabel }
 | INTEGER_LITERAL        if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
           startLabel = Just $1;
-          (endSpan, conds, blocks, endLabel) = $10;
+          (clauses, elseBlock, endSpan, endLabel) = $10;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span startLabel Nothing ((Just $4):conds) ((reverse $9):blocks) endLabel }
+     in BlIf () span startLabel Nothing          (($4, reverse $9)  :| clauses) elseBlock endLabel }
 | INTEGER_LITERAL id ':' if '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
   { let { startSpan = getSpan $1;
           startLabel = Just $1;
           TId _ startName = $2;
-          (endSpan, conds, blocks, endLabel) = $12;
+          (clauses, elseBlock, endSpan, endLabel) = $12;
           span = getTransSpan startSpan endSpan }
-     in BlIf () span startLabel (Just startName) ((Just $6):conds) ((reverse $11):blocks) endLabel }
+     in BlIf () span startLabel (Just startName) (($6, reverse $11) :| clauses) elseBlock endLabel }
 
-ELSE_BLOCKS :: { (SrcSpan, [Maybe (Expression A0)], [[Block A0]], Maybe (Expression A0)) }
+ELSE_BLOCKS :: { ([(Expression A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
+ELSE_BLOCKS
 : maybe(INTEGER_LITERAL) elsif '(' EXPRESSION ')' then MAYBE_COMMENT NEWLINE BLOCKS ELSE_BLOCKS
-  { let (endSpan, conds, blocks, endLabel) = $10
-    in (endSpan, Just $4 : conds, reverse $9 : blocks, endLabel) }
+  { let (clauses, elseBlock, endSpan, endLabel) = $10
+    in  (($4, reverse $9) : clauses, elseBlock, endSpan, endLabel) }
 | maybe(INTEGER_LITERAL) else                          MAYBE_COMMENT NEWLINE BLOCKS END_IF
   { let (endSpan, endLabel) = $6
-    in (endSpan, [Nothing], [reverse $5], endLabel) }
-| END_IF { let (endSpan, endLabel) = $1 in (endSpan, [], [], endLabel) }
+    in  ([], Just (reverse $5), endSpan, endLabel) }
+| END_IF
+  { let (endSpan, endLabel) = $1
+    in  ([], Nothing,           endSpan, endLabel) }
 
 END_IF :: { (SrcSpan, Maybe (Expression A0)) }
+END_IF
 : endif { (getSpan $1, Nothing) }
 | endif id { (getSpan $2, Nothing) }
 | INTEGER_LITERAL endif { (getSpan $2, Just $1) }
 | INTEGER_LITERAL endif id { (getSpan $3, Just $1) }
 
 CASE_BLOCK :: { Block A0 }
+CASE_BLOCK
 :                        selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $7;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $7;
           span = getTransSpan $1 endSpan }
-    in BlCase () span Nothing Nothing $3 caseRanges blocks endLabel }
+    in BlCase () span Nothing   Nothing          $3 clauses defaultCase endLabel }
 | INTEGER_LITERAL        selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $8;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $8;
           span = getTransSpan $1 endSpan }
-    in BlCase () span (Just $1) Nothing $4 caseRanges blocks endLabel }
+    in BlCase () span (Just $1) Nothing          $4 clauses defaultCase endLabel }
 |                 id ':' selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $9;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $9;
           TId s startName = $1;
           span = getTransSpan s endSpan }
-    in BlCase () span Nothing (Just startName) $5 caseRanges blocks endLabel }
+    in BlCase () span Nothing   (Just startName) $5 clauses defaultCase endLabel }
 | INTEGER_LITERAL id ':' selectcase '(' EXPRESSION ')' MAYBE_COMMENT NEWLINE CASES
-  { let { (caseRanges, blocks, endLabel, endSpan) = $10;
+  { let { (clauses, defaultCase, endSpan, endLabel) = $10;
           TId s startName = $2;
           span = getTransSpan s endSpan }
-    in BlCase () span (Just $1) (Just startName) $6 caseRanges blocks endLabel }
+    in BlCase () span (Just $1) (Just startName) $6 clauses defaultCase endLabel }
 
 -- We store line comments as statements, but this raises an issue: we have
 -- nowhere to place comments after a SELECT CASE but before a CASE. So we drop
 -- them. The inner CASES_ rule does /not/ use this, because comments can always
 -- be parsed as belonging to to the above CASE block.
-CASES :: { ([Maybe (AList Index A0)], [[Block A0]], Maybe (Expression A0), SrcSpan) }
+CASES  :: { ([(AList Index A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
 : COMMENT_BLOCK CASES_ { $2 }
 |               CASES_ { $1 }
 
-CASES_ :: { ([Maybe (AList Index A0)], [[Block A0]], Maybe (Expression A0), SrcSpan) }
+CASES_ :: { ([(AList Index A0, [Block A0])], Maybe [Block A0], SrcSpan, Maybe (Expression A0)) }
 : maybe(INTEGER_LITERAL) case '(' INDICIES ')' MAYBE_COMMENT NEWLINE BLOCKS CASES_
-  { let (scrutinees, blocks, endLabel, endSpan) = $9
-    in  (Just (fromReverseList $4) : scrutinees, reverse $8 : blocks, endLabel, endSpan) }
+  { let (clauses, defaultCase, endSpan, endLabel) = $9
+    in  ((fromReverseList $4, reverse $8) : clauses, defaultCase, endSpan, endLabel) }
 | maybe(INTEGER_LITERAL) case default          MAYBE_COMMENT NEWLINE BLOCKS END_SELECT
-  { let (endLabel, endSpan) = $7
-    in ([Nothing], [$6], endLabel, endSpan) }
+  { let (endSpan, endLabel) = $7
+    in ([], Just $6, endSpan, endLabel) }
 | END_SELECT
-  { let (endLabel, endSpan) = $1
-    in ([], [], endLabel, endSpan) }
+  { let (endSpan, endLabel) = $1
+    in ([], Nothing, endSpan, endLabel) }
 
-END_SELECT :: { (Maybe (Expression A0), SrcSpan) }
+END_SELECT :: { (SrcSpan, Maybe (Expression A0)) }
 : maybe(INTEGER_LITERAL) endselect maybe(id)
-  { ($1, maybe (getSpan $2) getSpan $3) }
+  { (maybe (getSpan $2) getSpan $3, $1) }
 
 MAYBE_EXPRESSION :: { Maybe (Expression A0) }
-: EXPRESSION { Just $1 }
+: EXPRESSION  { Just $1 }
 | {- EMPTY -} { Nothing }
 
 MAYBE_COMMENT :: { Maybe Token }
-: comment { Just $1 }
+: comment     { Just $1 }
 | {- EMPTY -} { Nothing }
 
 SUBPROGRAM_UNITS2 :: { [ ProgramUnit A0 ] }

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -43,6 +43,16 @@ infixl 7 <?>
 doc1 <?+> doc2 = if doc1 == empty || doc2 == empty then empty else doc1 <+> doc2
 infixl 7 <?+>
 
+-- Helpers
+printMaybe :: (a -> Doc) -> Maybe a -> Doc
+printMaybe f = \case Just a  -> f a
+                     Nothing -> empty
+
+printIndentedBlockWithPre
+    :: FortranVersion -> Indentation -> Doc -> [Block a] -> Doc
+printIndentedBlockWithPre v i doc b =
+    doc <> newline <> pprint v b (incIndentation i)
+
 newline :: Doc
 newline = char '\n'
 
@@ -243,48 +253,49 @@ instance IndentablePretty (Block a) where
         then indent i (pprint' v mLabel <+> pprint' v st <> newline)
         else pprint' v mLabel `overlay` indent i (pprint' v st <> newline)
 
-    pprint v (BlIf _ _ mLabel mName conds bodies el) i
+    pprint v (BlIf _ _ mLabel mName ((ifPred, thenBlock) :| elseIfs) mElseBlock el) i
       | v >= Fortran77 =
-        labeledIndent mLabel
-          (pprint' v mName <?> colon <+>
-          "if" <+> parens (pprint' v firstCond) <+> "then" <> newline) <>
-        pprint v firstBody nextI <>
-        foldl' (<>) empty (map displayCondBlock restCondsBodies) <>
-        labeledIndent el ("end if" <+> pprint' v mName <> newline)
+               labeledIndent mLabel displayIfThen
+            <> foldl' (<>) empty (map displayElseIf elseIfs)
+            <> printMaybe displayElse mElseBlock
+            <> labeledIndent el ("end if" <+> pprint' v mName)
+            <> newline
       | otherwise = tooOld v "Structured if" Fortran77
       where
-        ((firstCond, firstBody): restCondsBodies) = zip conds bodies
-        displayCondBlock (mCond, block) =
-          indent i
-            (case mCond of {
-              Just cond -> "else if" <+> parens (pprint' v cond) <+> "then";
-              Nothing -> "else"
-            } <> newline) <>
-          pprint v block nextI
-        nextI = incIndentation i
+        displayIfThen =
+            displayClause displayIfPred thenBlock
+        displayIfPred =
+            pprint' v mName <?> colon <+> displayPred "if" ifPred
+        displayPred str pred =
+            indent i str <+> parens (pprint' v pred) <+> "then"
+        displayElseIf (pred, block) =
+            displayClause (displayPred "else if" pred) block
+        displayElse block =
+            displayClause (indent i "else") block
+        displayClause = printIndentedBlockWithPre v i
         labeledIndent label stDoc =
           if v >= Fortran90
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
 
-    pprint v (BlCase _ _ mLabel mName scrutinee ranges bodies el) i
+    pprint v (BlCase _ _ mLabel mName scrutinee clauses mDefaultCase el) i
       | v >= Fortran90 =
-        indent i
-          (pprint' v mLabel <+>
-          pprint' v mName <?> colon <+>
-          "select case" <+> parens (pprint' v scrutinee) <> newline) <>
-        foldl' (<>) empty (zipWith (curry displayRangeBlock) ranges bodies) <>
-        indent i (pprint' v el <+> "end select" <+> pprint' v mName <> newline)
+             indent i (pre <+> "select case" <+> parens (pprint' v scrutinee))
+          <> newline
+          <> foldl' (<>) empty (map displayCase clauses)
+          <> printMaybe displayCaseDefault mDefaultCase
+          <> indent i (pprint' v el <+> "end select" <+> pprint' v mName)
+          <> newline
       | otherwise = tooOld v "Select case" Fortran90
       where
-        displayRangeBlock (mRanges, block) =
-          indent nextI
-            ("case" <+>
-            case mRanges of {
-              Just ranges' -> parens (pprint' v ranges');
-              Nothing -> "default" } <> newline) <>
-          pprint v block (incIndentation nextI)
         nextI = incIndentation i
+        pre = pprint' v mLabel <+> pprint' v mName <?> colon
+        displayCaseDefault =
+            displayClause (indent nextI "case default")
+        displayCase (ranges, block) =
+            displayClause (indent nextI $ "case" <+> displayRanges ranges) block
+        displayRanges = parens . pprint' v
+        displayClause = printIndentedBlockWithPre v nextI
 
     pprint v (BlInterface _ _ mLabel abstractp pus moduleProcs) i
       | v >= Fortran90 =

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -210,10 +210,10 @@ applyGroupingToSubblocks :: (ABlocks a -> ABlocks a) -> Block (Analysis a) -> Bl
 applyGroupingToSubblocks f b
   | BlStatement{} <- b =
       error "Individual statements do not have subblocks. Must not occur."
-  | BlIf a s l mn conds blocks         el <- b =
-    BlIf a s l mn conds (map f blocks) el
-  | BlCase a s l mn scrutinee conds blocks         el <- b =
-    BlCase a s l mn scrutinee conds (map f blocks) el
+  | BlIf a s l mn clauses elseBlock el <- b =
+    BlIf a s l mn (fmap (\(cond, block) -> (cond, f block)) clauses) (fmap f elseBlock) el
+  | BlCase a s l mn scrutinee clauses caseDefault el <- b =
+    BlCase a s l mn scrutinee (map (\(range, block) -> (range, f block)) clauses) (fmap f caseDefault) el
   | BlDo a s l n tl doSpec blocks     el <- b =
     BlDo a s l n tl doSpec (f blocks) el
   | BlDoWhile a s l n tl doSpec blocks     el <- b =

--- a/src/Language/Fortran/Util/Position.hs
+++ b/src/Language/Fortran/Util/Position.hs
@@ -7,6 +7,7 @@ import Text.PrettyPrint.GenericPretty
 import Text.PrettyPrint
 import Data.Binary
 import Control.DeepSeq
+import Data.List.NonEmpty ( NonEmpty(..) )
 
 import Language.Fortran.Util.SecondParameter
 
@@ -99,6 +100,11 @@ instance (Spanned a) => Spanned [a] where
   getSpan [x]   = getSpan x
   getSpan (x:xs) = getTransSpan x (last xs)
   setSpan _ _ = error "Cannot set span to an array"
+
+instance (Spanned a) => Spanned (NonEmpty a) where
+  getSpan (x :| [])     = getSpan x
+  getSpan (x :| (y:ys)) = getTransSpan x (last (y:ys))
+  setSpan _ _ = error "Cannot set span to a non-empty list"
 
 instance (Spanned a, Spanned b) => Spanned (a, Maybe b) where
   getSpan (x, Just y) = getTransSpan x y

--- a/test/Language/Fortran/Parser/Fixed/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/Fortran77/ParserSpec.hs
@@ -213,8 +213,10 @@ spec =
       let printArgs  = Just $ AList () u [ExpValue () u $ ValString "foo"]
           printStmt  = StPrint () u (ExpValue () u ValStar) printArgs
           printBlock = BlStatement () u Nothing printStmt
+          inner      = [printBlock]
+
       it "unlabelled" $ do
-        let bl = BlIf () u Nothing Nothing [ Just valTrue, Nothing ] [[printBlock], [printBlock]]  Nothing
+        let bl = BlIf () u Nothing Nothing ((valTrue, inner) :| []) (Just inner) Nothing
             src = unlines [ "      if (.true.) then ! comment if"
                           , "        print *, 'foo'"
                           , "      else ! comment else"
@@ -222,9 +224,10 @@ spec =
                           , "       endif ! comment end"
                           ]
         bParser src `shouldBe'` bl
+
       it "labelled" $ do
         let label = Just . intGen
-            bl = BlIf () u (label 10)  Nothing [Just valTrue, Nothing] [[printBlock], [printBlock]] (label 30)
+            bl = BlIf () u (label 10)  Nothing ((valTrue, inner) :| []) (Just inner) (label 30)
             src = unlines [ "10    if (.true.) then ! comment if"
                           , "        print *, 'foo'"
                           , "20    else ! comment else"

--- a/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
@@ -173,4 +173,4 @@ spec =
             expBinVars op x1 x2 = ExpBinary () u op (expValVar x1) (expValVar x2)
         bParser text `shouldBe'` expected
 
-    specFreeCommon sParser eParser
+    specFreeCommon bParser sParser eParser

--- a/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran90Spec.hs
@@ -427,72 +427,6 @@ spec =
           it "parses endwhere statement" $
             sParser "endwhere" `shouldBe'` StEndWhere () u Nothing
 
-    describe "If" $ do
-      let stPrint = StPrint () u starVal (Just $ fromList () [ ExpValue () u (ValString "foo")])
-      it "parser if block" $
-        let ifBlockSrc = unlines [ "if (.false.) then", "print *, 'foo'", "end if"]
-        in bParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse] [[BlStatement () u Nothing stPrint]] Nothing
-
-      it "parses named if block" $ do
-        let ifBlockSrc = unlines [ "mylabel : if (.true.) then", "print *, 'foo'", "end if mylabel"]
-            ifBlock = BlIf () u Nothing (Just "mylabel") [Just valTrue] [[BlStatement () u Nothing stPrint]] Nothing
-        bParser ifBlockSrc `shouldBe'` ifBlock
-
-      it "parses if-else block with inline comments (stripped)" $
-        let ifBlockSrc = unlines [ "if (.false.) then ! comment if", "print *, 'foo'", "else ! comment else", "print *, 'foo'", "end if ! comment end"]
-        in bParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
-
-      it "parses logical if statement" $ do
-        let assignment = StExpressionAssign () u (varGen "a") (varGen "b")
-            stIf = StIfLogical () u valTrue assignment
-        sParser "if (.true.) a = b" `shouldBe'` stIf
-
-      it "parses arithmetic if statement" $ do
-        let stIf = StIfArithmetic () u (varGen "x") (intGen 1)
-                                                    (intGen 2)
-                                                    (intGen 3)
-        sParser "if (x) 1, 2, 3" `shouldBe'` stIf
-
-    describe "Case" $ do
-      let printArgs str = Just $ AList () u [ExpValue () u $ ValString str]
-          printStmt = StPrint () u (ExpValue () u ValStar) . printArgs
-          printBlock = BlStatement () u Nothing . printStmt
-          ind2 = AList () u . pure $ IxSingle () u Nothing $ intGen 2
-          ind3Plus = AList () u . pure $ IxRange () u (Just $ intGen 3) Nothing Nothing
-          conds = [Just ind2, Just ind3Plus, Nothing]
-      it "unlabelled case block (with inline comments to be stripped)" $ do
-        let src = unlines [ "select case (x) ! comment select"
-                          , "! full line before first case (unrepresentable)"
-                          , "case (2) ! comment case 1"
-                          , "print *, 'foo'"
-                          , "case (3:) ! comment case 2"
-                          , "print *, 'bar'"
-                          , "case default ! comment case 3"
-                          , "print *, 'baz'"
-                          , "end select ! comment end"
-                          ]
-            blocks = (fmap . fmap) printBlock [["foo"], ["bar"], ["baz"]]
-            block = BlCase () u Nothing Nothing (varGen "x") conds blocks Nothing
-        bParser src `shouldBe'` block
-      it "labelled case block (with inline comments to be stripped" $ do
-        let src = unlines [ "10 mylabel: select case (x) ! comment select"
-                          , "20 case (2) ! comment case 1"
-                          , "30 print *, 'foo'"
-                          , "40 case (3:) ! comment case 2"
-                          , "50 print *, 'bar'"
-                          , "60 case default ! comment case 3"
-                          , "70 print *, 'baz'"
-                          , "80 end select mylabel ! comment end"
-                          ]
-            blocks = (fmap . fmap)
-                     (\(label, arg) -> BlStatement () u (Just $ intGen label) $ printStmt arg)
-                     [[(30, "foo")], [(50, "bar")], [(70, "baz")]]
-            block = BlCase () u
-                           (Just $ intGen 10) (Just "mylabel") (varGen "x")
-                           conds blocks
-                           (Just $ intGen 80)
-        bParser src `shouldBe'` block
-
     describe "Do" $ do
       it "parses do statement with label" $ do
         let assign = StExpressionAssign () u (varGen "i") (intGen 0)
@@ -578,4 +512,4 @@ spec =
           st = StUse () u (varGen "stats_lib") Nothing Exclusive (Just onlys)
       sParser "use stats_lib, only: a, b => c, operator(+), assignment(=)" `shouldBe'` st
 
-    specFreeCommon sParser eParser
+    specFreeCommon bParser sParser eParser

--- a/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran95Spec.hs
@@ -482,72 +482,6 @@ spec =
           it "parses endwhere statement" $
             sParser "endwhere" `shouldBe'` StEndWhere () u Nothing
 
-    describe "If" $ do
-      let stPrint = StPrint () u starVal (Just $ fromList () [ ExpValue () u (ValString "foo")])
-      it "parser if block" $
-        let ifBlockSrc = unlines [ "if (.false.) then", "print *, 'foo'", "end if"]
-        in bParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse] [[BlStatement () u Nothing stPrint]] Nothing
-
-      it "parses named if block" $ do
-        let ifBlockSrc = unlines [ "mylabel : if (.true.) then", "print *, 'foo'", "end if mylabel"]
-            ifBlock = BlIf () u Nothing (Just "mylabel") [Just valTrue] [[BlStatement () u Nothing stPrint]] Nothing
-        bParser ifBlockSrc `shouldBe'` ifBlock
-
-      it "parses if-else block with inline comments (stripped)" $
-        let ifBlockSrc = unlines [ "if (.false.) then ! comment if", "print *, 'foo'", "else ! comment else", "print *, 'foo'", "end if ! comment end"]
-        in bParser ifBlockSrc `shouldBe'` BlIf () u Nothing Nothing [Just valFalse, Nothing] [[BlStatement () u Nothing stPrint], [BlStatement () u Nothing stPrint]] Nothing
-
-      it "parses logical if statement" $ do
-        let assignment = StExpressionAssign () u (varGen "a") (varGen "b")
-            stIf = StIfLogical () u valTrue assignment
-        sParser "if (.true.) a = b" `shouldBe'` stIf
-
-      it "parses arithmetic if statement" $ do
-        let stIf = StIfArithmetic () u (varGen "x") (intGen 1)
-                                                    (intGen 2)
-                                                    (intGen 3)
-        sParser "if (x) 1, 2, 3" `shouldBe'` stIf
-
-    describe "Case" $ do
-      let printArgs str = Just $ AList () u [ExpValue () u $ ValString str]
-          printStmt = StPrint () u (ExpValue () u ValStar) . printArgs
-          printBlock = BlStatement () u Nothing . printStmt
-          ind2 = AList () u . pure $ IxSingle () u Nothing $ intGen 2
-          ind3Plus = AList () u . pure $ IxRange () u (Just $ intGen 3) Nothing Nothing
-          conds = [Just ind2, Just ind3Plus, Nothing]
-      it "unlabelled case block (with inline comments to be stripped)" $ do
-        let src = unlines [ "select case (x) ! comment select"
-                          , "! full line before first case (unrepresentable)"
-                          , "case (2) ! comment case 1"
-                          , "print *, 'foo'"
-                          , "case (3:) ! comment case 2"
-                          , "print *, 'bar'"
-                          , "case default ! comment case 3"
-                          , "print *, 'baz'"
-                          , "end select ! comment end"
-                          ]
-            blocks = (fmap . fmap) printBlock [["foo"], ["bar"], ["baz"]]
-            block = BlCase () u Nothing Nothing (varGen "x") conds blocks Nothing
-        bParser src `shouldBe'` block
-      it "labelled case block (with inline comments to be stripped" $ do
-        let src = unlines [ "10 mylabel: select case (x) ! comment select"
-                          , "20 case (2) ! comment case 1"
-                          , "30 print *, 'foo'"
-                          , "40 case (3:) ! comment case 2"
-                          , "50 print *, 'bar'"
-                          , "60 case default ! comment case 3"
-                          , "70 print *, 'baz'"
-                          , "80 end select mylabel ! comment end"
-                          ]
-            blocks = (fmap . fmap)
-                     (\(label, arg) -> BlStatement () u (Just $ intGen label) $ printStmt arg)
-                     [[(30, "foo")], [(50, "bar")], [(70, "baz")]]
-            block = BlCase () u
-                           (Just $ intGen 10) (Just "mylabel") (varGen "x")
-                           conds blocks
-                           (Just $ intGen 80)
-        bParser src `shouldBe'` block
-
     describe "Do" $ do
       it "parses do statement with label" $ do
         let assign = StExpressionAssign () u (varGen "i") (intGen 0)
@@ -647,4 +581,4 @@ spec =
           st = StDeclaration () u ty (Just (AList () u attrs)) (AList () u decls)
       sParser "integer, volatile :: a, b" `shouldBe'` st
 
-    specFreeCommon sParser eParser
+    specFreeCommon bParser sParser eParser

--- a/test/Language/Fortran/Transformation/GroupingSpec.hs
+++ b/test/Language/Fortran/Transformation/GroupingSpec.hs
@@ -208,7 +208,7 @@ ifInnerBlockSpanRaw = unlines [
   , "      end" ]
 ifInnerBlockSpan :: (String -> Block A0) -> SimpleSpan
 ifInnerBlockSpan p =
-  let BlIf _ _ _ _ _ bs _ = p ifInnerBlockSpanRaw
-  in  simplifySpan $ getSpan bs
+  let BlIf _ _ _ _ clauses elseBlock _ = p ifInnerBlockSpanRaw
+  in  simplifySpan $ getSpan (fmap snd clauses, elseBlock)
 expectedIfInnerBlockSpan :: SimpleSpan
 expectedIfInnerBlockSpan = (3, 1, 5, 35)


### PR DESCRIPTION
Previously, block IF and CASE constructs stored their conditions and
blocks separately. To use them, you had to `zip` them together, but also
handle the edge cases (ELSE, CASE DEFAULT). This change merges them into
a list of tuples. It should be easier to consume them safely, and we get
to simplify some code.

In some places, we do only want the blocks or the conditions e.g. the basic block analysis processes IF/ELSE IF conditions while ignoring the inner blocks. In such cases, we now have to write `fmap {fst,snd} tuples`. On the other hand, printing for these block constructs is now much easier to define, and we restrict our representation a bit more to what valid Fortran can look like.