### PR TITLE
Make sure non literals have parens where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+  *  fix missing parentheses when pretty printing certain syntax #233
+
 ### 0.10.1 (Aug 1, 2022)
   * export `ParseErrorSimple` from `Parser`, not internal module `Parser.Monad`
   * rewriter fixes #232

--- a/src/Language/Fortran/AST.hs
+++ b/src/Language/Fortran/AST.hs
@@ -174,7 +174,8 @@ data TypeSpec a = TypeSpec
   , typeSpecSelector :: Maybe (Selector a)
   } deriving stock (Eq, Show, Data, Generic, Functor)
 
--- | The "kind selector" of a declaration statement.
+-- | The "kind selector" of a declaration statement. Tightly bound to
+--   'TypeSpec'.
 --
 -- HP's F90 spec (pg.24) actually differentiates between "kind selectors" and
 -- "char selectors", where char selectors can specify a length (alongside kind),
@@ -185,6 +186,10 @@ data TypeSpec a = TypeSpec
 -- The upshot is, length is invalid for non-CHARACTER types, and the parser
 -- guarantees that it will be Nothing. For CHARACTER types, both maybe or may
 -- not be present.
+--
+-- Often used with the assumption that when a 'Selector' term is present, it
+-- contains some information (i.e. one of length or kind is @'Just' _@), so that
+-- the awkward "empty" possibility may be avoided.
 data Selector a = Selector
   { selectorAnno :: a
   , selectorSpan :: SrcSpan

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -148,12 +148,11 @@ spec =
 
         it "prints ValStar with parens" $ do
           let sel = Selector () u (Just $ ExpValue () u ValStar) Nothing
-              typeSpec = TypeSpec () u TypeCharacter (Just sel) 
+              typeSpec = TypeSpec () u TypeCharacter (Just sel)
               decl = Declarator () u (varGen "x") ScalarDecl (Just $ ExpValue () u ValStar) Nothing
               st = StDeclaration () u typeSpec Nothing (AList () u [decl])
               expect = "character*(*) x*(*)"
           pprint Fortran77 st Nothing `shouldBe` expect
-             
 
       describe "Intent" $
         it "prints intent statement" $ do

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -146,6 +146,15 @@ spec =
           let st = StDeclaration () u typeSpec Nothing (AList () u declList)
           pprint Fortran77 st Nothing `shouldBe` "integer x(5)/1, 2, 3, 4, 5/"
 
+        it "prints ValStar with parens" $ do
+          let sel = Selector () u (Just $ ExpValue () u ValStar) Nothing
+              typeSpec = TypeSpec () u TypeCharacter (Just sel) 
+              decl = Declarator () u (varGen "x") ScalarDecl (Just $ ExpValue () u ValStar) Nothing
+              st = StDeclaration () u typeSpec Nothing (AList () u [decl])
+              expect = "character*(*) x*(*)"
+          pprint Fortran77 st Nothing `shouldBe` expect
+             
+
       describe "Intent" $
         it "prints intent statement" $ do
           let exps = [ varGen "x", varGen "y" ]


### PR DESCRIPTION
Otherwise pretty printing declarations results in invalid fortran such as `foo**` rather than `foo*(*)`.