### PR TITLE
Fix parsing of allocate statements inside other statements (Fortran 2003 / free form)

### DIFF
--- a/src/Language/Fortran/Parser/Free/Lexer.x
+++ b/src/Language/Fortran/Parser/Free/Lexer.x
@@ -450,11 +450,20 @@ parenLevel = foldl' f 0
             | fillConstr TRightPar == toConstr tok = n - 1
             | otherwise                            = n
 
+-- Detect whether the current line is part of an allocate statement
+-- (which may be prepended with other tokens, e.g., if this is an `if` statement
+-- with aan allocate statement inside on a single line).
+allocateStatement :: [Token] -> Maybe [Token]
+allocateStatement (hd1:hd2:rest)
+  | toConstr hd1 `elem` [fillConstr TAllocate, fillConstr TDeallocate]
+  , toConstr hd2 == fillConstr TLeftPar
+  = Just rest
+  | otherwise = allocateStatement (hd2:rest)
+allocateStatement _ = Nothing
+
 allocateP :: User -> AlexInput -> Int -> AlexInput -> Bool
 allocateP _ _ _ ai
-  | alloc:lpar:rest <- prevTokens
-  , toConstr alloc `elem` [fillConstr TAllocate, fillConstr TDeallocate]
-  , fillConstr TLeftPar  == toConstr lpar
+  | Just rest <- allocateStatement (prevTokens)
   = null rest || (followsComma && parenLevel prevTokens == 1)
   | otherwise = False
   where

--- a/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
+++ b/test/Language/Fortran/Parser/Free/Fortran2003Spec.hs
@@ -180,4 +180,17 @@ spec =
             expBinVars op x1 x2 = ExpBinary () u op (expValVar x1) (expValVar x2)
         bParser text `shouldBe'` expected
 
+    describe "allocate statement" $ do
+      it "parses allocated nested in another statement" $ do
+        let text = "if(y) allocate(x,stat=ierr_allocate)"
+        let expected = StIfLogical () u
+                    (ExpValue () u (ValVariable "y")) (StAllocate () u Nothing
+                        (AList  {alistAnno = (),
+                                 alistSpan = u,
+                                 alistList = [ExpValue () u (ValVariable "x")]})
+                        (Just AList {alistAnno = (),
+                                     alistSpan = u,
+                                     alistList = [AOStat () u (ExpValue () u (ValVariable "ierr_allocate"))]}))
+        sParser text `shouldBe'` expected
+
     specFreeCommon bParser sParser eParser


### PR DESCRIPTION
This fixes issue #311 where the lexer was not appropriately contextualising keywords used for allocate statements because its contextual detection was a bit weak. This is fixed here with a test.