### PR TITLE
[WIP] Code generator random Fortran programs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -46,6 +46,7 @@ import Language.Fortran.Analysis.Renaming
 import qualified Language.Fortran.Parser as Parser
 import qualified Language.Fortran.Parser.Fixed.Lexer as Fixed
 import qualified Language.Fortran.Parser.Free.Lexer  as Free
+import Language.Fortran.Generate (generatePrograms)
 
 programName :: String
 programName = "fortran-src"
@@ -212,6 +213,12 @@ main = do
                            | otherwise    = B.replicate (maxLen - B.length line + 1) ' ' <> "!" <> nodeStr
                 B.putStrLn $ line <> suffix
         _ -> fail $ usageInfo programName options
+    (_, Generate n) -> do
+      let dir = fromMaybe "." (outputFile opts)
+      exists <- doesDirectoryExist dir
+      unless exists $ ioError $ userError $
+        "Output directory does not exist: " ++ dir
+      generatePrograms n dir
     _ -> fail $ usageInfo programName options
 
 
@@ -312,7 +319,7 @@ printTypeErrors = putStrLn . showTypeErrors
 data Action
   = Lex | Parse | Typecheck | Rename | BBlocks | SuperGraph | Reprint | DumpModFile | Compile
   | ShowFlows Bool Bool Int | ShowBlocks (Maybe Int) | ShowMakeGraph | ShowMakeList | Make
-  | ShowMyVersion
+  | ShowMyVersion | Generate Int
   deriving Eq
 
 instance Read Action where
@@ -401,8 +408,12 @@ options =
       "build an .fsmod file from the input"
   , Option ['o']
       ["output-file"]
-      (ReqArg (\ f opts -> opts { outputFile = Just f }) "FILE")
-      "name of output file (e.g. name of generated fsmod file)"
+      (ReqArg (\ f opts -> opts { outputFile = Just f }) "FILE/DIR")
+      "name of output file (e.g. name of generated fsmod file); for --generate, specifies the output directory"
+  , Option []
+      ["generate"]
+      (ReqArg (\n opts -> opts { action = Generate (read n) }) "SIZE")
+      "generate SIZE example Fortran programs as .f90 files into the directory specified by -o (default: current directory)"
   , Option []
       ["make-mods", "make"]
       (NoArg $ \ opts -> opts { action = Make })

--- a/compare_compilers.py
+++ b/compare_compilers.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+compare_compilers.py — for every .f90 file in a directory, compile with
+gfortran and ifort, then compare behaviour:
+
+  both fail to compile  → consistent failure, skip
+  one compiles, one not → discrepancy, report
+  both compile          → run both, diff stdout
+                           same output  → SUCCESS
+                           diff output  → report diff
+
+Usage:
+  python compare_compilers.py <directory> [options]
+"""
+
+import argparse
+import difflib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def banner(text: str) -> str:
+    bar = "=" * 64
+    return f"\n{bar}\n{text}\n{bar}"
+
+
+def compile_file(compiler: str, src: Path, out: Path, timeout: int = 60):
+    """Returns (success: bool, stderr: str)."""
+    try:
+        r = subprocess.run(
+            [compiler, str(src), "-o", str(out)],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return r.returncode == 0, r.stderr
+    except FileNotFoundError:
+        return False, f"{compiler}: command not found"
+    except subprocess.TimeoutExpired:
+        return False, f"{compiler}: compilation timed out"
+
+
+def run_exe(exe: Path, timeout: int):
+    """Returns (stdout: str, stderr: str, returncode: int, timed_out: bool)."""
+    try:
+        r = subprocess.run(
+            [str(exe)], capture_output=True, text=True,
+            input="", timeout=timeout,
+        )
+        return r.stdout, r.stderr, r.returncode, False
+    except subprocess.TimeoutExpired:
+        return "", "", -1, True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compile .f90 files with gfortran and ifort and diff their output."
+    )
+    parser.add_argument("directory", help="Directory containing .f90 files")
+    parser.add_argument(
+        "--gfortran", default="gfortran",
+        help="gfortran executable name/path (default: gfortran)"
+    )
+    parser.add_argument(
+        "--ifort", default="ifort",
+        help="ifort executable name/path (default: ifort)"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=10,
+        help="Per-program execution timeout in seconds (default: 10)"
+    )
+    parser.add_argument(
+        "--compile-timeout", type=int, default=60,
+        help="Per-file compilation timeout in seconds (default: 60)"
+    )
+    args = parser.parse_args()
+
+    src_dir = Path(args.directory)
+    if not src_dir.is_dir():
+        print(f"Error: '{src_dir}' is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    sources = sorted(src_dir.glob("*.f90"))
+    if not sources:
+        print(f"No .f90 files found in '{src_dir}'.")
+        sys.exit(0)
+
+    n_both_fail     = 0
+    n_discrepancy   = 0
+    n_output_match  = 0
+    n_output_mismatch = 0
+    n_runtime_issue = 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        for src in sources:
+            print(banner(src.name))
+
+            g_exe = tmp / f"{src.stem}_gfortran"
+            i_exe = tmp / f"{src.stem}_ifort"
+
+            g_ok, g_err = compile_file(args.gfortran, src, g_exe, args.compile_timeout)
+            i_ok, i_err = compile_file(args.ifort,    src, i_exe, args.compile_timeout)
+
+            # ── both failed ──────────────────────────────────────────────
+            if not g_ok and not i_ok:
+                print("Both compilers FAILED — consistent failure, skipping.")
+                n_both_fail += 1
+                continue
+
+            # ── one succeeded, one failed ────────────────────────────────
+            if g_ok != i_ok:
+                winner = args.gfortran if g_ok else args.ifort
+                loser  = args.ifort    if g_ok else args.gfortran
+                loser_err = i_err if g_ok else g_err
+                print(f"DISCREPANCY: {winner} compiled OK but {loser} failed.")
+                if loser_err.strip():
+                    print(f"\n{loser} stderr:\n{loser_err.rstrip()}")
+                n_discrepancy += 1
+                continue
+
+            # ── both compiled: run and compare ───────────────────────────
+            print(f"Both compiled. Running (timeout={args.timeout}s)...")
+
+            g_out, g_serr, g_rc, g_timeout = run_exe(g_exe, args.timeout)
+            i_out, i_serr, i_rc, i_timeout = run_exe(i_exe, args.timeout)
+
+            if g_timeout or i_timeout:
+                timed_out = []
+                if g_timeout: timed_out.append(args.gfortran)
+                if i_timeout: timed_out.append(args.ifort)
+                print(f"RUNTIME TIMEOUT after {args.timeout}s: {', '.join(timed_out)}")
+                n_runtime_issue += 1
+                continue
+
+            # Report exit codes if they differ
+            if g_rc != i_rc:
+                print(f"Exit codes differ: {args.gfortran}={g_rc}, {args.ifort}={i_rc}")
+
+            if g_out == i_out:
+                rc_note = "" if g_rc == i_rc else " (exit codes differ — see above)"
+                print(f"Output MATCHES ({len(g_out)} chars). SUCCESS.{rc_note}")
+                n_output_match += 1
+            else:
+                print("Output DIFFERS:")
+                diff = list(difflib.unified_diff(
+                    g_out.splitlines(keepends=True),
+                    i_out.splitlines(keepends=True),
+                    fromfile=f"{args.gfortran} stdout",
+                    tofile=f"{args.ifort} stdout",
+                ))
+                if diff:
+                    sys.stdout.writelines(diff)
+                else:
+                    # Non-printable difference
+                    print(f"  {args.gfortran}: {repr(g_out)}")
+                    print(f"  {args.ifort}:    {repr(i_out)}")
+                n_output_mismatch += 1
+
+    # ── summary ─────────────────────────────────────────────────────────────
+    total    = len(sources)
+    reported = n_discrepancy + n_output_match + n_output_mismatch + n_runtime_issue
+
+    print(banner("SUMMARY"))
+    print(f"  Files processed              : {total}")
+    print(f"  Both failed (consistent)     : {n_both_fail}")
+    print(f"  Compiler discrepancy         : {n_discrepancy}")
+    print(f"  Both ran, output matches     : {n_output_match}  ← successes")
+    print(f"  Both ran, output differs     : {n_output_mismatch}")
+    print(f"  Runtime issue / timeout      : {n_runtime_issue}")
+    print(f"\n  SUCCESSES: {n_output_match} / {total}  "
+          f"({'%.0f' % (100*n_output_match/total)}%)" if total else "")
+
+
+if __name__ == "__main__":
+    main()

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -84,6 +84,7 @@ library
       Language.Fortran.AST.Literal.Complex
       Language.Fortran.AST.Literal.Real
       Language.Fortran.Common.Array
+      Language.Fortran.Generate
       Language.Fortran.Intrinsics
       Language.Fortran.LValue
       Language.Fortran.Parser
@@ -186,6 +187,7 @@ library
     , happy >=1.19
   build-depends:
       GenericPretty >=1.2.2 && <2
+    , QuickCheck >=2.10 && <2.15
     , array ==0.5.*
     , base >=4.6 && <5
     , binary >=0.8.3.0 && <0.11
@@ -249,6 +251,7 @@ executable fortran-src
   ghc-options: -Wall -fno-warn-tabs
   build-depends:
       GenericPretty >=1.2.2 && <2
+    , QuickCheck >=2.10 && <2.15
     , array ==0.5.*
     , base >=4.6 && <5
     , binary >=0.8.3.0 && <0.11

--- a/package.yaml
+++ b/package.yaml
@@ -105,6 +105,8 @@ dependencies:
 - singletons-th   >= 3.0 && < 3.4
 - singletons-base >= 3.0 && < 3.4
 
+- QuickCheck >=2.10 && <2.15
+
 library:
   source-dirs: src
   ghc-options: -fno-warn-tabs

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -1,0 +1,31 @@
+module Language.Fortran.Generate where
+
+import Language.Fortran.AST
+import Test.QuickCheck
+
+import Language.Fortran.Util.Position
+
+-- instance Gen SrcSpan where
+--   arbitrary = do
+--     start <- arbitrary
+--     end   <- arbitrary
+--     return $ SrcSpan start end
+
+-- instance Gen Position where
+--   arbitrary = do
+--     absOffset <- arbitrary
+--     col       <- arbitrary
+--     line      <- arbitrary
+--     filePath  <- arbitrary
+--     pragmaOffset <- arbitrary
+--     return $ Position absOffset col line filePath pragmaOffset
+
+instance Arbitrary a => Arbitrary (Value a) where
+  arbitrary = oneof
+    [ do x <- arbitrary :: Gen Integer
+         pure $ ValInteger (show x) Nothing
+    , do s <- arbitrary :: Gen String
+         pure $ ValString s
+    , ValLogical <$> arbitrary <*> pure Nothing
+    , pure $ ValVariable "myVar"
+    ]

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -4,6 +4,11 @@ import Language.Fortran.AST
 import Test.QuickCheck
 
 import Language.Fortran.Util.Position
+import Language.Fortran.PrettyPrint
+import Language.Fortran.Version
+
+import Text.PrettyPrint
+import Text.PrettyPrint.HughesPJ
 
 -- instance Gen SrcSpan where
 --   arbitrary = do
@@ -29,3 +34,12 @@ instance Arbitrary a => Arbitrary (Value a) where
     , ValLogical <$> arbitrary <*> pure Nothing
     , pure $ ValVariable "myVar"
     ]
+
+-- Generate a list of 10 values and pretty print
+-- the results
+demo :: IO ()
+demo = do
+  values :: [Value ()] <- generate $ vectorOf 10 arbitrary
+  let prettyValues = map (pprint' Fortran90) values
+  mapM_ (putStrLn . render) prettyValues
+  putStrLn $ "Generated " ++ show (length values) ++ " values."

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE DefaultSignatures #-}
 module Language.Fortran.Generate where
 
 import Language.Fortran.AST
+import Language.Fortran.AST.Literal
+import Language.Fortran.AST.Literal.Real
 import Test.QuickCheck
 
 import Language.Fortran.Util.Position
@@ -27,6 +30,15 @@ instance Arbitrary a => Arbitrary (Value a) where
     , ValLogical <$> arbitrary <*> pure Nothing
     , pure $ ValVariable "myVar"
     ]
+
+instance Arbitrary RealLit where
+  arbitrary = do
+    float <- arbitrary :: Gen Double
+    -- Note: This is a very rough approximation. It generates a valid REAL
+    -- literal, but it may not be exactly the same as the original float
+    --  due to formatting differences.
+    -- (Haskell's 'show' may use scientific notation- issue?)
+    return $ RealLit (show float) (Exponent ExpLetterE (show (floor (logBase 10 (abs float))) :: String))  
 
 instance Arbitrary BaseType where
   arbitrary = oneof

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -91,12 +91,69 @@ type GenM a = StateT Env Gen a
 liftGen :: Gen a -> GenM a
 liftGen = lift
 
+-- | Generate a fresh variable name based on the current environment size.
+freshName :: GenM Name
+freshName = do
+  env <- get
+  pure $ "var" ++ show (Map.size env)
+
+-- | Generate one declaration statement, adding the variable to the environment.
+genDecl :: GenM (Statement A0)
+genDecl = do
+  name     <- freshName
+  baseType <- liftGen arbitrary
+  selector <- liftGen arbitrary
+  let typeSpec  = TypeSpec () nullSpan baseType selector
+      varExpr   = ExpValue () nullSpan (ValVariable name)
+      decl      = Declarator () nullSpan varExpr ScalarDecl Nothing Nothing
+      declList  = AList () nullSpan [decl]
+  modify (Map.insert name typeSpec)
+  pure $ StDeclaration () nullSpan typeSpec Nothing declList
+
+-- | Generate @n@ declarations, building up the environment as we go.
+genDecls :: Int -> GenM [Statement A0]
+genDecls n = replicateM n genDecl
+
+-- | Generate declarations for sizes 1..n, returning each batch.
+--   The environment accumulates across all batches.
+genDeclsScaled :: Int -> GenM [[Statement A0]]
+genDeclsScaled n = mapM genDecls [1..n]
+
+-- | Top-level runner: generate a subroutine with a growing set of declarations.
+--   Uses QuickCheck's 'sized' so the number of declarations scales with test size.
+genProgramUnit :: Gen (ProgramUnit A0)
+genProgramUnit = sized $ \sz -> do
+  let numDecls = max 1 (sz `div` 5)
+  (decls, env) <- runStateT (genDecls numDecls) Map.empty
+  -- env is now available for generating expressions / further statements
+  let blocks  = map (\s -> BlStatement () nullSpan Nothing s) decls
+      name    = "generated_sub"
+  pure $ PUSubroutine () nullSpan emptyPrefixSuffix name Nothing blocks Nothing
+
+genVarRef :: GenM (Expression A0)
+genVarRef = do
+  env <- get
+  (name, _) <- liftGen $ elements (Map.toList env)
+  pure $ ExpValue () nullSpan (ValVariable name)
 
 -- Generate a list of 10 values and pretty print
 -- the results
-demo :: IO ()
-demo = do
+demoVal :: IO ()
+demoVal = do
   values :: [Value ()] <- generate $ vectorOf 10 arbitrary
   let prettyValues = map (pprint' Fortran90) values
   mapM_ (putStrLn . render) prettyValues
   putStrLn $ "Generated " ++ show (length values) ++ " values."
+
+-- | Generate 10 full Fortran programs and print each one.
+demoProgram :: IO ()
+demoProgram = do
+  pus <- generate $ vectorOf 10 genProgramUnit
+  let meta = MetaInfo { miVersion = Fortran90, miFilename = "<generated>" }
+      programs = map (\pu -> ProgramFile meta [pu]) pus
+  mapM_ printOne (zip [1..] programs)
+  where
+    printOne (i, pf) = do
+      putStrLn $ "-- Program " ++ show (i :: Int) ++ " " ++ replicate 60 '-'
+      putStrLn $ pprintAndRender Fortran90 pf (Just 2)
+

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -18,6 +18,7 @@ import Control.Monad.State
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import System.FilePath ((</>))
+import Data.List (partition)
 
 --------------------------------------------------------------------------------
 -- Core (stateless) generators
@@ -40,7 +41,8 @@ instance Arbitrary RealLit where
     -- literal, but it may not be exactly the same as the original float
     --  due to formatting differences.
     -- (Haskell's 'show' may use scientific notation- issue?)
-    return $ RealLit (show float) (Exponent ExpLetterE (show (floor (logBase 10 (abs float))) :: String))  
+    let (floatString, _) = break (== 'e') $ show float
+    return $ RealLit floatString (Exponent ExpLetterE (show (floor (logBase 10 (abs float))) :: String))
 
 instance Arbitrary BaseType where
   arbitrary = oneof
@@ -54,7 +56,7 @@ instance Arbitrary a => Arbitrary (TypeSpec a) where
   arbitrary = do
     annotation <- arbitrary
     base       <- arbitrary
-    selector <- 
+    selector <-
       case base of
         TypeReal -> do
           -- For real types, we can optionally include a kind selector.
@@ -120,7 +122,7 @@ genDecl :: GenM (Statement A0)
 genDecl = do
   name      <- freshName
   typeSpec  <- arbitraryCtxt
-  initialExpr <- genTypedExpression typeSpec
+  initialExpr <- genTypedValue typeSpec
   let
       varExpr   = ExpValue () nullSpan (ValVariable name)
       decl      = Declarator () nullSpan varExpr ScalarDecl Nothing (Just initialExpr)
@@ -193,16 +195,17 @@ genTypedValue (TypeSpec _ _ baseType _) = case baseType of
     pure $ ExpValue () nullSpan (ValReal x Nothing)
   TypeLogical -> do
     b <- liftGen (arbitrary :: Gen Bool)
-    pure $ ExpValue () nullSpan (ValLogical b Nothing) 
+    pure $ ExpValue () nullSpan (ValLogical b Nothing)
   TypeCharacter -> do
     n <- liftGen $ choose (0, 20)
     --TODO: consider utf-8 because maybe this is somewhere things break in compilers
     s <- liftGen $ vectorOf n (choose (' ', '~'))
-    pure $ ExpValue () nullSpan (ValString s)
+    let s' = concat (map (\c -> if c == '\'' then "" else if c == '\"' then "\\\"" else [c]) s)
+    pure $ ExpValue () nullSpan (ValString s')
 
 instance ArbitraryCtxt a => ArbitraryCtxt [a] where
   arbitraryCtxt = do
-    n <- liftGen $ choose (0, 20)  -- Limit list length for simplicity
+    n <- liftGen $ choose (0, 2000)  -- Limit list length for simplicity
     replicateM n arbitraryCtxt
 
 oneofCtxt :: [GenM a] -> GenM a

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -35,6 +35,17 @@ instance Arbitrary a => Arbitrary (Value a) where
     , pure $ ValVariable "myVar"
     ]
 
+instance Arbitrary BaseType where
+  arbitrary = oneof
+    [ pure TypeInteger
+    , pure TypeReal
+    , pure TypeLogical
+    , pure TypeCharacter
+    ]
+
+
+
+
 -- Generate a list of 10 values and pretty print
 -- the results
 demo :: IO ()

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -8,7 +8,11 @@ import Language.Fortran.PrettyPrint
 import Language.Fortran.Version
 
 import Text.PrettyPrint
-import Text.PrettyPrint.HughesPJ
+import Text.PrettyPrint.HughesPJ hiding ((<>))
+
+import Control.Monad.State
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 
 -- instance Gen SrcSpan where
 --   arbitrary = do
@@ -43,7 +47,49 @@ instance Arbitrary BaseType where
     , pure TypeCharacter
     ]
 
+instance Arbitrary a => Arbitrary (TypeSpec a) where
+  arbitrary = do
+    annotation <- arbitrary
+    base       <- arbitrary
+    selector   <- arbitrary
+    pure $ TypeSpec annotation nullSpan base selector
 
+instance Arbitrary a => Arbitrary (Selector a) where
+  arbitrary = do 
+    annotation <- arbitrary
+    -- Positive length
+    len    :: Integer <- abs <$> arbitrary
+    -- Kind, powers of two
+    kind   :: Integer <- elements [1,2,4,8]
+    -- Wrap into expressions, with a chance of being Nothing
+    let kindExpr = ExpValue annotation nullSpan (ValInteger (show kind) Nothing)
+    lenExprM   <- maybeWrapper (pure (ExpValue annotation nullSpan (ValInteger (show len) Nothing)))
+    kindExprM  <- 
+       case lenExprM of 
+         Nothing -> return $ Just kindExpr  -- If no length, always include kind (cannot have nothing for both)
+         Just{}  -> maybeWrapper (pure kindExpr)
+    pure $ Selector annotation nullSpan lenExprM kindExprM
+
+maybeWrapper :: Gen a -> Gen (Maybe a)
+maybeWrapper gen = oneof [pure Nothing, Just <$> gen]
+
+
+nullSpan :: SrcSpan
+nullSpan = SrcSpan initPosition initPosition
+
+--------------------------------------------------------------------------------
+-- Stateful generation
+--------------------------------------------------------------------------------
+
+-- | Environment mapping variable names to their declared types.
+type Env = Map Name (TypeSpec A0)
+
+-- | Stateful generator: a 'Gen' action that can read/write an 'Env'.
+type GenM a = StateT Env Gen a
+
+-- | Lift a plain 'Gen' action into 'GenM'.
+liftGen :: Gen a -> GenM a
+liftGen = lift
 
 
 -- Generate a list of 10 values and pretty print

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -20,7 +20,7 @@ import Data.Map.Strict (Map)
 import System.FilePath ((</>))
 
 --------------------------------------------------------------------------------
--- Core generators
+-- Core (stateless) generators
 --------------------------------------------------------------------------------
 
 instance Arbitrary a => Arbitrary (Value a) where
@@ -67,7 +67,6 @@ instance Arbitrary a => Arbitrary (TypeSpec a) where
 
 maybeWrapper :: Gen a -> Gen (Maybe a)
 maybeWrapper gen = oneof [pure Nothing, Just <$> gen]
-
 
 nullSpan :: SrcSpan
 nullSpan = SrcSpan initPosition initPosition
@@ -133,10 +132,10 @@ genDecl = do
 genDecls :: Int -> GenM [Statement A0]
 genDecls n = replicateM n genDecl
 
--- | Top-level runner: generate a subroutine with a growing set of declarations.
---   Uses QuickCheck's 'sized' so the number of declarations scales with test size.
+-- | Generate a program unit with a growing set of declarations.
 instance Arbitrary (ProgramUnit A0) where
   arbitrary = sized $ \sz -> do
+    -- Uses QuickCheck's 'sized' so the number of declarations scales with test size.
     let numDecls = max 1 (sz `div` 5)
     (decls, env) <- runStateT (genDecls numDecls) Map.empty
     -- env is now available for generating expressions / further statements
@@ -151,8 +150,8 @@ instance Arbitrary (ProgramUnit A0) where
       printAllEnd env =
         [ BlStatement () nullSpan Nothing (StPrint () nullSpan (ExpValue () nullSpan ValStar) (fromList' () (map (\n -> ExpValue () nullSpan (ValVariable n)) (Map.keys env)))) ]
 
-
 instance ArbitraryCtxt (Statement A0) where
+  -- Bias assignments over print statements
   arbitraryCtxt = oneofCtxt (printer : replicate 3 assignment)
     where
       assignment :: GenM (Statement A0)
@@ -160,11 +159,14 @@ instance ArbitraryCtxt (Statement A0) where
         (lvar, typ) <- pickVar
         expr <- genTypedExpression typ
         pure $ StExpressionAssign () nullSpan (ExpValue () nullSpan (ValVariable lvar)) expr
+
       printer :: GenM (Statement A0)
       printer = do
-        expr <- genVarRef
+        (name, _) <- pickVar
+        let expr = ExpValue () nullSpan (ValVariable name)
         pure $ StPrint () nullSpan (ExpValue () nullSpan ValStar) (fromList' () [expr])
 
+-- Synthesise an expression of the given type
 genTypedExpression :: TypeSpec A0 -> GenM (Expression A0)
 genTypedExpression typeSpec = do
   -- For simplicity, we just generate a variable reference of the correct type.
@@ -180,6 +182,7 @@ genTypedExpression typeSpec = do
                         , genTypedValue typeSpec ]  -- In a full implementation, we would generate more complex expressions
       pure value
 
+-- Synthesise a value of the given type
 genTypedValue :: TypeSpec A0 -> GenM (Expression A0)
 genTypedValue (TypeSpec _ _ baseType _) = case baseType of
   TypeInteger -> do
@@ -192,7 +195,9 @@ genTypedValue (TypeSpec _ _ baseType _) = case baseType of
     b <- liftGen (arbitrary :: Gen Bool)
     pure $ ExpValue () nullSpan (ValLogical b Nothing) 
   TypeCharacter -> do
-    s <- liftGen (arbitrary :: Gen String)
+    n <- liftGen $ choose (0, 20)
+    --TODO: consider utf-8 because maybe this is somewhere things break in compilers
+    s <- liftGen $ vectorOf n (choose (' ', '~'))
     pure $ ExpValue () nullSpan (ValString s)
 
 instance ArbitraryCtxt a => ArbitraryCtxt [a] where
@@ -209,11 +214,6 @@ pickVar :: GenM (Name, TypeSpec A0)
 pickVar = do
   env <- get
   liftGen $ elements (Map.toList env)
-
-genVarRef :: GenM (Expression A0)
-genVarRef = do
-  (name, _) <- pickVar
-  pure $ ExpValue () nullSpan (ValVariable name)
 
 --------------------------------------------------------------------------------
 -- Demonstration / experimentation

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -92,6 +92,27 @@ type GenM a = StateT Env Gen a
 liftGen :: Gen a -> GenM a
 liftGen = lift
 
+-- | Like 'Arbitrary' but generators run in 'GenM', giving access to the
+--   typing environment.
+--
+--   The default implementation lifts 'arbitrary', so any type with an
+--   'Arbitrary' instance gets an 'ArbitraryCtxt' instance for free:
+--
+-- > instance ArbitraryCtxt BaseType  -- uses default
+--
+--   Override for types whose generation depends on the environment:
+--
+-- > instance ArbitraryCtxt (Statement A0) where
+-- >   arbitraryCtxt = genDecl
+class ArbitraryCtxt a where
+  arbitraryCtxt :: GenM a
+  default arbitraryCtxt :: Arbitrary a => GenM a
+  arbitraryCtxt = liftGen arbitrary
+
+instance ArbitraryCtxt BaseType
+instance ArbitraryCtxt (TypeSpec A0)
+instance ArbitraryCtxt (Selector A0)
+
 -- | Generate a fresh variable name based on the current environment size.
 freshName :: GenM Name
 freshName = do
@@ -105,11 +126,12 @@ freshName = do
 -- | Generate one declaration statement, adding the variable to the environment.
 genDecl :: GenM (Statement A0)
 genDecl = do
-  name     <- freshName
-  typeSpec  <- liftGen arbitrary
+  name      <- freshName
+  typeSpec  <- arbitraryCtxt
+  initialExpr <- genTypedExpression typeSpec
   let
       varExpr   = ExpValue () nullSpan (ValVariable name)
-      decl      = Declarator () nullSpan varExpr ScalarDecl Nothing Nothing
+      decl      = Declarator () nullSpan varExpr ScalarDecl Nothing (Just initialExpr)
       declList  = AList () nullSpan [decl]
   modify (Map.insert name typeSpec)
   pure $ StDeclaration () nullSpan typeSpec Nothing declList
@@ -120,19 +142,84 @@ genDecls n = replicateM n genDecl
 
 -- | Top-level runner: generate a subroutine with a growing set of declarations.
 --   Uses QuickCheck's 'sized' so the number of declarations scales with test size.
-genProgramUnit :: Gen (ProgramUnit A0)
-genProgramUnit = sized $ \sz -> do
-  let numDecls = max 1 (sz `div` 5)
-  (decls, env) <- runStateT (genDecls numDecls) Map.empty
-  -- env is now available for generating expressions / further statements
-  let blocks  = map (\s -> BlStatement () nullSpan Nothing s) decls
-      name    = "generated_sub"
-  pure $ PUSubroutine () nullSpan emptyPrefixSuffix name Nothing blocks Nothing
+instance Arbitrary (ProgramUnit A0) where
+  arbitrary = sized $ \sz -> do
+    let numDecls = max 1 (sz `div` 5)
+    (decls, env) <- runStateT (genDecls numDecls) Map.empty
+    -- env is now available for generating expressions / further statements
+    let declBlocks  = map (\s -> BlStatement () nullSpan Nothing s) decls
+        name    = "generated"
+    statements <- evalStateT arbitraryCtxt env :: Gen [Statement A0]
+    let computeBlocks = map (\s -> BlStatement () nullSpan Nothing s) statements
+    let blocks = declBlocks ++ computeBlocks ++ (printAllEnd env)
+    pure $ PUMain () nullSpan (Just name) blocks Nothing
+    where
+      -- print out everything in the environment at the end
+      printAllEnd env =
+        [ BlStatement () nullSpan Nothing (StPrint () nullSpan (ExpValue () nullSpan ValStar) (fromList' () (map (\n -> ExpValue () nullSpan (ValVariable n)) (Map.keys env)))) ]
+
+
+instance ArbitraryCtxt (Statement A0) where
+  arbitraryCtxt = oneofCtxt (printer : replicate 3 assignment)
+    where
+      assignment :: GenM (Statement A0)
+      assignment = do
+        (lvar, typ) <- pickVar
+        expr <- genTypedExpression typ
+        pure $ StExpressionAssign () nullSpan (ExpValue () nullSpan (ValVariable lvar)) expr
+      printer :: GenM (Statement A0)
+      printer = do
+        expr <- genVarRef
+        pure $ StPrint () nullSpan (ExpValue () nullSpan ValStar) (fromList' () [expr])
+
+genTypedExpression :: TypeSpec A0 -> GenM (Expression A0)
+genTypedExpression typeSpec = do
+  -- For simplicity, we just generate a variable reference of the correct type.
+  -- In a full implementation, we would generate more complex expressions.
+  env <- get
+  let candidates = [name | (name, t) <- Map.toList env, t == typeSpec]
+  if null candidates
+    then genTypedValue typeSpec  -- No variables of the correct type, fall back to arbitrary expression
+    else do
+      name <- liftGen $ elements candidates
+      annotation <- liftGen $ arbitrary
+      value <- oneofCtxt [ pure (ExpValue annotation nullSpan $ ValVariable name)
+                        , genTypedValue typeSpec ]  -- In a full implementation, we would generate more complex expressions
+      pure value
+
+genTypedValue :: TypeSpec A0 -> GenM (Expression A0)
+genTypedValue (TypeSpec _ _ baseType _) = case baseType of
+  TypeInteger -> do
+    x <- liftGen (arbitrary :: Gen Integer)
+    pure $ ExpValue () nullSpan (ValInteger (show x) Nothing)
+  TypeReal -> do
+    x <- liftGen arbitrary
+    pure $ ExpValue () nullSpan (ValReal x Nothing)
+  TypeLogical -> do
+    b <- liftGen (arbitrary :: Gen Bool)
+    pure $ ExpValue () nullSpan (ValLogical b Nothing) 
+  TypeCharacter -> do
+    s <- liftGen (arbitrary :: Gen String)
+    pure $ ExpValue () nullSpan (ValString s)
+
+instance ArbitraryCtxt a => ArbitraryCtxt [a] where
+  arbitraryCtxt = do
+    n <- liftGen $ choose (0, 20)  -- Limit list length for simplicity
+    replicateM n arbitraryCtxt
+
+oneofCtxt :: [GenM a] -> GenM a
+oneofCtxt gens = do
+  gen <- liftGen $ elements gens
+  gen
+
+pickVar :: GenM (Name, TypeSpec A0)
+pickVar = do
+  env <- get
+  liftGen $ elements (Map.toList env)
 
 genVarRef :: GenM (Expression A0)
 genVarRef = do
-  env <- get
-  (name, _) <- liftGen $ elements (Map.toList env)
+  (name, _) <- pickVar
   pure $ ExpValue () nullSpan (ValVariable name)
 
 --------------------------------------------------------------------------------
@@ -151,7 +238,7 @@ demoVal = do
 -- | Generate 10 full Fortran programs and print each one.
 demoProgram :: IO ()
 demoProgram = do
-  pus <- generate $ vectorOf 10 genProgramUnit
+  pus <- generate $ vectorOf 10 (arbitrary :: Gen (ProgramUnit A0))
   let meta = MetaInfo { miVersion = Fortran90, miFilename = "<generated>" }
       programs = map (\pu -> ProgramFile meta [pu]) pus
   mapM_ printOne (zip [1..] programs)

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -14,20 +14,9 @@ import Control.Monad.State
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 
--- instance Gen SrcSpan where
---   arbitrary = do
---     start <- arbitrary
---     end   <- arbitrary
---     return $ SrcSpan start end
-
--- instance Gen Position where
---   arbitrary = do
---     absOffset <- arbitrary
---     col       <- arbitrary
---     line      <- arbitrary
---     filePath  <- arbitrary
---     pragmaOffset <- arbitrary
---     return $ Position absOffset col line filePath pragmaOffset
+--------------------------------------------------------------------------------
+-- Core generators
+--------------------------------------------------------------------------------
 
 instance Arbitrary a => Arbitrary (Value a) where
   arbitrary = oneof
@@ -97,13 +86,16 @@ freshName = do
   env <- get
   pure $ "var" ++ show (Map.size env)
 
+--------------------------------------------------------------------------------
+-- Generate typing context and declarations
+--------------------------------------------------------------------------------
+
 -- | Generate one declaration statement, adding the variable to the environment.
 genDecl :: GenM (Statement A0)
 genDecl = do
   name     <- freshName
-  baseType <- liftGen arbitrary
-  selector <- liftGen arbitrary
-  let typeSpec  = TypeSpec () nullSpan baseType selector
+  typeSpec  <- liftGen arbitrary
+  let
       varExpr   = ExpValue () nullSpan (ValVariable name)
       decl      = Declarator () nullSpan varExpr ScalarDecl Nothing Nothing
       declList  = AList () nullSpan [decl]
@@ -113,11 +105,6 @@ genDecl = do
 -- | Generate @n@ declarations, building up the environment as we go.
 genDecls :: Int -> GenM [Statement A0]
 genDecls n = replicateM n genDecl
-
--- | Generate declarations for sizes 1..n, returning each batch.
---   The environment accumulates across all batches.
-genDeclsScaled :: Int -> GenM [[Statement A0]]
-genDeclsScaled n = mapM genDecls [1..n]
 
 -- | Top-level runner: generate a subroutine with a growing set of declarations.
 --   Uses QuickCheck's 'sized' so the number of declarations scales with test size.
@@ -135,6 +122,10 @@ genVarRef = do
   env <- get
   (name, _) <- liftGen $ elements (Map.toList env)
   pure $ ExpValue () nullSpan (ValVariable name)
+
+--------------------------------------------------------------------------------
+-- Demonstration / expertimentation
+--------------------------------------------------------------------------------
 
 -- Generate a list of 10 values and pretty print
 -- the results

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -54,24 +54,16 @@ instance Arbitrary a => Arbitrary (TypeSpec a) where
   arbitrary = do
     annotation <- arbitrary
     base       <- arbitrary
-    selector   <- arbitrary
+    selector <- 
+      case base of
+        TypeReal -> do
+          -- For real types, we can optionally include a kind selector.
+          kind   :: Integer <- elements [4,8]
+          let kindExpr = ExpValue annotation nullSpan (ValInteger (show kind) Nothing)
+          return $ Just $ Selector annotation nullSpan Nothing (Just kindExpr)
+        -- No selector
+        _ -> return Nothing
     pure $ TypeSpec annotation nullSpan base selector
-
-instance Arbitrary a => Arbitrary (Selector a) where
-  arbitrary = do 
-    annotation <- arbitrary
-    -- Positive length
-    len    :: Integer <- abs <$> arbitrary
-    -- Kind, powers of two
-    kind   :: Integer <- elements [1,2,4,8]
-    -- Wrap into expressions, with a chance of being Nothing
-    let kindExpr = ExpValue annotation nullSpan (ValInteger (show kind) Nothing)
-    lenExprM   <- maybeWrapper (pure (ExpValue annotation nullSpan (ValInteger (show len) Nothing)))
-    kindExprM  <- 
-       case lenExprM of 
-         Nothing -> return $ Just kindExpr  -- If no length, always include kind (cannot have nothing for both)
-         Just{}  -> maybeWrapper (pure kindExpr)
-    pure $ Selector annotation nullSpan lenExprM kindExprM
 
 maybeWrapper :: Gen a -> Gen (Maybe a)
 maybeWrapper gen = oneof [pure Nothing, Just <$> gen]
@@ -113,7 +105,6 @@ class ArbitraryCtxt a where
 
 instance ArbitraryCtxt BaseType
 instance ArbitraryCtxt (TypeSpec A0)
-instance ArbitraryCtxt (Selector A0)
 
 -- | Generate a fresh variable name based on the current environment size.
 freshName :: GenM Name

--- a/src/Language/Fortran/Generate.hs
+++ b/src/Language/Fortran/Generate.hs
@@ -13,9 +13,11 @@ import Language.Fortran.Version
 import Text.PrettyPrint
 import Text.PrettyPrint.HughesPJ hiding ((<>))
 
+import Control.Monad (forM_)
 import Control.Monad.State
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import System.FilePath ((</>))
 
 --------------------------------------------------------------------------------
 -- Core generators
@@ -223,7 +225,7 @@ genVarRef = do
   pure $ ExpValue () nullSpan (ValVariable name)
 
 --------------------------------------------------------------------------------
--- Demonstration / expertimentation
+-- Demonstration / experimentation
 --------------------------------------------------------------------------------
 
 -- Generate a list of 10 values and pretty print
@@ -246,4 +248,28 @@ demoProgram = do
     printOne (i, pf) = do
       putStrLn $ "-- Program " ++ show (i :: Int) ++ " " ++ replicate 60 '-'
       putStrLn $ pprintAndRender Fortran90 pf (Just 2)
+
+--------------------------------------------------------------------------------
+-- Generate programs to files
+--------------------------------------------------------------------------------
+
+-- | Generate @n@ Fortran programs and write each to @dir/<name>.f90@.
+--   Filenames are taken from the PUMain program unit name; unnamed programs
+--   are numbered @program_1.f90@, @program_2.f90@, etc.
+generatePrograms :: Int -> FilePath -> IO ()
+generatePrograms n dir = do
+  pus <- generate $ vectorOf n (resize n (arbitrary :: Gen (ProgramUnit A0)))
+  let meta = MetaInfo { miVersion = Fortran90, miFilename = "<generated>" }
+  forM_ (zip [1 :: Int ..] pus) $ \(i, pu) -> do
+    let name = "example" ++ show i
+        pu'   = updateName name pu
+        pf   = ProgramFile (meta { miFilename = name ++ ".f90" }) [pu']
+        src  = pprintAndRender Fortran90 pf (Just 2)
+        path = dir </> name ++ ".f90"
+    writeFile path src
+    putStrLn $ "Written: " ++ path
+  where
+    updateName name (PUMain a src (Just _) blocks subprog) = PUMain a src (Just name) blocks subprog
+    -- TODO: maybe want to expand this.
+    updateName name p = p
 


### PR DESCRIPTION
This is a WIP PR to provide a technique for automatically enumerating valid Fortran programs using QuickCheck style generation. The aim is to provide a facility for easily generating sample programs which can be used for testing other tools, e.g., refactoring tools and compilers. This leverages the machinery of QuickCheck's `Arbitrary` class.

Typing and scoping are the main challenges. Looking into work such as [Making Random Judgments: Automatically Generating
Well-Typed Terms from the Definition of a Type-System (ESOP 2015)](http://users.eecs.northwestern.edu/~baf111/random-judgments/random-judgments-esop15.pdf)
Also relevant: https://dl.acm.org/doi/pdf/10.1145/3363562
See also CSmith: https://users.cs.utah.edu/~regehr/papers/pldi11-preprint.pdf

- [x] Simple value generator
- [x] Declarations
- [ ] Source spans and positions (that do not need to be accureate)
- [x] Well-typed assignments
- [x] Well-typed values
- [ ] Well-typed expressions
- [ ] More statements
- [ ] Program units

Usage:
```
fortran-src --generate N -o DIR
```
generates `N` programs in the `DIR` directory.

I have also put a script in the top-level directory for comparing `gfortran` and `ifort`:
```
python compare_compilers.py out
```