### PR TITLE
Fixes issue #300 with parsing imports for Fortran 2003 when their are no attributes

### DIFF
--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -15,7 +15,7 @@ author:         Mistral Contrastin,
                 Matthew Danish,
                 Dominic Orchard,
                 Andrew Rice
-maintainer:     Dominic Orchard <dom.orchard@gmail.com>
+maintainer:     Dominic Orchard
 license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
@@ -200,8 +200,8 @@ library
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.6
-    , singletons-th >=3.0 && <3.6
+    , singletons-base >=3.0 && <3.4
+    , singletons-th >=3.0 && <3.4
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2
@@ -264,8 +264,8 @@ executable fortran-src
     , pretty >=1.1 && <2
     , process >=1.2.0.0
     , singletons ==3.0.*
-    , singletons-base >=3.0 && <3.6
-    , singletons-th >=3.0 && <3.6
+    , singletons-base >=3.0 && <3.4
+    , singletons-th >=3.0 && <3.4
     , temporary >=1.2 && <1.4
     , text >=1.2 && <2.2
     , uniplate >=1.6 && <2

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,7 @@ tested-with: GHC >= 9.0
 github: camfort/fortran-src
 bug-reports: https://github.com/camfort/fortran-src/issues
 author: [Mistral Contrastin, Matthew Danish, Dominic Orchard, Andrew Rice]
-maintainer: [me@madgen.net, Ben Orchard]
+maintainer: [Dominic Orchard]
 category: Language
 license: Apache-2.0
 license-file: LICENSE

--- a/src/Language/Fortran/Parser/Free/Fortran2003.y
+++ b/src/Language/Fortran/Parser/Free/Fortran2003.y
@@ -583,9 +583,9 @@ NONEXECUTABLE_STATEMENT :: { Statement A0 }
 | save { StSave () (getSpan $1) Nothing }
 
 -- according to IBM F2003 docs, dcolon is always required
-| procedure '(' MAYBE_PROC_INTERFACE ')' ATTRIBUTE_LIST '::' PROC_DECLS
+| procedure '(' MAYBE_PROC_INTERFACE ')' MAYBE_ATTRIBUTE_LIST '::' PROC_DECLS
   { let declAList = fromReverseList $7
-    in StProcedure () (getTransSpan $1 $7) $3 (Just (fromReverseList $5)) declAList }
+    in StProcedure () (getTransSpan $1 $7) $3 $5 declAList }
 
 | dimension MAYBE_DCOLON INITIALIZED_DECLARATOR_LIST
   { let declAList = fromReverseList $3
@@ -1037,6 +1037,14 @@ DECLARATION_STATEMENT :: { Statement A0 }
 | TYPE_SPEC INITIALIZED_DECLARATOR_LIST
   { let { declAList = fromReverseList $2 }
     in StDeclaration () (getTransSpan $1 declAList) $1 Nothing declAList }
+
+MAYBE_ATTRIBUTE_LIST :: { Maybe (AList Attribute A0) }
+: ',' NE_ATTRIBUTE_LIST { Just $ fromReverseList $2 }
+| {- EMPTY -} { Nothing }
+
+NE_ATTRIBUTE_LIST :: { [ Attribute A0 ] }
+: NE_ATTRIBUTE_LIST ',' ATTRIBUTE_SPEC { $3 : $1 }
+| ATTRIBUTE_SPEC { [ $1 ] }
 
 ATTRIBUTE_LIST :: { [ Attribute A0 ] }
 : ATTRIBUTE_LIST ',' ATTRIBUTE_SPEC { $3 : $1 }

--- a/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
@@ -56,6 +56,13 @@ spec =
             st = StUse () u (varGen "mod") Nothing Permissive (Just renames)
         sParser "use :: mod, sprod => prod, a => b" `shouldBe'` st
 
+      it "parses simple procedure with no args" $ do
+        let st = StProcedure () u (Just (ProcInterfaceName () u (varGen "name")))
+                                  Nothing
+                                  (AList () u [ProcDecl () u (varGen "other_name") Nothing] )
+        sParser "procedure(name) :: other_name" `shouldBe'` st
+
+
       it "parses procedure (interface-name, attribute, proc-decl)" $ do
         let call = ExpFunctionCall () u (varGen "c") (aEmpty () u)
             st = StProcedure () u (Just (ProcInterfaceName () u (varGen "a")))


### PR DESCRIPTION
Previously:
`    procedure(compare_grids)             :: compare_func`
failed but now is allowed.
(discovered whilst looking at issue #300 )
