### PR TITLE
Build a map (statefully) as we process declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Ubuntu / Stack / test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # relative paths are relative to the project directory
     - name: Cache Stack build artifacts (user + project)
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.stack
@@ -41,7 +41,7 @@ jobs:
       run: stack --no-terminal install
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ~/.local/bin/${{ env.EXE_NAME }}
         name: ${{ env.EXE_NAME }}-ubuntu-stack-${{ github.sha }}
@@ -69,7 +69,7 @@ jobs:
     # My issue on haskell/actions: https://github.com/haskell/actions/issues/41
     # This also requires us to do a deep fetch, else we don't get the Git commit
     # history we need to rewrite mod times.
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set all tracked file modification times to the time of their last commit
@@ -81,7 +81,7 @@ jobs:
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v2
+      uses: haskell/actions/setup@v4
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -89,7 +89,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}
@@ -114,11 +114,11 @@ jobs:
     steps:
 
     # TODO figure out timestamp fixer on Mac (no Mac available to test)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v2
+      uses: haskell/actions/setup@v4
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -126,7 +126,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}
@@ -143,10 +143,10 @@ jobs:
       env:
         HSPEC_OPTIONS: --color
 
-    # note that Cabal uses symlinks -- actions/upload-artifact@v2 apparently
+    # note that Cabal uses symlinks -- actions/upload-artifact@v4 apparently
     # dereferences for us
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ~/.cabal/bin/${{ env.EXE_NAME }}
         name: ${{ env.EXE_NAME }}-macos-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}
@@ -162,11 +162,11 @@ jobs:
         ghc: ["9.2"]
     steps:
     # TODO figure out timestamp fixer on Windows (need Bash)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v2
+      uses: haskell/actions/setup@v4
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -174,7 +174,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}
@@ -192,7 +192,7 @@ jobs:
         HSPEC_OPTIONS: --color
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: "C:/cabal/bin/${{ env.EXE_NAME }}.exe"
         name: ${{ env.EXE_NAME }}-windows-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Ubuntu / Stack / test
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     # relative paths are relative to the project directory
     - name: Cache Stack build artifacts (user + project)
-      uses: actions/cache@v4
+      uses: actions/cache@v2
       with:
         path: |
           ~/.stack
@@ -69,7 +69,7 @@ jobs:
     # My issue on haskell/actions: https://github.com/haskell/actions/issues/41
     # This also requires us to do a deep fetch, else we don't get the Git commit
     # history we need to rewrite mod times.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set all tracked file modification times to the time of their last commit
@@ -81,7 +81,7 @@ jobs:
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v4
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -89,7 +89,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@v2
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}
@@ -114,11 +114,11 @@ jobs:
     steps:
 
     # TODO figure out timestamp fixer on Mac (no Mac available to test)
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v4
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -126,7 +126,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@v2
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}
@@ -162,11 +162,11 @@ jobs:
         ghc: ["9.2"]
     steps:
     # TODO figure out timestamp fixer on Windows (need Bash)
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     - name: Setup Haskell build environment
       id: setup-haskell-build-env
-      uses: haskell/actions/setup@v4
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -174,7 +174,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache Cabal build artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@v2
       with:
         path: |
           ${{ steps.setup-haskell-build-env.outputs.cabal-store }}

--- a/.github/workflows/disabled/hackage.yml
+++ b/.github/workflows/disabled/hackage.yml
@@ -34,7 +34,7 @@ jobs:
     # My issue on haskell/actions: https://github.com/haskell/actions/issues/41
     # This also requires us to do a deep fetch, else we don't get the Git commit
     # history we need to rewrite mod times.
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set all tracked file modification times to the time of their last commit
@@ -56,7 +56,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache global Cabal store
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cabal/store
         key: hackage-deps-${{ runner.os }}-ghc_${{ env.ghc }}
@@ -68,14 +68,14 @@ jobs:
     - run: cabal sdist
 
     - name: Upload Hackage sdist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: dist-newstyle/sdist/${{ env.package_name }}-*.tar.gz
         name: ${{ env.package_name }}-sdist-${{ github.sha }}.tar.gz
         if-no-files-found: error
 
     - name: Upload Hackage Haddock docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: dist-newstyle/${{ env.package_name }}-*-docs.tar.gz
         name: ${{ env.package_name }}-hackage-haddocks-${{ github.sha }}.tar.gz

--- a/.github/workflows/disabled/hackage.yml
+++ b/.github/workflows/disabled/hackage.yml
@@ -34,7 +34,7 @@ jobs:
     # My issue on haskell/actions: https://github.com/haskell/actions/issues/41
     # This also requires us to do a deep fetch, else we don't get the Git commit
     # history we need to rewrite mod times.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set all tracked file modification times to the time of their last commit
@@ -56,7 +56,7 @@ jobs:
     - run: cabal freeze
 
     - name: Cache global Cabal store
-      uses: actions/cache@v4
+      uses: actions/cache@v2
       with:
         path: ~/.cabal/store
         key: hackage-deps-${{ runner.os }}-ghc_${{ env.ghc }}

--- a/src/Language/Fortran/Analysis.hs
+++ b/src/Language/Fortran/Analysis.hs
@@ -3,7 +3,7 @@
 -- |
 -- Common data structures and functions supporting analysis of the AST.
 module Language.Fortran.Analysis
-  ( initAnalysis, stripAnalysis, Analysis(..)
+  ( initAnalysis, analysis0, stripAnalysis, Analysis(..)
   , varName, srcName, lvVarName, lvSrcName, isNamedExpression
   , genVar, puName, puSrcName, blockRhsExprs, rhsExprs
   , ModEnv, NameType(..), Locality(..), markAsImported, isImported

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -409,9 +409,11 @@ genConstExpMap pf = ceMap
           Nothing       -> map))
       recursivelyProcessDecls stmts
 
+    -- Evaluate an expression down to a value
     getE0 :: M.Map Name Repr.FValue -> Expression (Analysis a) -> Maybe (Repr.FValue)
     getE0 pvMap e = either (const Nothing) (Just . fst) (Repr.runEvalFValuePure pvMap (Repr.evalExpr e))
 
+    -- Lookup an expression in the constants maps
     getE :: Expression (Analysis a) -> Maybe Repr.FValue
     getE = join . (flip IM.lookup ceMap <=< labelOf)
 
@@ -422,10 +424,7 @@ genConstExpMap pf = ceMap
         -- TODO constants may use other constants! but genConstExpMap needs more
         -- changes to support that
         case Repr.runEvalFValuePure pvMap (Repr.evalExpr e) of
-          Left _err ->
-            case e of
-              ExpValue _ _ (ValVariable{}) -> Nothing
-              _ -> Nothing
+          Left _err -> Nothing
           Right (a, _msgs) ->
             case e of
               ExpValue _ _ (ValVariable{}) -> Just a

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -425,10 +425,7 @@ genConstExpMap pf = ceMap
         -- changes to support that
         case Repr.runEvalFValuePure pvMap (Repr.evalExpr e) of
           Left _err -> Nothing
-          Right (a, _msgs) ->
-            case e of
-              ExpValue _ _ (ValVariable{}) -> Just a
-              _ -> Just a
+          Right (a, _msgs) -> Just a
 
 -- | Get constant-expression information and put it into the AST
 -- analysis annotation. Must occur after analyseBBlocks.

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -374,7 +374,7 @@ genConstExpMap pf = ceMap
     -- Generate map of information about 'constant expressions'.
     ceMap = IM.fromList [ (label, doExpr e) | e <- universeBi pf, Just label <- [labelOf e] ]
 
-    -- Initial map of parameteri declarations
+    -- Initial map of parameter declarations
     pvMap :: M.Map Name Repr.FValue
     pvMap = execState (recursivelyProcessDecls declarations) M.empty
 

--- a/src/Language/Fortran/Analysis/DataFlow.hs
+++ b/src/Language/Fortran/Analysis/DataFlow.hs
@@ -409,20 +409,6 @@ genConstExpMap pf = ceMap
           Nothing       -> map))
       recursivelyProcessDecls stmts
 
-    -- -- Generate map of 'parameter' variables, obtaining their value from ceMap below, lazily.
-    -- pvMapIter :: M.Map Name Repr.FValue -> M.Map Name Repr.FValue
-    -- pvMapIter map0 = map0 `M.union` M.fromList $
-    --   [ (varName v, expr)
-    --   | st@(StDeclaration _ _ (TypeSpec _ _ _ _) _ _) <- universeBi pf :: [Statement (Analysis a)]
-    --   , AttrParameter _ _ <- universeBi st :: [Attribute (Analysis a)]
-    --   , (Declarator _ _ v ScalarDecl _ (Just e)) <- universeBi st
-    --   , expr <- getE0 map0 e ]
-    --   ++
-    --   [ (varName v, expr)
-    --   | st@StParameter{} <- universeBi pf :: [Statement (Analysis a)]
-    --   , (Declarator _ _ v ScalarDecl _ (Just e)) <- universeBi st
-    --   , expr <- getE0 map0 e ]
-
     getE0 :: M.Map Name Repr.FValue -> Expression (Analysis a) -> Maybe (Repr.FValue)
     getE0 pvMap e = either (const Nothing) (Just . fst) (Repr.runEvalFValuePure pvMap (Repr.evalExpr e))
 

--- a/src/Language/Fortran/Util/ModFile.hs
+++ b/src/Language/Fortran/Util/ModFile.hs
@@ -139,7 +139,7 @@ emptyModFile = ModFile "" M.empty M.empty M.empty M.empty M.empty M.empty
 -- | Extracts the module map, declaration map and type analysis from
 -- an analysed and renamed ProgramFile, then inserts it into the
 -- ModFile.
-regenModFile :: forall a. Data a => F.ProgramFile (FA.Analysis a) -> ModFile -> ModFile
+regenModFile :: forall a. (Data a) => F.ProgramFile (FA.Analysis a) -> ModFile -> ModFile
 regenModFile pf mf = mf { mfModuleMap   = extractModuleMap pf
                         , mfDeclMap     = extractDeclMap pf
                         , mfTypeEnv     = FAT.extractTypeEnv pf
@@ -148,7 +148,7 @@ regenModFile pf mf = mf { mfModuleMap   = extractModuleMap pf
 
 -- | Generate a fresh ModFile from the module map, declaration map and
 -- type analysis of a given analysed and renamed ProgramFile.
-genModFile :: forall a. Data a => F.ProgramFile (FA.Analysis a) -> ModFile
+genModFile :: forall a. (Data a) => F.ProgramFile (FA.Analysis a) -> ModFile
 genModFile = flip regenModFile emptyModFile
 
 -- | Looks up the raw "other data" that may be stored in a ModFile by

--- a/test/Language/Fortran/Repr/EvalSpec.hs
+++ b/test/Language/Fortran/Repr/EvalSpec.hs
@@ -10,6 +10,8 @@ import Language.Fortran.AST
 import Language.Fortran.Repr
 import Language.Fortran.Repr.Eval.Value
 
+import Language.Fortran.Analysis
+
 import Data.Int
 
 spec :: Spec
@@ -29,15 +31,15 @@ shouldEvalTo checkVal prog =
           -- _ -> expectationFailure "not a scalar"
       Left e -> expectationFailure (show e)
 
-expBinary :: BinaryOp -> Expression () -> Expression () -> Expression ()
-expBinary = ExpBinary () u
+expBinary :: BinaryOp -> Expression (Analysis ()) -> Expression (Analysis ()) -> Expression (Analysis ())
+expBinary = ExpBinary (analysis0 ()) u
 
-expValue :: Value () -> Expression ()
-expValue = ExpValue () u
+expValue :: Value (Analysis ()) -> Expression (Analysis ())
+expValue = ExpValue (analysis0 ()) u
 
 -- | default kind. take integral-like over String because nicer to write :)
-valInteger :: (Integral a, Show a) => a -> Value ()
+valInteger :: (Integral a, Show a) => a -> Value (Analysis ())
 valInteger i = ValInteger (show i) Nothing
 
-expValInt :: (Integral a, Show a) => a -> Expression ()
+expValInt :: (Integral a, Show a) => a -> Expression (Analysis ())
 expValInt = expValue . valInteger


### PR DESCRIPTION
I noticed some problems with building a constant expression map were coming through into CamFort. This seems to fix things now (makes the associated tests pass in CamFort)- the main idea is in `genConstExpMap` to find all the statements the declare `parameters` or have a constants, and then evaluate them one at a time, building a map from values to `FRepr` representations.