### PR TITLE
WIP: Qualified fortran version

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ We support the latest recommended version of Cabal (as of 2021-09-17, Cabal 3.4)
 cabal build
 ```
 
+You can leverage cabal to initialize a ghci session, and call the main function like such:
+
+```shell
+cabal repl
+
+:load app/Main.hs
+
+:main --version
+```
+
 ### Testing
 Unit tests are stored in `test`. Run with `stack test` or `cabal test`.
 

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -200,8 +200,8 @@ library
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.4
-    , singletons-th >=3.0 && <3.4
+    , singletons-base >=3.0 && <3.6
+    , singletons-th >=3.0 && <3.6
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2
@@ -264,8 +264,8 @@ executable fortran-src
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.4
-    , singletons-th >=3.0 && <3.4
+    , singletons-base >=3.0 && <3.6
+    , singletons-th >=3.0 && <3.6
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2

--- a/src/Language/Fortran/Parser/Fixed/Lexer.x
+++ b/src/Language/Fortran/Parser/Fixed/Lexer.x
@@ -30,7 +30,7 @@ import Language.Fortran.Parser.Monad
 import Language.Fortran.Version
 import Language.Fortran.Util.FirstParameter
 import Language.Fortran.Util.Position
-import Language.Fortran.Parser.LexerUtils ( readIntOrBoz )
+import Language.Fortran.Parser.LexerUtils ( readIntOrBoz, unescapeSpecialChars )
 import Language.Fortran.AST.Literal.Boz
 
 }
@@ -1128,7 +1128,7 @@ lexer' = do
     AlexEOF -> return $ TEOF $ SrcSpan (getPos alexInput) (getPos alexInput)
     AlexError _ -> do
       parseState <- get
-      fail $ psFilename parseState ++ " - lexing failed: " ++ show (psAlexInput parseState)
+      fail $ psFilename parseState ++ " - lexing failed: " ++ (unescapeSpecialChars $ show (psAlexInput parseState))
     AlexSkip newAlex _ -> putAlex newAlex >> lexer'
     AlexToken newAlex _ action -> do
       putAlex newAlex

--- a/src/Language/Fortran/Parser/Fixed/Lexer.x
+++ b/src/Language/Fortran/Parser/Fixed/Lexer.x
@@ -269,13 +269,13 @@ tokens :-
 -- Predicated lexer helpers
 --------------------------------------------------------------------------------
 
-(&&&) :: (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
-      -> (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
-      -> (FortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
-f &&& g = \ fv ai1 i ai2 -> f fv ai1 i ai2 && g fv ai1 i ai2
+(&&&) :: (QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+      -> (QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+      -> (QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool)
+f &&& g = \ qfv ai1 i ai2 -> f qfv ai1 i ai2 && g qfv ai1 i ai2
 
-formatExtendedP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-formatExtendedP fv _ _ ai = fv `elem` [Fortran77Extended, Fortran77Legacy] &&
+formatExtendedP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+formatExtendedP qfv _ _ ai = getLanguageRevision qfv `elem` [Fortran77Extended, Fortran77Legacy] &&
   case xs of
     [ TFormat _, _ ] -> False
     [ TLabel _ _, TFormat _ ] -> False
@@ -283,37 +283,37 @@ formatExtendedP fv _ _ ai = fv `elem` [Fortran77Extended, Fortran77Legacy] &&
   where
     xs = take 2 . reverse . aiPreviousTokensInLine $ ai
 
-implicitType77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-implicitType77P fv b c d = fortran77P fv b c d && implicitStP fv b c d
+implicitType77P :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+implicitType77P qfv b c d = fortran77P qfv b c d && implicitStP qfv b c d
 
-implicitTypeExtendedP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-implicitTypeExtendedP fv b c d = extended77P fv b c d && implicitStP fv b c d
+implicitTypeExtendedP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+implicitTypeExtendedP qfv b c d = extended77P qfv b c d && implicitStP qfv b c d
 
-implicitStP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+implicitStP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 implicitStP _ _ _ ai = checkPreviousTokensInLine f ai
   where
     f (TImplicit _) = True
     f _ = False
 
-extendedIdP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-extendedIdP fv a b ai = fv `elem` [Fortran77Extended, Fortran77Legacy] && idP fv a b ai
+extendedIdP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+extendedIdP qfv a b ai = getLanguageRevision qfv `elem` [Fortran77Extended, Fortran77Legacy] && idP qfv a b ai
 
-legacyIdP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-legacyIdP fv a b ai = fv == Fortran77Legacy && idP fv a b ai
+legacyIdP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+legacyIdP qfv a b ai = getLanguageRevision qfv == Fortran77Legacy && idP qfv a b ai
 
-idP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-idP fv ao i ai = not (doP fv ai) && not (ifP fv ao i ai)
-             && (equalFollowsP fv ai || rParFollowsP fv ai)
+idP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+idP qfv ao i ai = not (doP qfv ai) && not (ifP qfv ao i ai)
+             && (equalFollowsP qfv ai || rParFollowsP qfv ai)
 
-doP :: FortranVersion -> AlexInput -> Bool
-doP fv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
+doP :: QualifiedFortranVersion -> AlexInput -> Bool
+doP qfv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
     case unParse (lexer $ f (0::Integer)) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = st}
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = ParanthesesCount 0 False
       , psContext = [ ConStart ] }
@@ -330,15 +330,15 @@ doP fv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
         TRightPar{} -> lexer $ f (n-1)
         _ -> lexer $ f n
 
-ifP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-ifP fv _ _ ai = "if" == (reverse . lexemeMatch . aiLexeme $ ai) &&
+ifP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+ifP qfv _ _ ai = "if" == (reverse . lexemeMatch . aiLexeme $ ai) &&
     case unParse (lexer $ f) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = st}
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = ParanthesesCount 0 False
       , psContext = [ ConStart ] }
@@ -348,15 +348,15 @@ ifP fv _ _ ai = "if" == (reverse . lexemeMatch . aiLexeme $ ai) &&
         TLeftPar{} -> return True
         _ -> return False
 
-functionP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-functionP fv _ _ ai = "function" == (reverse . lexemeMatch . aiLexeme $ ai) &&
+functionP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+functionP qfv _ _ ai = "function" == (reverse . lexemeMatch . aiLexeme $ ai) &&
     case unParse (lexer $ f) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = st}
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = ParanthesesCount 0 False
       , psContext = [ ConStart ] }
@@ -367,21 +367,21 @@ functionP fv _ _ ai = "function" == (reverse . lexemeMatch . aiLexeme $ ai) &&
         TLeftPar{} -> return True
         _ -> return False
 
-hollerithP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+hollerithP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 hollerithP _ _ _ ai = isDigit (lookBack 2 ai)
 
-notToP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+notToP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 notToP _ _ _ ai = not $ "to" `isPrefixOf` (reverse . lexemeMatch . aiLexeme $ ai)
 
-equalFollowsP :: FortranVersion -> AlexInput -> Bool
-equalFollowsP fv ai =
+equalFollowsP :: QualifiedFortranVersion -> AlexInput -> Bool
+equalFollowsP qfv ai =
     case unParse (lexer $ f False (0::Integer)) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = st}
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = ParanthesesCount 0 False
       , psContext = [ ConStart ] }
@@ -410,15 +410,15 @@ equalFollowsP fv ai =
         TRightPar{} -> lexer $ f True (n - 1)
         _ -> lexer $ f True n
 
-rParFollowsP :: FortranVersion -> AlexInput -> Bool
-rParFollowsP fv ai =
+rParFollowsP :: QualifiedFortranVersion -> AlexInput -> Bool
+rParFollowsP qfv ai =
     case unParse (lexer $ f) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = st}
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = ParanthesesCount 0 False
       , psContext = [ ConStart ] }
@@ -427,17 +427,17 @@ rParFollowsP fv ai =
         TRightPar{} -> return True
         _ -> return False
 
-commentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+commentP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 commentP _ aiOld _ aiNew = atColP 1 aiOld && _endsWithLine
   where
     _endsWithLine = (posColumn . aiPosition) aiNew /= 1
 
-bangCommentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+bangCommentP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 bangCommentP _ _ _ aiNew = _endsWithLine
   where
     _endsWithLine = (posColumn . aiPosition) aiNew /= 1
 
-withinLabelColsP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+withinLabelColsP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 withinLabelColsP _ aiOld _ aiNew = getCol aiOld >= 1 && getCol aiNew <= 6
   where
     getCol = posColumn . aiPosition
@@ -449,7 +449,7 @@ atColP n ai = (posColumn . aiPosition) ai == n
 -- by looking at previous token. Since exponent can only follow a "." or an
 -- integer token. Anything other previous token will prevent matching the input
 -- as an exponent token.
-exponentP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+exponentP :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
 exponentP _ _ _ ai =
   case aiPreviousTokensInLine ai of
     -- real*8 d8 is not an exponent
@@ -458,18 +458,25 @@ exponentP _ _ _ ai =
     TDot{} : _ -> True
     _ -> False
 
-fortran66P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-fortran66P fv _ _ _ = fv == Fortran66
+fortran66P :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+fortran66P qfv _ _ _ = getLanguageRevision qfv == Fortran66
 
-fortran77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-fortran77P fv _ _ _ = fv == Fortran77 || fv == Fortran77Extended || fv == Fortran77Legacy
+fortran77P :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+fortran77P qfv _ _ _ = 
+  case getLanguageRevision qfv of
+    Fortran77         -> True
+    Fortran77Extended -> True
+    Fortran77Legacy   -> True
+    otherwise         -> False
 
-extended77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-extended77P fv _ _ _ = fv == Fortran77Extended || fv == Fortran77Legacy
+extended77P :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+extended77P qfv _ _ _ = 
+  case getLanguageRevision qfv of
+    Fortran77Extended -> True
+    Fortran77Legacy   -> True
 
-legacy77P :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
-legacy77P fv _ _ _ = fv == Fortran77Legacy
-
+legacy77P :: QualifiedFortranVersion -> AlexInput -> Int -> AlexInput -> Bool
+legacy77P qfv _ _ _ = getLanguageRevision qfv == Fortran77Legacy
 
 --------------------------------------------------------------------------------
 -- Lexer helpers
@@ -886,7 +893,7 @@ data AlexInput = AlexInput
   , aiCaseSensitive             :: Bool
   , aiInComment                 :: Bool
   , aiInFormat                  :: Bool
-  , aiFortranVersion            :: FortranVersion
+  , aiFortranVersion            :: QualifiedFortranVersion
   } deriving (Show)
 
 instance Loc AlexInput where
@@ -897,8 +904,8 @@ instance LastToken AlexInput Token where
 
 type LexAction a = Parse AlexInput Token a
 
-vanillaAlexInput :: String -> FortranVersion -> B.ByteString -> AlexInput
-vanillaAlexInput fn fv bs = AlexInput
+vanillaAlexInput :: String -> QualifiedFortranVersion -> B.ByteString -> AlexInput
+vanillaAlexInput fn qfv bs = AlexInput
   { aiSourceBytes = bs
   , aiEndOffset = B.length bs
   , aiPosition = initPosition { posFilePath = fn }
@@ -912,7 +919,7 @@ vanillaAlexInput fn fv bs = AlexInput
   , aiCaseSensitive = False
   , aiInComment = False
   , aiInFormat = False
-  , aiFortranVersion = fv
+  , aiFortranVersion = qfv
   }
 
 updateLexeme :: Maybe Char -> Position -> AlexInput -> AlexInput
@@ -944,16 +951,16 @@ alexGetByte ai
   -- Skip the continuation line altogether
   | isContinuation ai && _isWhiteInsensitive = skip Continuation ai
   -- Skip comment lines "between" continuations
-  | aiFortranVersion ai >= Fortran77 && _isWhiteInsensitive
+  | (getLanguageRevision $ aiFortranVersion ai) >= Fortran77 && _isWhiteInsensitive
   && isNewlineCommentsFollowedByContinuation ai = skip NewlineComment ai
   -- If we are not parsing a Hollerith skip whitespace
   | _curChar `elem` [ ' ', '\t' ] && _isWhiteInsensitive = skip Char ai
   -- Ignore inline comments
-  | aiFortranVersion ai == Fortran77Legacy && _isWhiteInsensitive
+  | (getLanguageRevision $ aiFortranVersion ai) == Fortran77Legacy && _isWhiteInsensitive
     && not _inFormat && _curChar == '!' && not _blankLine
   = skip Comment ai
   -- Ignore comments after column 72 in fortran77
-  | aiFortranVersion ai == Fortran77Legacy && not (aiInComment ai)
+  | (getLanguageRevision $ aiFortranVersion ai) == Fortran77Legacy && not (aiInComment ai)
     && posColumn _position > 72 && _curChar /= '\n'
   = skip Comment ai
   -- Read genuine character and advance. Also covers white sensitivity.
@@ -1140,6 +1147,6 @@ lexer' = do
           return token
         Nothing -> lexer'
 
-alexScanUser :: FortranVersion -> AlexInput -> Int -> AlexReturn (LexAction (Maybe Token))
+alexScanUser :: QualifiedFortranVersion -> AlexInput -> Int -> AlexReturn (LexAction (Maybe Token))
 
 }

--- a/src/Language/Fortran/Parser/Free/Lexer.x
+++ b/src/Language/Fortran/Parser/Free/Lexer.x
@@ -147,6 +147,11 @@ tokens :-
 <0> "entry"                                       { addSpan TEntry }
 <0> "include"                                     { addSpan TInclude }
 
+-- deprecated / non-standard declarations 
+<0> "structure"    / { legacyDECStructureP }      { addSpan TStructure }
+<0> "endstructure" / { legacyDECStructureP }      { addSpan TEndStructure }
+
+
 -- Type def related
 <0,scT> "type"                                    { addSpan TType }
 <scN> "type" / { allocateP }                      { addSpan TType }
@@ -338,6 +343,10 @@ tokens :-
 -- Predicated lexer helpers
 --------------------------------------------------------------------------------
 
+legacyDECStructureP :: User -> AlexInput -> Int -> AlexInput -> Bool
+legacyDECStructureP (User qfv _) _ _ _ = hasDecStructure qfv
+
+
 formatP :: User -> AlexInput -> Int -> AlexInput -> Bool
 formatP _ _ _ ai
   | Just TFormat{} <- aiPreviousToken ai = True
@@ -397,14 +406,14 @@ opP _ _ _ ai
   | otherwise = False
 
 partOfExpOrPointerAssignmentP :: User -> AlexInput -> Int -> AlexInput -> Bool
-partOfExpOrPointerAssignmentP (User fv pc) _ _ ai =
+partOfExpOrPointerAssignmentP (User qfv pc) _ _ ai =
     case unParse (lexer $ f False (0::Integer)) ps of
       ParseOk True _ -> True
       _ -> False
   where
     ps = ParseState
       { psAlexInput = ai { aiStartCode = StartCode scN Return }
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psParanthesesCount = pc
       , psContext = [ ConStart ] }
@@ -612,7 +621,7 @@ prevTokenConstr :: AlexInput -> Maybe Constr
 prevTokenConstr ai = toConstr <$> aiPreviousToken ai
 
 nextTokenConstr :: User -> AlexInput -> Maybe Constr
-nextTokenConstr (User fv pc) ai =
+nextTokenConstr (User qfv pc) ai =
     case unParse lexer' parseState of
       ParseOk token _ -> Just $ toConstr token
       _ -> Nothing
@@ -620,7 +629,7 @@ nextTokenConstr (User fv pc) ai =
     parseState = ParseState
       { psAlexInput = ai
       , psParanthesesCount = pc
-      , psVersion = fv
+      , psVersion = qfv
       , psFilename = "<unknown>"
       , psContext = [ ConStart ] }
 
@@ -880,6 +889,7 @@ data AlexInput = AlexInput
   , aiStartCode                 :: {-# UNPACK #-} !StartCode
   , aiPreviousToken             :: !(Maybe Token)
   , aiPreviousTokensInLine      :: !([ Token ])
+  , aiFortranVersion            :: !QualifiedFortranVersion
   } deriving (Show)
 
 instance Loc AlexInput where
@@ -890,8 +900,8 @@ instance LastToken AlexInput Token where
 
 type LexAction a = Parse AlexInput Token a
 
-vanillaAlexInput :: String -> B.ByteString -> AlexInput
-vanillaAlexInput fn bs = AlexInput
+vanillaAlexInput :: String -> QualifiedFortranVersion -> B.ByteString -> AlexInput
+vanillaAlexInput fn qfv bs = AlexInput
   { aiSourceBytes          = bs
   , aiPosition             = initPosition { posFilePath = fn }
   , aiEndOffset            = B.length bs
@@ -899,7 +909,9 @@ vanillaAlexInput fn bs = AlexInput
   , aiLexeme               = initLexeme
   , aiStartCode            = StartCode 0 Return
   , aiPreviousToken        = Nothing
-  , aiPreviousTokensInLine = [ ] }
+  , aiPreviousTokensInLine = [ ]
+  , aiFortranVersion       = qfv
+   }
 
 updateLexeme :: Char -> Position -> AlexInput -> AlexInput
 updateLexeme !char !p !ai = ai { aiLexeme = Lexeme (char:match) start' p isCmt' }
@@ -909,7 +921,7 @@ updateLexeme !char !p !ai = ai { aiLexeme = Lexeme (char:match) start' p isCmt' 
     isCmt'                     = isCmt || (null match && char == '!')
 
 -- Fortran version and parantheses count to be used by alexScanUser
-data User = User FortranVersion ParanthesesCount
+data User = User QualifiedFortranVersion ParanthesesCount
 
 --------------------------------------------------------------------------------
 -- Definitions needed for alexScanUser
@@ -1225,6 +1237,8 @@ data Token =
   -- Program unit related
   | TProgram            SrcSpan
   | TEndProgram         SrcSpan
+  | TStructure          SrcSpan
+  | TEndStructure       SrcSpan
   | TFunction           SrcSpan
   | TEndFunction        SrcSpan
   | TResult             SrcSpan

--- a/src/Language/Fortran/Parser/LexerUtils.hs
+++ b/src/Language/Fortran/Parser/LexerUtils.hs
@@ -1,5 +1,5 @@
 {-| Utils for both lexers. -}
-module Language.Fortran.Parser.LexerUtils ( readIntOrBoz ) where
+module Language.Fortran.Parser.LexerUtils ( readIntOrBoz, unescapeSpecialChars) where
 
 import Language.Fortran.AST.Literal.Boz
 import Numeric
@@ -16,3 +16,17 @@ readIntOrBoz s = do
 readSToMaybe :: [(a, b)] -> Maybe a
 readSToMaybe = \case (x, _):_ -> Just x
                      _        -> Nothing
+
+
+-- | Pretty prints exception message that contains things like carriage return, indents, etc.
+unescapeSpecialChars :: String -> String
+unescapeSpecialChars [] = []
+unescapeSpecialChars ('\\' : c : rest) =
+  case c of
+    'n'  -> '\n' : unescapeSpecialChars rest
+    't'  -> '\t' : unescapeSpecialChars rest
+    'r'  -> '\r' : unescapeSpecialChars rest
+    '\\' -> '\\' : unescapeSpecialChars rest
+    _    -> '\\' : c : unescapeSpecialChars rest
+unescapeSpecialChars (c : rest) =
+  c : unescapeSpecialChars rest

--- a/src/Language/Fortran/Parser/Monad.hs
+++ b/src/Language/Fortran/Parser/Monad.hs
@@ -39,11 +39,11 @@ data Context =
   deriving (Show, Eq)
 
 data ParseState a = ParseState
-  { psAlexInput :: a
+  { psAlexInput        :: a
   , psParanthesesCount :: ParanthesesCount
-  , psVersion :: FortranVersion  -- To differentiate lexing behaviour
-  , psFilename :: String -- To save correct source location in AST
-  , psContext :: [ Context ]
+  , psVersion          :: QualifiedFortranVersion  -- To differentiate lexing behaviour
+  , psFilename         :: String -- To save correct source location in AST
+  , psContext          :: [ Context ]
   }
   deriving (Show)
 
@@ -160,7 +160,7 @@ execParse m s = snd (runParseUnsafe m s)
 -- Parser helper functions
 -------------------------------------------------------------------------------
 
-getVersion :: (Loc a, LastToken a b, Show b) => Parse a b FortranVersion
+getVersion :: (Loc a, LastToken a b, Show b) => Parse a b QualifiedFortranVersion
 getVersion = do
   s <- get
   return (psVersion s)

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -2,9 +2,15 @@
 
 module Language.Fortran.Version
   ( FortranVersion(..)
+  , QualifiedFortranVersion(..)
+  , CompilerOption(..)
   , fortranVersionAliases
   , selectFortranVersion
   , deduceFortranVersion
+  , hasDecStructure
+  , getLanguageRevision
+  , addCompilerOption
+  , makeQualifiedVersion
   ) where
 
 import           Data.Char (toLower)
@@ -28,6 +34,38 @@ data FortranVersion = Fortran66
                     | Fortran2003
                     | Fortran2008
                     deriving (Ord, Eq, Data, Typeable, Generic)
+
+data CompilerOption = DecStructure -- | represents -fdec-structure (gfortran, DEC extensions), also supported in intel fortran
+                    deriving (Show, Ord, Eq, Data, Typeable, Generic)
+
+data QualifiedFortranVersion = VanillaVersion FortranVersion
+                             | QualifiedVersion FortranVersion [CompilerOption]
+                             deriving (Show, Ord, Eq, Data, Typeable, Generic)
+
+-- Extract the base Fortran version
+getLanguageRevision :: QualifiedFortranVersion -> FortranVersion
+getLanguageRevision (VanillaVersion v) = v
+getLanguageRevision (QualifiedVersion v _) = v
+
+-- Check if a specific compiler option is enabled
+hasCompilerOption :: CompilerOption -> QualifiedFortranVersion -> Bool
+hasCompilerOption _ (VanillaVersion _) = False
+hasCompilerOption opt (QualifiedVersion _ opts) = opt `elem` opts
+
+-- Add a compiler option to a QualifiedFortranVersion
+addCompilerOption :: CompilerOption -> QualifiedFortranVersion -> QualifiedFortranVersion
+addCompilerOption opt (VanillaVersion v) = QualifiedVersion v [opt]
+addCompilerOption opt (QualifiedVersion v opts)
+  | opt `elem` opts = QualifiedVersion v opts  -- Avoid duplicates?
+  | otherwise = QualifiedVersion v (opt : opts)
+
+-- | Check for Fortran77Legacy language revision or DecStructure compiler option
+hasDecStructure :: QualifiedFortranVersion -> Bool
+hasDecStructure qfv = getLanguageRevision  qfv == Fortran77Legacy || hasCompilerOption DecStructure qfv
+
+makeQualifiedVersion :: FortranVersion -> [CompilerOption] -> QualifiedFortranVersion
+makeQualifiedVersion version [] = VanillaVersion version
+makeQualifiedVersion version opts = QualifiedVersion version opts
 
 instance Show FortranVersion where
   show Fortran66         = "Fortran 66"


### PR DESCRIPTION
I'm starting work to allow having `CompilerOption` list to describe the introduced `QualifiedFortranVersion`, which will enable supporting `DecStructure` option.

Looking for maintainers feedback if this is right approach?

As of now, I'd like to get things to work back, which should be done by adjusting Parser.hs and maybe some more things in Main.hs, and later revise the new symbol names, which right now, may not be what we ultimately want.

If a maintainer want to look at the remaining type check error and suggest the right approach, as it is not clear to me at this stage.

Once this compile, I have a bit more work in the lexer to also have the `TRecord` token and maybe other things.

related: #303