### PR TITLE
Catch more legacy comments

### DIFF
--- a/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
@@ -294,11 +294,11 @@ spec =
         resetSrcSpan (collectFixedTokens' Fortran77Legacy src) `shouldBe`
           resetSrcSpan [ TId u "l", TOpAssign u, TId u "r", TNewline u
                        , TId u "r", TOpAssign u, TId u "l", TNewline u, TEOF u]
-      it "lexel comment line overflow" $ do
+      it "lexes all comment line even with overflow" $ do
         let src = unlines [ replicate 80 'c'
                           , "      l = r" ]
         resetSrcSpan (collectFixedTokens' Fortran77Legacy src) `shouldBe`
-          resetSrcSpan [ TComment u (replicate 71 'c'), TNewline u
+          resetSrcSpan [ TComment u (replicate 79 'c'), TNewline u
                        , TId u "l", TOpAssign u, TId u "r", TNewline u, TEOF u]
 
 example1 :: String

--- a/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/LexerSpec.hs
@@ -166,6 +166,10 @@ spec =
         resetSrcSpan (collectFixedTokens' Fortran77Legacy "      integer foo ! bar")
           `shouldBe` resetSrcSpan [TType u "integer", TId u "foo", TEOF u]
 
+      it "lexes inline comments as blocks when possible" $
+        resetSrcSpan (collectFixedTokens' Fortran77Legacy "\n      ! Block")
+          `shouldBe` resetSrcSpan [TNewline u, TComment u " Block", TEOF u]
+
       it "lexes continuation lines separated by comments" $ do
         let src = unlines [ "      integer foo,"
                           , "C hello"


### PR DESCRIPTION
Three changes to the fixed lexer:
* Catch inline comments when they're the only thing on a line.
* Catch them case sensitively. Not sure why this wasn't the case before but information in the comments might be lost otherwise.
* Catch parts of comments that go over column 72. Once again there might be information that's lost otherwise.

Resolves #236.