### PR TITLE
Fix pad implicit comments

### DIFF
--- a/test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f
+++ b/test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f
@@ -1,0 +1,4 @@
+      program main
+      integer hello*4 ! This is a long comment that goes over the 72 columns
+     +      , hello2*2
+      end program main

--- a/test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f.expected
+++ b/test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f.expected
@@ -1,0 +1,5 @@
+      program main
+      ! This is a long comment that goes over the 72 columns
+      integer*4 hello
+      integer*2 hello2
+      end program main

--- a/test/Language/Fortran/RewriterSpec.hs
+++ b/test/Language/Fortran/RewriterSpec.hs
@@ -300,6 +300,26 @@ spec = do
         , "006_linewrap_heuristic.f"
         ]
 #endif
+    it "implicit comment removal" $ do
+      base <- getCurrentDirectory
+      let
+        body workDir = processReplacements $ M.fromList
+          [ ( workDir ++ "001_foo.f"
+            , [ Replacement
+                  (SourceRange (SourceLocation 1 0) (SourceLocation 3 0))
+                  $ unlines [ "      ! This is a long comment that goes over the 72 columns"
+                            , "      integer*4 hello"
+                            , "      integer*2 hello2"
+                            ]
+              ]
+            )
+          ]
+      wrapReplacementsMapInvocationTestHelper
+        body
+        base
+        Nothing
+        "replacementsmap-padimplicitcomment"
+        [ "001_foo.f" ]
 
   describe "Filtering overlapping replacements" $ do
     it "Simple overlap" $ do


### PR DESCRIPTION
It was getting run for RChar removals, which are run in per character chunks and ended up adding a line with a single character as an implicit comment with no newline and breaking the source.