### PR TITLE
release 0.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
       matrix:
         cabal: [latest]
         ghc:
-        - "9.0.2"
-        - "9.2.4"
-        - "9.4.2"
+        - "9.0"
+        - "9.2"
+        - "9.4"
 
     steps:
 
@@ -81,7 +81,7 @@ jobs:
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -118,7 +118,7 @@ jobs:
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -166,7 +166,7 @@ jobs:
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.15.1 (Jun 22, 2023)
+  * remove unused vector-sized dependency
+
 ### 0.15.0 (May 04, 2023)
   * handle more `INT` intrinsic forms
     [#263](https://github.com/camfort/fortran-src/pull/263)

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           fortran-src
-version:        0.15.0
+version:        0.15.1
 synopsis:       Parsers and analyses for Fortran standards 66, 77, 90, 95 and 2003 (partial).
 description:    Provides lexing, parsing, and basic analyses of Fortran code covering standards: FORTRAN 66, FORTRAN 77, Fortran 90, Fortran 95, Fortran 2003 (partial) and some legacy extensions. Includes data flow and basic block analysis, a renamer, and type analysis. For example usage, see the @<https://hackage.haskell.org/package/camfort CamFort>@ project, which uses fortran-src as its front end.
 category:       Language

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fortran-src
-version: '0.15.0'
+version: '0.15.1'
 synopsis: Parsers and analyses for Fortran standards 66, 77, 90, 95 and 2003 (partial).
 description: >-
   Provides lexing, parsing, and basic analyses of Fortran code covering


### PR DESCRIPTION
Removing a dependency (unused) requires a new release. The dependency messes up the Stack build for library users, so seems worthwhile.