### PR TITLE
Free form legacy support

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -15,7 +15,8 @@ author:         Mistral Contrastin,
                 Matthew Danish,
                 Dominic Orchard,
                 Andrew Rice
-maintainer:     Dominic Orchard <dom.orchard@gmail.com>
+maintainer:     me@madgen.net,
+                Ben Orchard
 license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
@@ -30,6 +31,8 @@ extra-source-files:
     test-data/module/mid1.f90
     test-data/module/mid2.f90
     test-data/module/top.f90
+    test-data/pragma.f90
+    test-data/pragma.f90.expected
     test-data/rewriter/replacementsmap-columnlimit/001_foo.f
     test-data/rewriter/replacementsmap-columnlimit/001_foo.f.expected
     test-data/rewriter/replacementsmap-columnlimit/002_other.f
@@ -61,6 +64,10 @@ extra-source-files:
     test-data/rewriter/replacementsmap-simple/005_unicode.f
     test-data/rewriter/replacementsmap-simple/005_unicode.f.expected
     test-data/rewriter/temp-failure/fail.f
+    test-data/small.f90
+    test-data/small.f90.expected
+    test-data/st.expected
+    test-data/st2.expected
 
 source-repository head
   type: git
@@ -200,8 +207,8 @@ library
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.6
-    , singletons-th >=3.0 && <3.6
+    , singletons-base >=3.0 && <3.4
+    , singletons-th >=3.0 && <3.4
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2
@@ -264,8 +271,8 @@ executable fortran-src
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.6
-    , singletons-th >=3.0 && <3.6
+    , singletons-base >=3.0 && <3.4
+    , singletons-th >=3.0 && <3.4
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -480,7 +480,7 @@ instance Pretty (Statement a) where
       | otherwise = prettyError "unhandled version"
 
     pprint' v (StStructure _ _ mName itemList) =
-        olderThan Fortran77Legacy "Structure" v $
+        continueOnlyFor [Fortran77Legacy, Fortran90Legacy] "Structure" v $
           "structure"
           <+> (if isJust mName then "/" <> pprint' v mName <> "/" else empty)
           <> newline
@@ -545,11 +545,11 @@ instance Pretty (Statement a) where
       | otherwise = "data" <+> hsep (map (pprint' v) dataGroups)
 
     pprint' v (StAutomatic _ _ decls) =
-        continueOnlyFor [Fortran77Extended, Fortran77Legacy] "Automatic statement" v $
+        continueOnlyFor [Fortran77Extended, Fortran77Legacy, Fortran90Legacy] "Automatic statement" v $
             "automatic" <+> pprint' v decls
 
     pprint' v (StStatic _ _ decls) =
-        continueOnlyFor [Fortran77Extended, Fortran77Legacy] "Static statement" v $
+        continueOnlyFor [Fortran77Extended, Fortran77Legacy, Fortran90Legacy] "Static statement" v $
             "static" <+> pprint' v decls
 
     pprint' v (StNamelist _ _ namelist)

--- a/src/Language/Fortran/Version.hs
+++ b/src/Language/Fortran/Version.hs
@@ -24,6 +24,7 @@ data FortranVersion = Fortran66
                     | Fortran77Extended -- ^ F77 with some extensions
                     | Fortran77Legacy   -- ^ F77 with most extensions
                     | Fortran90
+                    | Fortran90Legacy -- ^ F90 with legacy extensions
                     | Fortran95
                     | Fortran2003
                     | Fortran2008
@@ -35,6 +36,7 @@ instance Show FortranVersion where
   show Fortran77Extended = "Fortran 77 Extended"
   show Fortran77Legacy   = "Fortran 77 Legacy"
   show Fortran90         = "Fortran 90"
+  show Fortran90Legacy   = "Fortran 90 Legacy"
   show Fortran95         = "Fortran 95"
   show Fortran2003       = "Fortran 2003"
   show Fortran2008       = "Fortran 2008"
@@ -48,6 +50,7 @@ fortranVersionAliases = [ ("66" , Fortran66)
                         , ("77l", Fortran77Legacy)
                         , ("77" , Fortran77)
                         , ("90" , Fortran90)
+                        , ("90l", Fortran90Legacy)
                         , ("95" , Fortran95)
                         , ("03" , Fortran2003)
                         , ("08" , Fortran2008) ]


### PR DESCRIPTION
This PR adds support for legacy extensions but in free form lexing, i.e., for Fortran 90 code.
- [x] new Fortran90Legacy version (and associated changes)
- [ ] Handle structure
- [ ] Handle automatic
- [ ] Handle static
- [ ] Tests pass