### PR TITLE
Assume extended `Fortran77Legacy` for `*.f`, `*.for` etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Usage: fortran-src [OPTION...] <file>
                           --show-flows-from=AST-BLOCK-ID   dump a graph showing flows-from information from the given AST-block ID; prefix with 's' for supergraph
 ```
 
+If you do not pass a `--fortranVersion` flag, the version will be guessed from
+the file name:
+
+  * Files ending in `*.f` are parsed with extended FORTRAN 77 syntax.
+  * Files ending in `*.f90` are parsed with Fortran 90 syntax (and respectively
+    for `*.f2003`/`*.f03`, `*.f2008`/`*.f08`).
+  * Unknown extensions are parsed like `*.f` files.
+
 ## Building
 You will need the GMP library plus header files: on many platforms, this will be
 via the package `libgmp-dev`.

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -61,9 +61,9 @@ selectFortranVersion alias = snd <$> find (\ entry -> fst entry `isInfixOf` map 
 deduceFortranVersion :: FilePath -> FortranVersion
 deduceFortranVersion path
   | isExtensionOf ".f"      = Fortran77Legacy
-  | isExtensionOf ".for"    = Fortran77
-  | isExtensionOf ".fpp"    = Fortran77
-  | isExtensionOf ".ftn"    = Fortran77
+  | isExtensionOf ".for"    = Fortran77Legacy
+  | isExtensionOf ".fpp"    = Fortran77Legacy
+  | isExtensionOf ".ftn"    = Fortran77Legacy
   | isExtensionOf ".f90"    = Fortran90
   | isExtensionOf ".f95"    = Fortran95
   | isExtensionOf ".f03"    = Fortran2003

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -20,9 +20,9 @@ import Text.PrettyPrint.GenericPretty (Out)
 -- The constructor ordering is important, since it's used for the Ord instance
 -- (which is used extensively for pretty printing).
 data FortranVersion = Fortran66
-                    | Fortran77
-                    | Fortran77Extended
-                    | Fortran77Legacy
+                    | Fortran77         -- ^ fairly close to FORTRAN 77 standard
+                    | Fortran77Extended -- ^ F77 with some extensions
+                    | Fortran77Legacy   -- ^ F77 with most extensions
                     | Fortran90
                     | Fortran95
                     | Fortran2003
@@ -60,7 +60,7 @@ selectFortranVersion alias = snd <$> find (\ entry -> fst entry `isInfixOf` map 
 -- Defaults to Fortran 90 if suffix is unrecognized.
 deduceFortranVersion :: FilePath -> FortranVersion
 deduceFortranVersion path
-  | isExtensionOf ".f"      = Fortran77Extended
+  | isExtensionOf ".f"      = Fortran77Legacy
   | isExtensionOf ".for"    = Fortran77
   | isExtensionOf ".fpp"    = Fortran77
   | isExtensionOf ".ftn"    = Fortran77


### PR DESCRIPTION
Closes #259 . We are now more lenient for the default case. The user can always provide an explicit version/parser to use where relevant.