### PR TITLE
Avoid interpreting CPP as Boz

### DIFF
--- a/src/Language/Fortran/AST/Literal/Boz.hs
+++ b/src/Language/Fortran/AST/Literal/Boz.hs
@@ -95,7 +95,7 @@ parseBoz s =
       | p' == 'x' = Just $ BozPrefixZ Nonconforming
       | otherwise = Nothing
       where p' = Char.toLower p
-    errInvalid = error "Language.Fortran.AST.BOZ.parseBoz: invalid BOZ string"
+    errInvalid = error ("Language.Fortran.AST.BOZ.parseBoz: invalid BOZ string: " <> show s)
     -- | Remove the first and last elements in a list.
     shave = tail . init
 


### PR DESCRIPTION
We have an issue in that CPP pragma can get interpreted as BOZ constants in some places (which I've actually struggled to totally reproduce).

(also, at the moment we swallow bad BOZ constants rather than showing the user what they are. This PR also  fixes it very simply).