### PR TITLE
document Fst/SndParam safety, fix erroneous instances

### DIFF
--- a/src/Language/Fortran/AST/Literal.hs
+++ b/src/Language/Fortran/AST/Literal.hs
@@ -1,15 +1,23 @@
 module Language.Fortran.AST.Literal where
 
 import Language.Fortran.AST.Common ( Name )
-import Language.Fortran.Util.Position ( SrcSpan )
+import Language.Fortran.Util.Position ( SrcSpan, Spanned )
+import Language.Fortran.Util.FirstParameter  ( FirstParameter )
+import Language.Fortran.Util.SecondParameter ( SecondParameter )
+import Language.Fortran.AST.Annotated ( Annotated )
 
-import           GHC.Generics                   ( Generic )
-import           Data.Data                      ( Data, Typeable )
-import           Control.DeepSeq                ( NFData )
-import           Text.PrettyPrint.GenericPretty ( Out )
+import GHC.Generics                   ( Generic )
+import Data.Data                      ( Data, Typeable )
+import Control.DeepSeq                ( NFData )
+import Text.PrettyPrint.GenericPretty ( Out )
 
 data KindParam a
   = KindParamInt a SrcSpan String -- ^ @[0-9]+@
   | KindParamVar a SrcSpan Name   -- ^ @[a-z][a-z0-9]+@ (case insensitive)
     deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
     deriving anyclass (NFData, Out)
+
+instance FirstParameter  (KindParam a) a
+instance Annotated       KindParam
+instance SecondParameter (KindParam a) SrcSpan
+instance Spanned         (KindParam a)

--- a/src/Language/Fortran/AST/Literal/Complex.hs
+++ b/src/Language/Fortran/AST/Literal/Complex.hs
@@ -5,7 +5,7 @@ module Language.Fortran.AST.Literal.Complex where
 import Language.Fortran.AST.Common ( Name )
 import Language.Fortran.AST.Literal ( KindParam )
 import Language.Fortran.AST.Literal.Real
-import Language.Fortran.Util.Position ( SrcSpan )
+import Language.Fortran.Util.Position ( SrcSpan, Spanned )
 
 import GHC.Generics                   ( Generic )
 import Data.Data                      ( Data, Typeable )
@@ -31,8 +31,9 @@ data ComplexLit a = ComplexLit
     deriving anyclass (NFData, Out)
 
 instance FirstParameter  (ComplexLit a) a
-instance SecondParameter (ComplexLit a) a
 instance Annotated       ComplexLit
+instance SecondParameter (ComplexLit a) SrcSpan
+instance Spanned         (ComplexLit a)
 
 -- | A part (either real or imaginary) of a complex literal.
 --
@@ -52,3 +53,8 @@ data ComplexPart a
   | ComplexPartNamed  a SrcSpan Name                          -- ^ named constant
     deriving stock    (Eq, Show, Data, Typeable, Generic, Functor)
     deriving anyclass (NFData, Out)
+
+instance FirstParameter  (ComplexPart a) a
+instance Annotated       ComplexPart
+instance SecondParameter (ComplexPart a) SrcSpan
+instance Spanned         (ComplexPart a)

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE UndecidableInstances  #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fortran.PrettyPrint where
 
@@ -14,7 +13,6 @@ import Language.Fortran.AST.Literal.Real
 import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.AST.Literal.Complex
 import Language.Fortran.Version
-import Language.Fortran.Util.FirstParameter
 
 import Text.PrettyPrint
 
@@ -955,8 +953,6 @@ instance Pretty (Index a) where
     pprint' v (IxRange _ _ low up stride) =
        pprint' v low <> colon <> pprint' v up <> colon <?> pprint' v stride
 
--- A subset of Value permit the 'FirstParameter' operation
-instance FirstParameter (Value a) String
 instance Pretty (Value a) where
     pprint' _ ValStar       = char '*'
     pprint' _ ValColon      = char ':'
@@ -975,7 +971,11 @@ instance Pretty (Value a) where
     pprint' v (ValInteger i mkp) = text i <> pprint' v mkp
     pprint' v (ValReal rl mkp) = text (prettyHsRealLit rl) <> pprint' v mkp
     pprint' _ (ValBoz b) = text $ prettyBoz b
-    pprint' _ valLit = text . getFirstParameter $ valLit
+
+    pprint' _ (ValHollerith s) = text s
+    pprint' _ (ValVariable  s) = text s
+    pprint' _ (ValIntrinsic s) = text s
+    pprint' _ (ValType      s) = text s
 
 instance Pretty (ComplexLit a) where
     pprint' v c = parens $ commaSep [realPart, imagPart]

--- a/src/Language/Fortran/Util/FirstParameter.hs
+++ b/src/Language/Fortran/Util/FirstParameter.hs
@@ -1,3 +1,18 @@
+{-|
+A convenience class for retrieving the first field of any constructor in a
+datatype.
+
+The primary usage for this class is generic derivation:
+
+    data D a = D a () String deriving Generic
+    instance FirstParameter (D a) a
+
+Note that _the deriver does not check you are requesting a valid/safe instance._
+Invalid instances propagate the error to runtime. Fixing this requires a lot
+more type-level work. (The generic-lens library has a general solution, but it's
+slow and memory-consuming.)
+-}
+
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FunctionalDependencies #-}

--- a/src/Language/Fortran/Util/SecondParameter.hs
+++ b/src/Language/Fortran/Util/SecondParameter.hs
@@ -1,3 +1,18 @@
+{-|
+A convenience class for retrieving the first field of any constructor in a
+datatype.
+
+The primary usage for this class is generic derivation:
+
+    data D a = D a () String deriving Generic
+    instance SecondParameter (D a) ()
+
+Note that _the deriver does not check you are requesting a valid/safe instance._
+Invalid instances propagate the error to runtime. Fixing this requires a lot
+more type-level work. (The generic-lens library has a general solution, but it's
+slow and memory-consuming.)
+-}
+
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FunctionalDependencies #-}


### PR DESCRIPTION
I wrote an erroneous SecondParameter instance for a literal that would
always fail at runtime. Along with fixing that, I swapped out an unsafe
orphan instance derived for `Value` (since it apparently only saved on
writing a couple more lines).

I tried putting the safety check in the generic derivation, but I
couldn't get it to work. Copying from generic-lens works, but it has to
do too much work, and bumps Language.Fortran.AST compilation time x4 and
memory usage to x3 - way too much. So instead, I've noted their
behaviour in the respective module.