### PR TITLE
Fix reformatting of 73 character long lines

### DIFF
--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -548,6 +548,19 @@ spec =
                   <> "&\n     &"
                   <> "illy_variable_name = 1"
         reformatMixedFormInsertContinuations input `shouldBe` expect
+      it "correctly handles 72 character long statements" $ do
+        let input  = "      integer*4 :: x, y, z\n"
+                  <> "        x = +(((y - (z - 48)) * ((z + 62) - z)) + (((- z) * x) / (- x)))"
+            expect = "      integer*4 :: x, y, z\n"
+                  <> "        x = +(((y - (z - 48)) * ((z + 62) - z)) + (((- z) * x) / (- x)))"
+        reformatMixedFormInsertContinuations input `shouldBe` expect
+      it "correctly handles 73 character long statements" $ do
+        let input  = "      integer*4 :: x, y, z\n"
+                  <> "        x = + (((y - (z - 48)) * ((z + 62) - z)) + (((- z) * x) / (- x)))"
+            expect = "      integer*4 :: x, y, z\n"
+                  <> "        x = + (((y - (z - 48)) * ((z + 62) - z)) + (((- z) * x) / (- x))&\n"
+                  <> "     &)"
+        reformatMixedFormInsertContinuations input `shouldBe` expect
 
       it "does not continuate a long mixed-form comment line" $ do
         let input  = "      ! a very long, long comment that ends up"


### PR DESCRIPTION
According to http://fortranwiki.org/fortran/show/Continuation+lines ampersand sign should be placed at column 73 and after, but not at column 72. So that `&` is ignored in fixed-form and is processed in free-form languages.

This patch fixes old behavior, which sometimes produced lines 73 characters long.

We (D. Beer, R. Hidalgo-Charman and myself) found this bug working on random FORTRAN code autogeneration tool. One of the examples of generated files with too long lines:

```fortran
.........
      if (- (+ (+ (50 / 38)))) then
        x = + (((y - (z - 48)) * ((z + 62) - z)) + (((- z) * x) / (- x)))
        x = 53
        print *, 24
        print *, + (z - (+ (+ (+ 20))))
        x = + y
        x = + (+ x)
        x = + (42 - (((- 82) / (y - y)) / 45))
        print *, (((- (z / 86)) * ((y + y) - (44 + x))) / (- ((- y) - (-&
     & x)))) - z
        x = + z
      else if (z) then
.........
```