### PR TITLE
Allow a local path to be given to genUniqNameToFilenameMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.16.2
+  * Small change to allow a path to be added when building mod-file naming map
+
 ### 0.16.1 (Sep 04, 2024)
   * Minor fix to `fromConstReal` which was partial.
   * Added `Ord` instance for `AST` and all its sub data types, allowing, for example, ASTs to be in containers like Data.Set

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -51,7 +51,7 @@ programName :: String
 programName = "fortran-src"
 
 showVersion :: String
-showVersion = "0.16.1"
+showVersion = "0.16.2"
 
 main :: IO ()
 main = do

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           fortran-src
-version:        0.16.1
+version:        0.16.2
 synopsis:       Parsers and analyses for Fortran standards 66, 77, 90, 95 and 2003 (partial).
 description:    Provides lexing, parsing, and basic analyses of Fortran code covering standards: FORTRAN 66, FORTRAN 77, Fortran 90, Fortran 95, Fortran 2003 (partial) and some legacy extensions. Includes data flow and basic block analysis, a renamer, and type analysis. For example usage, see the @<https://hackage.haskell.org/package/camfort CamFort>@ project, which uses fortran-src as its front end.
 category:       Language

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fortran-src
-version: '0.16.1'
+version: '0.16.2'
 synopsis: Parsers and analyses for Fortran standards 66, 77, 90, 95 and 2003 (partial).
 description: >-
   Provides lexing, parsing, and basic analyses of Fortran code covering

--- a/src/Language/Fortran/Util/ModFile.hs
+++ b/src/Language/Fortran/Util/ModFile.hs
@@ -80,7 +80,7 @@ import Data.Maybe
 import GHC.Generics (Generic)
 import System.Directory ( doesFileExist, getModificationTime )
 import qualified System.FilePath
-import System.FilePath ( (-<.>), (</>) )
+import System.FilePath ( (-<.>), (</>), normalise )
 import System.IO ( hPutStrLn, stderr )
 
 --------------------------------------------------
@@ -250,11 +250,13 @@ moduleFilename = mfFilename
 
 -- | Create a map that links all unique variable/function names in the
 -- ModFiles to their corresponding *originating* filename (i.e., where they are declared)
-genUniqNameToFilenameMap :: ModFiles -> M.Map F.Name String
-genUniqNameToFilenameMap = M.unions . map perMF
+genUniqNameToFilenameMap :: FilePath -> ModFiles -> M.Map F.Name String
+genUniqNameToFilenameMap localPath = M.unions . map perMF
   where
-    perMF mf = M.fromList [ (n, fname) | modEnv <- M.elems localModuleMap
-                                       , (n, _) <- M.elems modEnv ]
+    perMF mf = M.fromList
+                [ (n, normalise $ localPath </> fname)
+                   | modEnv <- M.elems localModuleMap
+                   , (n, _) <- M.elems modEnv ]
       where
         -- Make sure that we remove imported declarations so we can
         -- properly localise declarations to the originator file.

--- a/test/Language/Fortran/Analysis/ModFileSpec.hs
+++ b/test/Language/Fortran/Analysis/ModFileSpec.hs
@@ -34,12 +34,13 @@ pParser name = do
 -- of the variable `constant` to the leaf module, whilst understanding
 -- in the `mid1` and `mid2` modules that it is an imported declaration.
 testModuleMaps = do
-    paths <- expandDirs ["test-data" </> "module"]
+    let fixturePath = "test-data" </> "module"
+    paths <- expandDirs [fixturePath]
     -- parse all files into mod files
     pfs <- mapM (\p -> pParser p) paths
     let modFiles = map genModFile pfs
     -- get unique name to filemap
-    let mmap = genUniqNameToFilenameMap modFiles
+    let mmap = genUniqNameToFilenameMap "" modFiles
     -- check that `constant` is declared in leaf.f90
     let Just leaf = M.lookup "leaf_constant_1" mmap
     leaf `shouldBe` ("test-data" </> "module" </> "leaf.f90")


### PR DESCRIPTION
This is useful if we want to load modfiles from not their parent directory. Used by camfort