### PR TITLE
Option to run CPP with optional argument to pass command-line arguments

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -195,6 +195,7 @@ library
     , filepath ==1.4.*
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , process >=1.2.0.0
     , singletons >=3.0 && <3.2
     , singletons-base >=3.0 && <3.2
     , singletons-th >=3.0 && <3.2
@@ -259,6 +260,7 @@ executable fortran-src
     , fortran-src
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , process >=1.2.0.0
     , singletons >=3.0 && <3.2
     , singletons-base >=3.0 && <3.2
     , singletons-th >=3.0 && <3.2
@@ -355,6 +357,7 @@ test-suite spec
     , hspec >=2.2 && <3
     , mtl >=2.2 && <3
     , pretty >=1.1 && <2
+    , process >=1.2.0.0
     , singletons >=3.0 && <3.2
     , singletons-base >=3.0 && <3.2
     , singletons-th >=3.0 && <3.2

--- a/package.yaml
+++ b/package.yaml
@@ -97,6 +97,7 @@ dependencies:
 - filepath >=1.4 && <1.5
 - temporary >=1.2 && <1.4
 - either ^>=5.0.1.1
+- process >= 1.2.0.0
 
 # 3.0 requires GHC 9.0; 3.1 requires GHC 9.2
 - singletons      >= 3.0 && < 3.2

--- a/src/Language/Fortran/Util/Files.hs
+++ b/src/Language/Fortran/Util/Files.hs
@@ -1,5 +1,6 @@
 module Language.Fortran.Util.Files
   ( flexReadFile
+  , runCPP
   , getDirContents
   , rGetDirContents
   ) where
@@ -10,8 +11,10 @@ import qualified Data.ByteString.Char8      as B
 import           System.Directory (listDirectory, canonicalizePath,
                                    doesDirectoryExist, getDirectoryContents)
 import           System.FilePath  ((</>))
-import           Data.List        ((\\))
-
+import           System.IO.Temp   (withSystemTempDirectory)
+import           System.Process   (callProcess)
+import           Data.List        ((\\), foldl')
+import           Data.Char        (isNumber)
 -- | Obtain a UTF-8 safe 'B.ByteString' representation of a file's contents.
 --
 -- Invalid UTF-8 is replaced with the space character.
@@ -39,3 +42,29 @@ rGetDirContents d = canonicalizePath d >>= \d' -> go [d'] d'
               x' <- go (path : seen) path
               return $ map (\ y -> x ++ "/" ++ y) x'
             else return [x]
+
+-- | Run the C Pre Processor over the file before reading into a bytestring
+runCPP :: Maybe String -> FilePath -> IO B.ByteString
+runCPP Nothing path          = flexReadFile path -- Nothing = do not run CPP
+runCPP (Just cppOpts) path   = do
+  -- Fold over the lines, skipping CPP pragmas and inserting blank
+  -- lines as needed to make the line numbers match up for the current
+  -- file. CPP pragmas for other files are just ignored.
+  let processCPPLine :: ([B.ByteString], Int) -> B.ByteString -> ([B.ByteString], Int)
+      processCPPLine (revLs, curLineNo) curLine
+        | B.null curLine || B.head curLine /= '#' = (curLine:revLs, curLineNo + 1)
+        | linePath /= path                        = (revLs, curLineNo)
+        | newLineNo <= curLineNo                  = (revLs, curLineNo)
+        | otherwise                               = (replicate (newLineNo - curLineNo) B.empty ++ revLs,
+                                                     newLineNo)
+          where
+            newLineNo = read . B.unpack . B.takeWhile isNumber . B.drop 2 $ curLine
+            linePath = B.unpack . B.takeWhile (/='"') . B.drop 1 . B.dropWhile (/='"') $ curLine
+
+  withSystemTempDirectory "fortran-src" $ \ tmpdir -> do
+    let outfile = tmpdir </> "cpp.out"
+    callProcess "cpp" $ words cppOpts ++ ["-CC", "-nostdinc", "-o", outfile, path]
+    contents <- flexReadFile outfile
+    let ls = B.lines contents
+    let ls' = reverse . fst $ foldl' processCPPLine ([], 1) ls
+    return $ B.unlines ls'


### PR DESCRIPTION
`-C` option for a simple run of CPP, `-C=opts` to add additional CPP arguments (it's recommended to enclose them in quotes).