### PR TITLE
minor tweaks:

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ We support the latest recommended version of Cabal (as of 2021-09-17, Cabal 3.4)
 cabal build
 ```
 
+You can leverage cabal to initialize a ghci session, and call the main function like such:
+
+```shell
+cabal repl
+
+:load app/Main.hs
+
+:main --version
+```
+
 ### Testing
 Unit tests are stored in `test`. Run with `stack test` or `cabal test`.
 

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -200,8 +200,8 @@ library
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.4
-    , singletons-th >=3.0 && <3.4
+    , singletons-base >=3.0 && <3.6
+    , singletons-th >=3.0 && <3.6
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2
@@ -264,8 +264,8 @@ executable fortran-src
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.4
-    , singletons-th >=3.0 && <3.4
+    , singletons-base >=3.0 && <3.6
+    , singletons-th >=3.0 && <3.6
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2

--- a/src/Language/Fortran/Parser/Fixed/Lexer.x
+++ b/src/Language/Fortran/Parser/Fixed/Lexer.x
@@ -30,7 +30,7 @@ import Language.Fortran.Parser.Monad
 import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 import Language.Fortran.Util.Position
-import Language.Fortran.Parser.LexerUtils ( readIntOrBoz )
+import Language.Fortran.Parser.LexerUtils ( readIntOrBoz, unescapeSpecialChars )
 import Language.Fortran.AST.Literal.Boz
 
 }
@@ -1128,7 +1128,7 @@ lexer' = do
     AlexEOF -> return $ TEOF $ SrcSpan (getPos alexInput) (getPos alexInput)
     AlexError _ -> do
       parseState <- get
-      fail $ psFilename parseState ++ " - lexing failed: " ++ show (psAlexInput parseState)
+      fail $ psFilename parseState ++ " - lexing failed: " ++ (unescapeSpecialChars $ show (psAlexInput parseState))
     AlexSkip newAlex _ -> putAlex newAlex >> lexer'
     AlexToken newAlex _ action -> do
       putAlex newAlex

--- a/src/Language/Fortran/Parser/LexerUtils.hs
+++ b/src/Language/Fortran/Parser/LexerUtils.hs
@@ -1,5 +1,5 @@
 {-| Utils for both lexers. -}
-module Language.Fortran.Parser.LexerUtils ( readIntOrBoz ) where
+module Language.Fortran.Parser.LexerUtils ( readIntOrBoz, unescapeSpecialChars) where
 
 import Language.Fortran.AST.Literal.Boz
 import Numeric
@@ -16,3 +16,17 @@ readIntOrBoz s = do
 readSToMaybe :: [(a, b)] -> Maybe a
 readSToMaybe = \case (x, _):_ -> Just x
                      _        -> Nothing
+
+
+-- | Pretty prints exception message that contains things like carriage return, indents, etc.
+unescapeSpecialChars :: String -> String
+unescapeSpecialChars [] = []
+unescapeSpecialChars ('\\' : c : rest) =
+  case c of
+    'n'  -> '\n' : unescapeSpecialChars rest
+    't'  -> '\t' : unescapeSpecialChars rest
+    'r'  -> '\r' : unescapeSpecialChars rest
+    '\\' -> '\\' : unescapeSpecialChars rest
+    _    -> '\\' : c : unescapeSpecialChars rest
+unescapeSpecialChars (c : rest) =
+  c : unescapeSpecialChars rest


### PR DESCRIPTION
*  bump singletons-* packages in order to build on recent ghc / cabal
*  define unescapeSpecialChars in LexerUtils.hs
* use unescapeSpecialChars on the fail call, when the lexing aborts, which makes the output in the console more readable to end user

Also put a note about `cabal repl` in the readme, to help newbies to get going in hacking in the repository.