### PR TITLE
use generic-optics to define First,SecondParameter

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -144,7 +144,9 @@ library
     , either >=5.0.1.1 && <5.1
     , fgl ==5.*
     , filepath ==1.4.*
+    , generic-optics >=2.2.1.0 && <2.3
     , mtl >=2.2 && <3
+    , optics-core >=0.4.1 && <0.5
     , pretty >=1.1 && <2
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2
@@ -190,7 +192,9 @@ executable fortran-src
     , fgl ==5.*
     , filepath ==1.4.*
     , fortran-src
+    , generic-optics >=2.2.1.0 && <2.3
     , mtl >=2.2 && <3
+    , optics-core >=0.4.1 && <0.5
     , pretty >=1.1 && <2
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2
@@ -267,8 +271,10 @@ test-suite spec
     , fgl ==5.*
     , filepath ==1.4.*
     , fortran-src
+    , generic-optics >=2.2.1.0 && <2.3
     , hspec >=2.2 && <3
     , mtl >=2.2 && <3
+    , optics-core >=0.4.1 && <0.5
     , pretty >=1.1 && <2
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2

--- a/package.yaml
+++ b/package.yaml
@@ -64,6 +64,8 @@ dependencies:
 - filepath >=1.4 && <1.5
 - temporary >=1.2 && <1.4
 - either ^>=5.0.1.1
+- generic-optics ^>= 2.2.1.0
+- optics-core ^>= 0.4.1
 
 # --pedantic for building (not used for stack ghci)
 ghc-options:

--- a/src/Language/Fortran/AST/Literal/Complex.hs
+++ b/src/Language/Fortran/AST/Literal/Complex.hs
@@ -31,7 +31,7 @@ data ComplexLit a = ComplexLit
     deriving anyclass (NFData, Out)
 
 instance FirstParameter  (ComplexLit a) a
-instance SecondParameter (ComplexLit a) a
+instance SecondParameter (ComplexLit a) SrcSpan
 instance Annotated       ComplexLit
 
 -- | A part (either real or imaginary) of a complex literal.

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE UndecidableInstances  #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fortran.PrettyPrint where
 
@@ -14,7 +13,6 @@ import Language.Fortran.AST.Literal.Real
 import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.AST.Literal.Complex
 import Language.Fortran.Version
-import Language.Fortran.Util.FirstParameter
 
 import Text.PrettyPrint
 
@@ -955,8 +953,6 @@ instance Pretty (Index a) where
     pprint' v (IxRange _ _ low up stride) =
        pprint' v low <> colon <> pprint' v up <> colon <?> pprint' v stride
 
--- A subset of Value permit the 'FirstParameter' operation
-instance FirstParameter (Value a) String
 instance Pretty (Value a) where
     pprint' _ ValStar       = char '*'
     pprint' _ ValColon      = char ':'
@@ -975,7 +971,11 @@ instance Pretty (Value a) where
     pprint' v (ValInteger i mkp) = text i <> pprint' v mkp
     pprint' v (ValReal rl mkp) = text (prettyHsRealLit rl) <> pprint' v mkp
     pprint' _ (ValBoz b) = text $ prettyBoz b
-    pprint' _ valLit = text . getFirstParameter $ valLit
+
+    pprint' _ (ValHollerith s) = text s
+    pprint' _ (ValVariable  s) = text s
+    pprint' _ (ValIntrinsic s) = text s
+    pprint' _ (ValType      s) = text s
 
 instance Pretty (ComplexLit a) where
     pprint' v c = parens $ commaSep [realPart, imagPart]

--- a/src/Language/Fortran/Util/SecondParameter.hs
+++ b/src/Language/Fortran/Util/SecondParameter.hs
@@ -1,76 +1,26 @@
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeApplications #-}
 
-module Language.Fortran.Util.SecondParameter(SecondParameter(..)) where
+module Language.Fortran.Util.SecondParameter
+  ( SecondParameter(..)
+  , getSecondParameter, setSecondParameter
+  ) where
 
-import GHC.Generics
+import Data.Generics.Product.Positions ( HasPosition(position) )
+import Optics.Lens ( Lens )
+import Optics.Getter ( view )
+import Optics.Setter ( set )
 
-class SecondParameter a e | a -> e where
-  getSecondParameter :: a -> e
-  setSecondParameter :: e -> a -> a
+class SecondParameter s a | s -> a where
+  lensSecondParameter :: Lens s s a a
 
-  default getSecondParameter :: (Generic a, GSecondParameter (Rep a) e) => a -> e
-  getSecondParameter = getSecondParameter' . from
+  default lensSecondParameter :: HasPosition 2 s s a a => Lens s s a a
+  lensSecondParameter = position @2
 
-  default setSecondParameter :: (Generic a, GSecondParameter (Rep a) e) => e -> a -> a
-  setSecondParameter e = to . setSecondParameter' e . from
+getSecondParameter :: SecondParameter s a => s -> a
+getSecondParameter = view lensSecondParameter
 
-class GSecondParameter f e where
-  getSecondParameter' :: f a -> e
-  setSecondParameter' :: e -> f a -> f a
-
-instance GSecondParameter (K1 i a) e where
-  getSecondParameter' _ = undefined
-  setSecondParameter' _ = undefined
-
-instance GSecondParameter a e => GSecondParameter (M1 i c a) e where
-  getSecondParameter' (M1 x) = getSecondParameter' x
-  setSecondParameter' e (M1 x) = M1 $ setSecondParameter' e x
-
-instance (GSecondParameter a e, GSecondParameter b e) => GSecondParameter (a :+: b) e where
-  getSecondParameter' (L1 a) = getSecondParameter' a
-  getSecondParameter' (R1 a) = getSecondParameter' a
-
-  setSecondParameter' e (L1 a) = L1 $ setSecondParameter' e a
-  setSecondParameter' e (R1 a) = R1 $ setSecondParameter' e a
-
-instance (ParameterLeaf a, GSecondParameter a e, GSecondParameter' b e) => GSecondParameter (a :*: b) e where
-  getSecondParameter' (a :*: b) = 
-    if isLeaf a 
-    then getSecondParameter'' b
-    else getSecondParameter' a
-
-  setSecondParameter' e (a :*: b) = 
-    if isLeaf a 
-    then a :*: setSecondParameter'' e b
-    else setSecondParameter' e a :*: b
-
-class GSecondParameter' f e where
-  getSecondParameter'' :: f a -> e
-  setSecondParameter'' :: e -> f a -> f a
-
-instance GSecondParameter' a e => GSecondParameter' (M1 i c a) e where
-  getSecondParameter'' (M1 a) = getSecondParameter'' a
-  setSecondParameter'' e (M1 a) = M1 $ setSecondParameter'' e a
-
-instance GSecondParameter' a e => GSecondParameter' (a :*: b) e where
-  getSecondParameter'' (a :*: _) = getSecondParameter'' a
-  setSecondParameter'' e (a :*: b) = setSecondParameter'' e a :*: b
-
-instance {-# OVERLAPPING #-} GSecondParameter' (K1 i e) e where
-  getSecondParameter'' (K1 a) = a
-  setSecondParameter'' e (K1 _) = K1 e
-
-instance {-# OVERLAPPABLE #-} GSecondParameter' (K1 i a) e where
-  getSecondParameter'' _ = undefined
-  setSecondParameter'' _ _  = undefined
-
-class ParameterLeaf f where
-  isLeaf :: f a -> Bool
-
-instance ParameterLeaf (M1 i c a) where
-  isLeaf _ = True
-
-instance ParameterLeaf (a :*: b) where
-  isLeaf _ = False
+setSecondParameter :: SecondParameter s a => a -> s -> s
+setSecondParameter = set lensSecondParameter

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,8 @@
-resolver: lts-16.28
+resolver: lts-19.6
 packages:
 - '.'
 save-hackage-creds: false
+
+extra-deps:
+- generic-optics-2.2.1.0@sha256:738a87c90070dccebf643dda93773aa6f4819eb5df8be3ceaefbec1542ac14bc,3744
+- optics-0.4.1@sha256:0b85afb3c88a474da9db2986b4ff9d15195f6b220cc4c557968cfb0fdb915526,7560

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,24 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: generic-optics-2.2.1.0@sha256:738a87c90070dccebf643dda93773aa6f4819eb5df8be3ceaefbec1542ac14bc,3744
+    pantry-tree:
+      size: 2173
+      sha256: 55628691fc178bbba0fea0c6637a2e304113d0d0e48cb2580222cc2f13398325
+  original:
+    hackage: generic-optics-2.2.1.0@sha256:738a87c90070dccebf643dda93773aa6f4819eb5df8be3ceaefbec1542ac14bc,3744
+- completed:
+    hackage: optics-0.4.1@sha256:0b85afb3c88a474da9db2986b4ff9d15195f6b220cc4c557968cfb0fdb915526,7560
+    pantry-tree:
+      size: 1157
+      sha256: 1e011868453a8c81e6635fb664900287798f2bacb4eeafb2229c13cdd21aea4a
+  original:
+    hackage: optics-0.4.1@sha256:0b85afb3c88a474da9db2986b4ff9d15195f6b220cc4c557968cfb0fdb915526,7560
 snapshots:
 - completed:
-    size: 533053
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/28.yaml
-    sha256: a9c01d860ac8dfb3a1b6f7ec4a36dd9504a95392b89c99b0877da63fa36a8e97
-  original: lts-16.28
+    size: 618876
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/6.yaml
+    sha256: fb634b19f31da06684bb07ce02a20c75a3162138f279b388905b03ebd57bb50f
+  original: lts-19.6


### PR DESCRIPTION
Our generics code was unsafe in that if you tried to derive an instance
which was invalid (e.g. you say an `a` is the first parameter in each
constructor, but it isn't), it would still derive an instance, but give
you an `undefined` runtime error upon using it. Pushing that error to
compile time is complex, but it's a solved problem by kcsongor's in his
wonderful generic-lens library.

This change adds generic-optics and optics-core to dependencies. They're
very lightweight. Performance should be the same; compile time should
most likely increase.