### PR TITLE
Rewriter Fixes

### DIFF
--- a/test-data/rewriter/replacementsmap-columnlimit/004_comment.f
+++ b/test-data/rewriter/replacementsmap-columnlimit/004_comment.f
@@ -6,6 +6,6 @@ c     This is the API for foo subroutine. We take in some inputs, apply some coo
         some_string = "some_string"
 
         if (foo) then
-            IF (some_string(0).eq.'s') foo=9                              Text after col 72 are comments and should remain
+            IF (some_string(0).eq.'s') foo=9                            Text after col 72 are comments and should remain
         endif
       end

--- a/test-data/rewriter/replacementsmap-columnlimit/004_comment.f.expected
+++ b/test-data/rewriter/replacementsmap-columnlimit/004_comment.f.expected
@@ -7,6 +7,6 @@ c     This is the API for foo subroutine. We take in some inputs, apply some coo
 
         if (foo) then
             IF (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-     +(0).eq.'s') foo=9                                                   Text after col 72 are comments and should remain
+     +(0).eq.'s') foo=9                                                 Text after col 72 are comments and should remain
         endif
       end


### PR DESCRIPTION
Wrapping implicit comments - contributed by Anthony Burzillo
* Add test with incorrect wrapping for comments
* Add test for continuation comments
* Add failing test related to the context of coments after replacement
* Fix comments after forced continuations
* Refactor chunk expansion with documentation
* Add test for inline comments going over 72

Fix incorrect line wrap from eager comment detection - contributed by Vaibhav Yenamandra
* Track quotations between chunks while searching
* When looking for a '!' in source, search outside strings