### PR TITLE
Don't inline solo includes

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -45,6 +45,8 @@ extra-source-files:
     test-data/rewriter/replacementsmap-overlapping-filtered/001_foo.f.expected
     test-data/rewriter/replacementsmap-overlapping/001_foo.f
     test-data/rewriter/replacementsmap-overlapping/001_foo.f.expected
+    test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f
+    test-data/rewriter/replacementsmap-padimplicitcomment/001_foo.f.expected
     test-data/rewriter/replacementsmap-simple/001_foo.f
     test-data/rewriter/replacementsmap-simple/001_foo.f.expected
     test-data/rewriter/replacementsmap-simple/002_foo.f

--- a/src/Language/Fortran/Parser.hs
+++ b/src/Language/Fortran/Parser.hs
@@ -303,14 +303,13 @@ f77lIncludes incs mods fn bs = do
 -- | Entry point for include files
 -- 
 -- We can't perform full analysis (though it might be possible to do in future)
--- but the AST is enough for certain types of analysis/refactoring
+-- but a list of blocks is enough for certain types of analysis/refactoring
 f77lIncIncludes
-  :: [FilePath] -> String -> B.ByteString -> IO [Block A0]
-f77lIncIncludes incs fn bs =
+  :: String -> B.ByteString -> IO [Block A0]
+f77lIncIncludes fn bs =
   case makeParserFixed F77.includesParser Fortran77Legacy fn bs of
     Left e -> liftIO $ throwIO e
-    Right bls ->
-      evalStateT (descendBiM (f77lIncludesInline incs []) bls) Map.empty
+    Right bls -> pure bls
 
 f77lIncludesInner :: Parser [Block A0]
 f77lIncludesInner = makeParserFixed F77.includesParser Fortran77Legacy

--- a/test/Language/Fortran/Parser/Fixed/Fortran77/IncludeSpec.hs
+++ b/test/Language/Fortran/Parser/Fixed/Fortran77/IncludeSpec.hs
@@ -6,13 +6,13 @@ import System.FilePath
 import Test.Hspec
 import TestUtil
 
-import Language.Fortran.Parser ( f77lIncludes )
+import qualified Language.Fortran.Parser as Parser
 import Language.Fortran.AST
 import Language.Fortran.Util.Position
 import qualified Data.ByteString.Char8 as B
 
 iParser :: [String] -> String -> IO (ProgramFile A0)
-iParser incs = f77lIncludes incs mempty "<unknown>" . B.pack
+iParser incs = Parser.f77lInlineIncludes incs mempty "<unknown>" . B.pack
 
 makeSrcR :: (Int, Int, Int, String) -> (Int, Int, Int, String) -> SrcSpan
 makeSrcR (i1, i2, i3, s) (j1, j2, j3, s') = SrcSpan (Position i1 i2 i3 s Nothing) (Position j1 j2 j3 s' Nothing)


### PR DESCRIPTION
When dealing with solo includes we don't have the context to know where its includes are so we probably shouldn't be inlining them.

Happy for this to be named something else. 
I'm also unsure if there are cases where we want to inline includes still, but I don't think we'll have the context for our use cases, but if you can think of one maybe it will make sense for us to have a function that inlines them and one that doesn't.