### PR TITLE
Improve reporting, mostly around type information but also source spans

### DIFF
--- a/src/Language/Fortran/Analysis/Types.hs
+++ b/src/Language/Fortran/Analysis/Types.hs
@@ -2,8 +2,11 @@ module Language.Fortran.Analysis.Types
   ( analyseTypes
   , analyseTypesWithEnv
   , analyseAndCheckTypesWithEnv
+  , stripExtended
   , extractTypeEnv
+  , extractTypeEnvExtended
   , TypeEnv
+  , TypeEnvExtended
   , TypeError
   , deriveSemTypeFromDeclaration
   , deriveSemTypeFromTypeSpec
@@ -35,6 +38,11 @@ import Language.Fortran.Version (FortranVersion(..))
 
 -- | Mapping of names to type information.
 type TypeEnv = M.Map Name IDType
+-- | Mapping of names to type information with more information about the source
+type TypeEnvExtended = M.Map Name (Name, SrcSpan, IDType)
+
+stripExtended :: TypeEnvExtended -> TypeEnv
+stripExtended = M.map (\(_, _, t) -> t)
 
 -- | Information about a detected type error.
 type TypeError = (String, SrcSpan)
@@ -119,6 +127,24 @@ extractTypeEnv pf = M.union puEnv expEnv
     expEnv = M.fromList [ (n, ty) | e@(ExpValue _ _ ValVariable{}) <- universeBi pf :: [Expression (Analysis a)]
                                   , let n = varName e
                                   , ty <- maybeToList (idType (getAnnotation e)) ]
+
+extractTypeEnvExtended :: forall a. Data a => ProgramFile (Analysis a) -> TypeEnvExtended
+extractTypeEnvExtended pf = M.union puEnv expEnv
+  where
+    puEnv = M.fromList [ (n, (srcName, getSpan pu, ty)) | pu <- universeBi pf :: [ProgramUnit (Analysis a)]
+                                 , Named n <- [puName pu]
+                                 , Named srcName <- [puSrcName pu]
+                                 , ty <- maybeToList (idType (getAnnotation pu)) ]
+    expEnv = M.fromList [ (n, (srcName e, sp, ty)) | e@(ExpValue _ _ ValVariable{}) <- universeBi pf :: [Expression (Analysis a)]
+                                  , let n = varName e
+                                  , sp <- getDeclarator n
+                                  , ty <- maybeToList (idType (getAnnotation e)) ]
+    getDeclarator v' =
+        [ sp | d@(Declarator _ sp ev _ _ _) <- universeBi pf :: [Declarator (Analysis a)]
+             , varName ev == v' ]
+
+
+
 
 type TransType f g a = (f (Analysis a) -> Infer (f (Analysis a))) -> g (Analysis a) -> Infer (g (Analysis a))
 annotateTypes :: Data a => ProgramFile (Analysis a) -> Infer (ProgramFile (Analysis a))

--- a/src/Language/Fortran/Util/ModFile.hs
+++ b/src/Language/Fortran/Util/ModFile.hs
@@ -118,7 +118,7 @@ data ModFile = ModFile { mfFilename    :: String
                        , mfStringMap   :: StringMap
                        , mfModuleMap   :: FAR.ModuleMap
                        , mfDeclMap     :: DeclMap
-                       , mfTypeEnv     :: FAT.TypeEnv
+                       , mfTypeEnv     :: FAT.TypeEnvExtended
                        , mfParamVarMap :: ParamVarMap
                        , mfOtherData   :: M.Map String LB.ByteString }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -142,7 +142,7 @@ emptyModFile = ModFile "" M.empty M.empty M.empty M.empty M.empty M.empty
 regenModFile :: forall a. (Data a) => F.ProgramFile (FA.Analysis a) -> ModFile -> ModFile
 regenModFile pf mf = mf { mfModuleMap   = extractModuleMap pf
                         , mfDeclMap     = extractDeclMap pf
-                        , mfTypeEnv     = FAT.extractTypeEnv pf
+                        , mfTypeEnv     = FAT.extractTypeEnvExtended pf
                         , mfParamVarMap = extractParamVarMap pf
                         , mfFilename    = F.pfGetFilename pf }
 
@@ -224,7 +224,7 @@ localisedModuleMap = M.map (M.filter (not . FA.isImported . snd))
 
 -- | Extract the combined module map from a set of ModFiles. Useful
 -- for parsing a Fortran file in a large context of other modules.
-combinedTypeEnv :: ModFiles -> FAT.TypeEnv
+combinedTypeEnv :: ModFiles -> FAT.TypeEnvExtended
 combinedTypeEnv = M.unions . map mfTypeEnv
 
 -- | Extract the combined declaration map from a set of

--- a/src/Language/Fortran/Util/Position.hs
+++ b/src/Language/Fortran/Util/Position.hs
@@ -26,7 +26,7 @@ instance Binary Position
 instance NFData Position
 
 instance Show Position where
-  show (Position _ c l _ _) = show l ++ ':' : show c
+  show (Position _ c l _ _) = show l ++ ':' : show (c - 1)
 
 initPosition :: Position
 initPosition = Position

--- a/src/Language/Fortran/Util/Position.hs
+++ b/src/Language/Fortran/Util/Position.hs
@@ -26,6 +26,9 @@ instance Binary Position
 instance NFData Position
 
 instance Show Position where
+  -- Column number decrement by 1 as the lexer generates column numbers
+  -- starting at position 1
+  -- See PR https://github.com/camfort/fortran-src/pull/292
   show (Position _ c l _ _) = show l ++ ':' : show (c - 1)
 
 initPosition :: Position


### PR DESCRIPTION
This PR does two things:
1. Improves the reporting of type information, e.g.
previously we'd get things like:

```
_area_of_circle_1                - Function
area_of_circle_area_2           Real 4 Variable
area_of_circle_pi_4             Real 4 Parameter
area_of_circle_r_3              Real 4 Variable
main_area_6             Real 4 Variable
main_r_5                Real 4 Variable
```
now we get:

```
4:12     r              Real 4 Variable
4:15     area           Real 4 Variable
11:4     area_of_circle          - Function
12:27    pi             Real 4 Parameter
13:28    r              Real 4 Variable
14:16    area           Real 4 Variable
```

2. This PR deals with the long standing issues that source span column numbers are always 1 bigger than they should be! This is now fixed in the `Show` instance (as fixing it deeper down causes issues with the way the lexer automata works). 