### PR TITLE
Add missing instances for ArgumentExpression; more common parser definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     case sensitive, parse beyond column 72 (#237, @RaoulHC)
   * allow `ExpDataRef` constructor in `varName` (fixes a crash in type analysis
     #238)
+  * add `Annotated`, `Spanned` instances for intermediate AST data type
+    `ArgumentExpression`
 
 ### 0.10.2 (Aug 18, 2022)
   * fix missing parentheses when pretty printing certain syntax #233

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     #238)
   * add `Annotated`, `Spanned` instances for intermediate AST data type
     `ArgumentExpression`
+  * export statement-level "pre-prepared" parsers (previously, you would have to
+    define the parser yourself using parser utils and the Happy parser export)
 
 ### 0.10.2 (Aug 18, 2022)
   * fix missing parentheses when pretty printing certain syntax #233

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -200,9 +200,9 @@ library
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
     , vector-sized >=1.5.0 && <1.6
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DFS_DISABLE_WIN_BROKEN_TESTS
-  default-language: Haskell2010
 
 executable fortran-src
   main-is: Main.hs
@@ -264,9 +264,9 @@ executable fortran-src
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
     , vector-sized >=1.5.0 && <1.6
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DFS_DISABLE_WIN_BROKEN_TESTS
-  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -360,6 +360,6 @@ test-suite spec
     , text >=1.2 && <2
     , uniplate >=1.6 && <2
     , vector-sized >=1.5.0 && <1.6
+  default-language: Haskell2010
   if os(windows)
     cpp-options: -DFS_DISABLE_WIN_BROKEN_TESTS
-  default-language: Haskell2010

--- a/src/Language/Fortran/Parser.hs
+++ b/src/Language/Fortran/Parser.hs
@@ -23,6 +23,12 @@ module Language.Fortran.Parser
   -- * Other parsers
   , f90Expr
 
+  -- ** Statement
+  , byVerStmt
+  , f66StmtNoTransform, f77StmtNoTransform, f77eStmtNoTransform
+    , f77lStmtNoTransform, f90StmtNoTransform, f95StmtNoTransform
+    , f2003StmtNoTransform
+
   -- * Various combinators
   , transformAs, defaultTransformation
   , Parser, ParseErrorSimple(..)
@@ -138,6 +144,30 @@ f77lNoTransform  = makeParserFixed F77.programParser   Fortran77Legacy
 f90NoTransform   = makeParserFree  F90.programParser   Fortran90
 f95NoTransform   = makeParserFree  F95.programParser   Fortran95
 f2003NoTransform = makeParserFree  F2003.programParser Fortran2003
+
+f66StmtNoTransform, f77StmtNoTransform, f77eStmtNoTransform, f77lStmtNoTransform,
+  f90StmtNoTransform, f95StmtNoTransform, f2003StmtNoTransform
+    :: Parser (Statement A0)
+f66StmtNoTransform   = makeParserFixed F66.statementParser   Fortran66
+f77StmtNoTransform   = makeParserFixed F77.statementParser   Fortran77
+f77eStmtNoTransform  = makeParserFixed F77.statementParser   Fortran77Extended
+f77lStmtNoTransform  = makeParserFixed F77.statementParser   Fortran77Legacy
+f90StmtNoTransform   = makeParserFree  F90.statementParser   Fortran90
+f95StmtNoTransform   = makeParserFree  F95.statementParser   Fortran95
+f2003StmtNoTransform = makeParserFree  F2003.statementParser Fortran2003
+
+byVerStmt :: FortranVersion -> Parser (Statement A0)
+byVerStmt = \case
+  Fortran66         -> f66StmtNoTransform
+  Fortran77         -> f77StmtNoTransform
+  Fortran77Extended -> f77eStmtNoTransform
+  Fortran77Legacy   -> f77lStmtNoTransform
+  Fortran90         -> f90StmtNoTransform
+  Fortran95         -> f95StmtNoTransform
+  Fortran2003       -> f2003StmtNoTransform
+  v                 -> error $  "Language.Fortran.Parser.byVerStmt: "
+                             <> "no parser available for requested version: "
+                             <> show v
 
 f90Expr :: Parser (Expression A0)
 f90Expr = makeParser initParseStateFreeExpr F90.expressionParser Fortran90


### PR DESCRIPTION
Missed some weirder instances for a weirder data "intermediate" data type, so added with commentary.

With the previous change to parser exporting, we can define lots of useful parsers directly in fortran-src. e.g. CamFort uses a statement parser for F90; this change lets us request the F90 statement parser from fortran-src instead (and we can also request by version to enable extra parametricity).