### PR TITLE
Line directive pragma handling in freeform lexer

### DIFF
--- a/src/Language/Fortran/Parser/Free/Lexer.x
+++ b/src/Language/Fortran/Parser/Free/Lexer.x
@@ -1105,12 +1105,12 @@ advance move position =
 
 processLinePragma :: String -> AlexInput -> AlexInput
 processLinePragma m ai =
-  case words (drop 1 m) of
+  case dropWhile ((`elem` ["#", "line", "#line"]) . map toLower) (words m) of
     -- 'line' pragma - rewrite the current line and filename
-    "line":lineStr:_
+    lineStr:otherWords
       | line <- readIntOrBoz lineStr -> do
         let revdropWNQ = reverse . drop 1 . dropWhile (flip notElem "'\"")
-        let file       = revdropWNQ . revdropWNQ $ m
+        let file       = revdropWNQ . revdropWNQ $ unwords otherWords
         -- lineOffs is the difference between the given line and the current next line
         let lineOffs   = fromIntegral line - (posLine (aiPosition ai) + 1)
         let newP       = (aiPosition ai) { posPragmaOffset = Just (lineOffs, file)

--- a/test/Language/Fortran/Parser/Free/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Free/LexerSpec.hs
@@ -295,6 +295,10 @@ spec =
           shouldBe (ppoOf <$> collectF90 "i = &\n #line 40 \"file.f\"\n  42") $
                    ppoOf <$> lpToks
 
+        it "Continuation with line pragma (CPP style)" $
+          shouldBe (ppoOf <$> collectF90 "i = &\n # 40 \"file.f\"\n  42") $
+                   ppoOf <$> lpToks
+
       describe "Comment" $ do
         it "Full line comment" $
           shouldBe' (collectF90 "! = & ! hi \n") $

--- a/test/Language/Fortran/Parser/Free/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Free/LexerSpec.hs
@@ -295,8 +295,32 @@ spec =
           shouldBe (ppoOf <$> collectF90 "i = &\n #line 40 \"file.f\"\n  42") $
                    ppoOf <$> lpToks
 
+        it "Continuation with line pragma (tokens)" $
+          shouldBe' (collectF90 "i = &\n #line 40 \"file.f\"\n  42")
+                    lpToks
+
         it "Continuation with line pragma (CPP style)" $
           shouldBe (ppoOf <$> collectF90 "i = &\n # 40 \"file.f\"\n  42") $
+                   ppoOf <$> lpToks
+
+      describe "Line pragma directives" $ do
+        -- posPragmaOffset is the difference between the given line and the current next line.
+        let testPos = initPosition { posPragmaOffset = Just (40 - (2 + 1), "file.f") }
+            testSS = SrcSpan testPos testPos
+            lpToks = fmap ($initSrcSpan) [ flip TId "i", TOpAssign, flip TIntegerLiteral "42", TNewline ] ++
+                     fmap ($testSS) [flip TId "j", TOpAssign, flip TIntegerLiteral "42", TEOF ]
+            ppoOf  = posPragmaOffset . ssFrom . getSpan
+
+        it "Line pragma" $
+          shouldBe (ppoOf <$> collectF90 "i = 42\n#line 40 \"file.f\"\n j = 42") $
+                   ppoOf <$> lpToks
+
+        it "Line pragma (tokens)" $
+          shouldBe' (collectF90 "i = 42\n#line 40 \"file.f\"\n j = 42")
+                    lpToks
+
+        it "Line pragma (CPP style)" $
+          shouldBe (ppoOf <$> collectF90 "i = 42\n# 40 \"file.f\"\n j = 42") $
                    ppoOf <$> lpToks
 
       describe "Comment" $ do


### PR DESCRIPTION
For the freeform lexer, fixes longstanding problems with lexing line directives (both inside and outside of continuations). Handles directives of the following forms:

- `# 40 "file.f"`
- `# line 40 "file.f"`
