### PR TITLE
Fix block parsing

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -26,6 +26,7 @@ extra-source-files:
     README.md
     CHANGELOG.md
     test-data/f77-include/foo.f
+    test-data/f77-include/no-newline/foo.f
     test-data/rewriter/replacementsmap-columnlimit/001_foo.f
     test-data/rewriter/replacementsmap-columnlimit/001_foo.f.expected
     test-data/rewriter/replacementsmap-columnlimit/002_other.f

--- a/src/Language/Fortran/Parser.hs
+++ b/src/Language/Fortran/Parser.hs
@@ -280,9 +280,7 @@ f77lIncludesInline dirs seen st = case st of
         Just blocks' -> pure $ StInclude a s e (Just blocks')
         Nothing -> do
           (fullPath, inc) <- liftIO $ readInDirs dirs path
-          -- Append newline to include, as grammar is defined to expect a
-          -- newline at the end of most blocks
-          case f77lIncludesInner fullPath (B.snoc inc '\n') of
+          case f77lIncludesInner fullPath inc of
             Right blocks -> do
               blocks' <- descendBiM (f77lIncludesInline dirs (path:seen)) blocks
               modify (Map.insert path blocks')

--- a/test-data/f77-include/no-newline/foo.f
+++ b/test-data/f77-include/no-newline/foo.f
@@ -1,0 +1,1 @@
+      integer a

--- a/test/Language/Fortran/Parser/Fixed/Fortran77/IncludeSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/Fortran77/IncludeSpec.hs
@@ -22,31 +22,35 @@ spec =
                           "      include 'foo.f'",
                           "      end"
                          ]
-        inc = "./test-data/f77-include"
         name = "bar"
-        pf = ProgramFile mi77' [pu]
         puSpan = makeSrcR (6,7,1,"<unknown>") (48,9,3,"<unknown>")
         st1Span = makeSrcR (24,7,2,"<unknown>") (38,21,2,"<unknown>")
         expSpan = makeSrcR (32,15,2,"<unknown>") (38,21,2,"<unknown>")
+        pf inc = ProgramFile mi77' [pu]
+         where
+          -- the expansion returns the span in the included file
+          -- it should return the span at the inclusion
+          foo = inc </> "foo.f"
+          st2Span = makeSrcR (6,7,1, foo) (14,15,1,foo)
+          declSpan = makeSrcR (6,7,1,foo) (14,15,1,foo)
+          typeSpan = makeSrcR (6,7,1,foo) (12,13,1,foo)
+          blockSpan = makeSrcR (14,15,1,foo) (14,15,1,foo)
+          varGen' str =  ExpValue () blockSpan $ ValVariable str
 
-        -- the expansion returns the span in the included file
-        -- it should return the span at the inclusion
-        foo = inc </> "foo.f"
-        st2Span = makeSrcR (6,7,1, foo) (14,15,1,foo)
-        declSpan = makeSrcR (6,7,1,foo) (14,15,1,foo)
-        typeSpan = makeSrcR (6,7,1,foo) (12,13,1,foo)
-        blockSpan = makeSrcR (14,15,1,foo) (14,15,1,foo)
-        varGen' str =  ExpValue () blockSpan $ ValVariable str
-
-        pu = PUMain () puSpan (Just name) blocks Nothing
-        blocks = [bl1]
-        decl = Declarator () blockSpan (varGen' "a") ScalarDecl Nothing Nothing
-        typeSpec = TypeSpec () typeSpan TypeInteger Nothing
-        st2 = StDeclaration () st2Span typeSpec Nothing (AList () blockSpan [decl])
-        bl1 = BlStatement () st1Span Nothing st1
-        st1 = StInclude () st1Span ex (Just [bl2])
-        ex = ExpValue () expSpan (ValString "foo.f")
-        bl2 = BlStatement () declSpan Nothing st2
+          pu = PUMain () puSpan (Just name) blocks Nothing
+          blocks = [bl1]
+          decl = Declarator () blockSpan (varGen' "a") ScalarDecl Nothing Nothing
+          typeSpec = TypeSpec () typeSpan TypeInteger Nothing
+          st2 = StDeclaration () st2Span typeSpec Nothing (AList () blockSpan [decl])
+          bl1 = BlStatement () st1Span Nothing st1
+          st1 = StInclude () st1Span ex (Just [bl2])
+          ex = ExpValue () expSpan (ValString "foo.f")
+          bl2 = BlStatement () declSpan Nothing st2
     it "includes some files and expands them" $ do
+      let inc = "." </> "test-data" </> "f77-include"
       pfParsed <- iParser [inc] source
-      pfParsed `shouldBe` pf
+      pfParsed `shouldBe` pf inc
+    it "includes without a newline behave the same" $ do 
+      let inc = "." </> "test-data" </> "f77-include" </> "no-newline"
+      pfParsed <- iParser [inc] source
+      pfParsed `shouldBe` pf inc

--- a/test/Language/Fortran/Parser/Fixed/Fortran77/ParserSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/Fortran77/ParserSpec.hs
@@ -11,6 +11,7 @@ import qualified Language.Fortran.Parser.Fixed.Fortran77 as F77
 import qualified Language.Fortran.Parser.Fixed.Lexer     as Fixed
 
 import Prelude hiding ( exp )
+import Data.List ( intercalate )
 import qualified Data.ByteString.Char8 as B
 
 parseWith :: FortranVersion -> Parse Fixed.AlexInput Fixed.Token a -> String -> a
@@ -217,23 +218,25 @@ spec =
 
       it "unlabelled" $ do
         let bl = BlIf () u Nothing Nothing ((valTrue, inner) :| []) (Just inner) Nothing
-            src = unlines [ "      if (.true.) then ! comment if"
-                          , "        print *, 'foo'"
-                          , "      else ! comment else"
-                          , "        print *, 'foo'"
-                          , "       endif ! comment end"
-                          ]
+            src = intercalate "\n"
+              [ "      if (.true.) then ! comment if"
+              , "        print *, 'foo'"
+              , "      else ! comment else"
+              , "        print *, 'foo'"
+              , "       endif ! comment end"
+              ]
         bParser src `shouldBe'` bl
 
       it "labelled" $ do
         let label = Just . intGen
             bl = BlIf () u (label 10)  Nothing ((valTrue, inner) :| []) (Just inner) (label 30)
-            src = unlines [ "10    if (.true.) then ! comment if"
-                          , "        print *, 'foo'"
-                          , "20    else ! comment else"
-                          , "        print *, 'foo'"
-                          , "30     endif ! comment end"
-                          ]
+            src = intercalate "\n"
+              [ "10    if (.true.) then ! comment if"
+              , "        print *, 'foo'"
+              , "20    else ! comment else"
+              , "        print *, 'foo'"
+              , "30     endif ! comment end"
+              ]
         bParser src `shouldBe'` bl
 
     describe "Legacy Extensions" $ do


### PR DESCRIPTION
The way it currently worked meant it would fail to parse includes that
didn't end with a newline, which is valid. To allow this the block
parsing had to be reorganized, with the block parser not expecting
trailing newlines, but otherwise behaves the same.

We might want to do this for other parsers, but because they currently
don't expand includes, it's not actually a problem for them.