### PR TITLE
Postfix boz in free form lexer and generalised include inlining

### DIFF
--- a/src/Language/Fortran/Parser/Fixed/Fortran66.y
+++ b/src/Language/Fortran/Parser/Fixed/Fortran66.y
@@ -6,6 +6,7 @@ module Language.Fortran.Parser.Fixed.Fortran66
   , blockParser
   , statementParser
   , expressionParser
+  , includesParser
   ) where
 
 import Language.Fortran.Version
@@ -25,6 +26,7 @@ import Prelude hiding ( EQ, LT, GT ) -- Same constructors exist in the AST
 %name blockParser      BLOCK
 %name statementParser  STATEMENT
 %name expressionParser EXPRESSION
+%name includesParser   INCLUDES
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
 %tokentype { Token }
@@ -138,6 +140,9 @@ MAYBE_ARGUMENTS :: { Maybe (AList Expression A0) }
 | {- Nothing -} { Nothing }
 
 NAME :: { Name } : id { let (TId _ name) = $1 in name }
+
+INCLUDES :: { [ Block A0 ] }
+: BLOCKS NEWLINE { reverse $1 }
 
 BLOCKS :: { [ Block A0 ] }
 : BLOCKS BLOCK { $2 : $1 }

--- a/src/Language/Fortran/Parser/Free/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Free/Fortran2003.y
@@ -7,6 +7,7 @@ module Language.Fortran.Parser.Free.Fortran2003
   , blockParser
   , statementParser
   , expressionParser
+  , includesParser
   ) where
 
 import Language.Fortran.Version
@@ -28,6 +29,7 @@ import qualified Data.List as List
 %name blockParser      BLOCK
 %name statementParser  STATEMENT
 %name expressionParser EXPRESSION
+%name includesParser   INCLUDES
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
 %tokentype { Token }
@@ -348,6 +350,9 @@ NAME :: { Name } : id { let (TId _ name) = $1 in name }
 IMPORT_NAME_LIST :: { [Expression A0] }
 : IMPORT_NAME_LIST ',' VARIABLE { $3 : $1 }
 | VARIABLE { [ $1 ] }
+
+INCLUDES :: { [ Block A0 ] }
+: BLOCKS NEWLINE { reverse $1 }
 
 BLOCKS :: { [ Block A0 ] } : BLOCKS BLOCK { $2 : $1 } | {- EMPTY -} { [ ] }
 

--- a/src/Language/Fortran/Parser/Free/Fortran90.y
+++ b/src/Language/Fortran/Parser/Free/Fortran90.y
@@ -7,6 +7,7 @@ module Language.Fortran.Parser.Free.Fortran90
   , blockParser
   , statementParser
   , expressionParser
+  , includesParser
   ) where
 
 import Language.Fortran.Version
@@ -27,6 +28,7 @@ import qualified Data.List as List
 %name functionParser   SUBPROGRAM_UNIT
 %name blockParser      BLOCK
 %name statementParser  STATEMENT
+%name includesParser   INCLUDES
 %name expressionParser EXPRESSION
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
@@ -295,6 +297,9 @@ INTERFACE_END :: { Token }
 : end { $1 } | endInterface { $1 } | endInterface id { $2 }
 
 NAME :: { Name } : id { let (TId _ name) = $1 in name }
+
+INCLUDES :: { [ Block A0 ] }
+: BLOCKS NEWLINE { reverse $1 }
 
 BLOCKS :: { [ Block A0 ] } : BLOCKS BLOCK { $2 : $1 } | {- EMPTY -} { [ ] }
 

--- a/src/Language/Fortran/Parser/Free/Fortran95.y
+++ b/src/Language/Fortran/Parser/Free/Fortran95.y
@@ -7,6 +7,7 @@ module Language.Fortran.Parser.Free.Fortran95
   , blockParser
   , statementParser
   , expressionParser
+  , includesParser
   ) where
 
 import Language.Fortran.Version
@@ -28,6 +29,7 @@ import qualified Data.List as List
 %name blockParser      BLOCK
 %name statementParser  STATEMENT
 %name expressionParser EXPRESSION
+%name includesParser   INCLUDES
 %monad { LexAction }
 %lexer { lexer } { TEOF _ }
 %tokentype { Token }
@@ -304,6 +306,9 @@ INTERFACE_END :: { Token }
 : end { $1 } | endInterface { $1 } | endInterface id { $2 }
 
 NAME :: { Name } : id { let (TId _ name) = $1 in name }
+
+INCLUDES :: { [ Block A0 ] }
+: BLOCKS NEWLINE { reverse $1 }
 
 BLOCKS :: { [ Block A0 ] } : BLOCKS BLOCK { $2 : $1 } | {- EMPTY -} { [ ] }
 

--- a/src/Language/Fortran/Parser/Free/Lexer.x
+++ b/src/Language/Fortran/Parser/Free/Lexer.x
@@ -51,9 +51,9 @@ $hash = [\#]
 @label = $digit{1,5}
 @name = $letter $alphanumeric*
 
-@binary = b\'$bit+\'
-@octal  = o\'$octalDigit+\'
-@hex    = z\'$hexDigit+\'
+@binary = b\'$bit+\' | \'$bit+\'b
+@octal  = o\'$octalDigit+\' | \'$octalDigit+\'o
+@hex    = [xz]\'$hexDigit+\' | \'$hexDigit+\'[xz]
 
 @digitString = $digit+
 @kindParam = (@digitString|@name)


### PR DESCRIPTION
Forgot to upstream these two patches that I wrote when helping some people with their Fortran 90 codebase.

First is a super small change for support for postfix boz notation which I encountered.

Second is for handling include inlining in the general case. It only worked on Fortran 77 before because that was all we cared about, but it probably should have been made to work for all parsers to begin with. I think it's sufficiently tested by the existing Fortran 77 tests, but let me know if you think it needs some more.