### PR TITLE
Pretty-printer for Fortran 77 needs to re-interpret do blocks

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -138,7 +138,7 @@ main = do
       case actionOpt of
         Lex | version `elem` [ Fortran66, Fortran77, Fortran77Extended, Fortran77Legacy ] ->
           print $ Parser.collectTokens Fixed.lexer' $ initParseStateFixed "<unknown>" version contents
-        Lex | version `elem` [Fortran90, Fortran2003, Fortran2008] ->
+        Lex | version `elem` [Fortran90, Fortran90Legacy, Fortran2003, Fortran2008] ->
           print $ Parser.collectTokens Free.lexer'  $ initParseStateFree "<unknown>" version contents
         Lex        -> ioError $ userError $ usageInfo programName options
         Parse      -> pp parsedPF

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -61,6 +61,16 @@ extra-source-files:
     test-data/rewriter/replacementsmap-simple/005_unicode.f
     test-data/rewriter/replacementsmap-simple/005_unicode.f.expected
     test-data/rewriter/temp-failure/fail.f
+    test-data/prettyprint/labeled-continue/contalt.f
+    test-data/prettyprint/labeled-continue/contalt.f.expected
+    test-data/prettyprint/labeled-continue/contalt.f.f77.expected
+    test-data/prettyprint/labeled-continue/continue-bug.f
+    test-data/prettyprint/labeled-continue/continue-bug.f.expected
+    test-data/prettyprint/labeled-continue/continue-bug.f.f77.expected
+    test-data/prettyprint/labeled-continue/nested.f
+    test-data/prettyprint/labeled-continue/nested.f.expected
+    test-data/prettyprint/labeled-continue/nested.f.f77.expected
+
 
 source-repository head
   type: git

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -325,6 +325,10 @@ instance IndentablePretty (Block a) where
         abstract | v >= Fortran2003 && abstractp = "abstract "
                  | otherwise = empty
 
+    -- Up to Fortran77, nested labeled do-loops can be closed by the
+    -- same labeled statement. In that case, it does not matter which
+    -- loop prints the `continue` statement, as long as there is only
+    -- one closing statement with a particular label in the end
     pprint v (BlDo _ _ mLabel mn tl doSpec body el) i
       | v >= Fortran77Extended =
         labeledIndent mLabel

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -253,46 +253,6 @@ endGen v constructName name i = indent i $ "end" <+> middle <> newline
 instance IndentablePretty [Block a] where
     pprint v bs i = foldl' (\b a -> b <> pprint v a i) empty bs
 
--- Extract list of end-labels in do loops
-nestedLabels :: Block a -> Set Integer -> Set Integer
-nestedLabels = go
-  where
-    go :: Block a -> Set Integer -> Set Integer
-    go b acc = case b of
-      BlDo _ _ _ _ _ _ body el ->
-        let mLabel = labelOf el
-            acc'   = maybe acc (`Set.insert` acc) mLabel
-        in foldr go acc' body
-               
-      BlDoWhile _ _ _ _ _ _ body el ->
-        let mLabel = labelOf el
-            acc'   = maybe acc (`Set.insert` acc) mLabel
-        in foldr go acc' body
-
-      -- other constructors unchanged
-      BlStatement{} -> acc
-      BlInterface{} -> acc
-      BlComment{}   -> acc
-
-      BlIf _ _ _ _ clauses elseBlock _ ->
-        let clauses' = NonEmpty.toList clauses
-            blocks = concatMap snd clauses' 
-            acc' = foldr go acc blocks
-        in maybe acc (foldr go acc') elseBlock
-
-      BlCase _ _ _ _ _ clauses caseDefault _ ->
-        let clauses' = concatMap snd clauses
-            acc' = foldr go acc clauses'
-        in maybe acc (foldr go acc') caseDefault
-
-      BlForall _ _ _ _ _ blocks _ -> foldr go acc blocks
-
-      BlAssociate _ _ _ _ _ blocks _ -> foldr go acc blocks
-
-labelOf :: Maybe (Expression a) -> Maybe Integer
-labelOf (Just (ExpValue _ _ (ValInteger i _))) = Just $ read i
-labelOf _ = Nothing
-
 instance IndentablePretty (Block a) where
     pprint v (BlForall _ _ mLabel mName _ body mel) i =
       labeledIndent mLabel (pprint' v mName) <> newline <>
@@ -376,6 +336,8 @@ instance IndentablePretty (Block a) where
         in case (tl, mn, el) of
           -- Labeled do with end label: print labeled continue
           (Just _, Nothing, Just _) ->
+            -- For nested loops with the same target only 
+            -- print end label for inner-most loop 
             if printEndLabel then
               indent i (pprint' v el <> " " <> "continue" <> newline)
             else
@@ -392,6 +354,8 @@ instance IndentablePretty (Block a) where
             labeledIndent mLabel
               ("do" <+> pprint' v tLabel <+> pprint' v doSpec <> newline) <>
               pprint v body nextI <>
+              -- For nested loops with the same target only 
+              -- print end label for inner-most loop 
               if isJust el && printEndLabel then
                 pprint' v el `overlay` indent i ("continue" <> newline)
               else
@@ -404,6 +368,34 @@ instance IndentablePretty (Block a) where
           if v >= Fortran90
             then indent i (pprint' v label <+> stDoc)
             else pprint' v mLabel `overlay` indent i stDoc
+
+        -- Extract list of end-labels in do loops
+        nestedLabels :: Block a -> Set Integer -> Set Integer
+        nestedLabels = go
+          where
+            go b acc = case b of
+              BlDo _ _ _ _ _ _ body' el'      -> goBody body' el' acc
+              BlDoWhile _ _ _ _ _ _ body' el' -> goBody body' el' acc
+
+              BlIf _ _ _ _ clauses elseB _ ->
+                let acc' = foldr go acc (concatMap snd (NonEmpty.toList clauses))
+                in maybe acc' (foldr go acc') elseB
+
+              BlCase _ _ _ _ _ clauses def _ ->
+                let acc' = foldr go acc (concatMap snd clauses)
+                in maybe acc' (foldr go acc') def
+
+              BlForall _ _ _ _ _ bs _    -> foldr go acc bs
+              BlAssociate _ _ _ _ _ bs _ -> foldr go acc bs
+
+              _ -> acc
+
+            goBody body' el' acc =
+              foldr go (maybe acc (`Set.insert` acc) (labelOf el')) body'
+
+        labelOf :: Maybe (Expression a) -> Maybe Integer
+        labelOf (Just (ExpValue _ _ (ValInteger i _))) = Just $ read i
+        labelOf _ = Nothing
 
     pprint v (BlDoWhile _ _ mLabel mName mTarget cond body el) i
        | v >= Fortran77Extended =

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -339,7 +339,7 @@ instance IndentablePretty (Block a) where
               ("do" <+> pprint' v tLabel <+> pprint' v doSpec <> newline) <>
               pprint v body nextI <>
               if isJust el -- If there is an end label, show a labelled continue
-                then pprint' v el `overlay` indent i ("continue" <+> newline)
+                then pprint' v el `overlay` indent i ("continue" <> newline)
                 else empty
           Nothing ->
             prettyError "Fortran 77 and earlier versions only have labeled DO blocks"

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -328,9 +328,12 @@ instance IndentablePretty (Block a) where
           (pprint' v mn <?> colon <+>
           "do" <+> pprint' v tl <+> pprint' v doSpec <> newline) <>
         pprint v body nextI <>
-        if isJust tl && isNothing mn
-          then empty
-          else labeledIndent el ("end do" <+> pprint' v mn <> newline)
+        case (tl, mn, el) of
+          -- Labeled do with end label: print labeled continue
+          (Just _, Nothing, Just _) ->
+            indent i (pprint' v el <> " " <> "continue" <> newline)
+          -- Named do or unlabeled do: print end do
+          _ -> labeledIndent el ("end do" <+> pprint' v mn <> newline)
 
       | otherwise =
         case tl of

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -6,6 +6,9 @@ module Language.Fortran.PrettyPrint where
 import Data.Maybe (isJust, isNothing, listToMaybe)
 import Data.List (foldl')
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 import Prelude hiding (EQ,LT,GT,pred,exp,(<>))
 
@@ -250,6 +253,46 @@ endGen v constructName name i = indent i $ "end" <+> middle <> newline
 instance IndentablePretty [Block a] where
     pprint v bs i = foldl' (\b a -> b <> pprint v a i) empty bs
 
+-- Extract list of end-labels in do loops
+nestedLabels :: Block a -> Set Integer -> Set Integer
+nestedLabels = go
+  where
+    go :: Block a -> Set Integer -> Set Integer
+    go b acc = case b of
+      BlDo _ _ _ _ _ _ body el ->
+        let mLabel = labelOf el
+            acc'   = maybe acc (`Set.insert` acc) mLabel
+        in foldr go acc' body
+               
+      BlDoWhile _ _ _ _ _ _ body el ->
+        let mLabel = labelOf el
+            acc'   = maybe acc (`Set.insert` acc) mLabel
+        in foldr go acc' body
+
+      -- other constructors unchanged
+      BlStatement{} -> acc
+      BlInterface{} -> acc
+      BlComment{}   -> acc
+
+      BlIf _ _ _ _ clauses elseBlock _ ->
+        let clauses' = NonEmpty.toList clauses
+            blocks = concatMap snd clauses' 
+            acc' = foldr go acc blocks
+        in maybe acc (foldr go acc') elseBlock
+
+      BlCase _ _ _ _ _ clauses caseDefault _ ->
+        let clauses' = concatMap snd clauses
+            acc' = foldr go acc clauses'
+        in maybe acc (foldr go acc') caseDefault
+
+      BlForall _ _ _ _ _ blocks _ -> foldr go acc blocks
+
+      BlAssociate _ _ _ _ _ blocks _ -> foldr go acc blocks
+
+labelOf :: Maybe (Expression a) -> Maybe Integer
+labelOf (Just (ExpValue _ _ (ValInteger i _))) = Just $ read i
+labelOf _ = Nothing
+
 instance IndentablePretty (Block a) where
     pprint v (BlForall _ _ mLabel mName _ body mel) i =
       labeledIndent mLabel (pprint' v mName) <> newline <>
@@ -328,22 +371,31 @@ instance IndentablePretty (Block a) where
           (pprint' v mn <?> colon <+>
           "do" <+> pprint' v tl <+> pprint' v doSpec <> newline) <>
         pprint v body nextI <>
-        case (tl, mn, el) of
+        let nls = foldr nestedLabels Set.empty body
+            printEndLabel = not $ maybe True (`Set.member` nls) (labelOf el)
+        in case (tl, mn, el) of
           -- Labeled do with end label: print labeled continue
           (Just _, Nothing, Just _) ->
-            indent i (pprint' v el <> " " <> "continue" <> newline)
+            if printEndLabel then
+              indent i (pprint' v el <> " " <> "continue" <> newline)
+            else
+              empty
           -- Named do or unlabeled do: print end do
           _ -> labeledIndent el ("end do" <+> pprint' v mn <> newline)
 
       | otherwise =
         case tl of
           Just tLabel ->
+            let nls = foldr nestedLabels Set.empty body
+                printEndLabel = not $ maybe True (`Set.member` nls) (labelOf el)
+            in
             labeledIndent mLabel
               ("do" <+> pprint' v tLabel <+> pprint' v doSpec <> newline) <>
               pprint v body nextI <>
-              if isJust el -- If there is an end label, show a labelled continue
-                then pprint' v el `overlay` indent i ("continue" <> newline)
-                else empty
+              if isJust el && printEndLabel then
+                pprint' v el `overlay` indent i ("continue" <> newline)
+              else
+                  empty
           Nothing ->
             prettyError "Fortran 77 and earlier versions only have labeled DO blocks"
       where

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -331,12 +331,16 @@ instance IndentablePretty (Block a) where
         if isJust tl && isNothing mn
           then empty
           else labeledIndent el ("end do" <+> pprint' v mn <> newline)
+
       | otherwise =
         case tl of
           Just tLabel ->
             labeledIndent mLabel
               ("do" <+> pprint' v tLabel <+> pprint' v doSpec <> newline) <>
-            pprint v body nextI
+              pprint v body nextI <>
+              if isJust el -- If there is an end label, show a labelled continue
+                then pprint' v el `overlay` indent i ("continue" <+> newline)
+                else empty
           Nothing ->
             prettyError "Fortran 77 and earlier versions only have labeled DO blocks"
       where

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -174,7 +174,7 @@ collectNonLabeledDoBlocks targetLabel blocks =
                            BlStatement _ _ _ StContinue{} -> []
                            _                              -> [b]
 
-
+-- Compare two labels (which are stored via expressions)
 compLabel :: Maybe (Expression a) -> Maybe (Expression a) -> Bool
 compLabel (Just (ExpValue _ _ (ValInteger l1 _)))
           (Just (ExpValue _ _ (ValInteger l2 _))) = strip l1 == strip l2

--- a/test-data/prettyprint/labeled-continue/contalt.f
+++ b/test-data/prettyprint/labeled-continue/contalt.f
@@ -1,0 +1,8 @@
+      program contal
+      implicit none
+      integer i
+      do 42 i = 1, 9, 2
+      print *, i
+      i = (i - 1)
+42    continue
+      end

--- a/test-data/prettyprint/labeled-continue/contalt.f.expected
+++ b/test-data/prettyprint/labeled-continue/contalt.f.expected
@@ -1,0 +1,8 @@
+program contal
+implicit none
+integer :: i
+do 42 i = 1, 9, 2
+print *, i
+i = (i - 1)
+42 continue
+end program contal

--- a/test-data/prettyprint/labeled-continue/contalt.f.f77.expected
+++ b/test-data/prettyprint/labeled-continue/contalt.f.f77.expected
@@ -1,0 +1,8 @@
+      program contal
+      implicit none
+      integer i
+      do 42 i = 1, 9, 2
+        print *, i
+        i = (i - 1)
+42    continue
+      end

--- a/test-data/prettyprint/labeled-continue/continue-bug.f
+++ b/test-data/prettyprint/labeled-continue/continue-bug.f
@@ -1,0 +1,12 @@
+      PROGRAM TEST
+      IMPLICIT NONE
+      PARAMETER (MAXLAY=20)
+      DIMENSION A(MAXLAY), B(MAXLAY), C(MAXLAY)
+      INTEGER NLAY
+      OPEN(UNIT=10)
+      READ(10, *) NLAY
+      DO 100 I = 1, NLAY
+         READ(10, *) A(I), B(I), C(I)
+  100 CONTINUE
+      CLOSE(10)
+      END

--- a/test-data/prettyprint/labeled-continue/continue-bug.f.expected
+++ b/test-data/prettyprint/labeled-continue/continue-bug.f.expected
@@ -1,0 +1,12 @@
+program test
+implicit none
+parameter (maxlay = 20)
+dimension :: a(maxlay), b(maxlay), c(maxlay)
+integer :: nlay
+open (unit=10)
+read (10, *) nlay
+do 100 i = 1, nlay
+read (10, *) a(i), b(i), c(i)
+100 continue
+close (10)
+end program test

--- a/test-data/prettyprint/labeled-continue/continue-bug.f.f77.expected
+++ b/test-data/prettyprint/labeled-continue/continue-bug.f.f77.expected
@@ -1,0 +1,12 @@
+      program test
+      implicit none
+      parameter (maxlay = 20)
+      dimension a(maxlay), b(maxlay), c(maxlay)
+      integer nlay
+      open (unit=10)
+      read (10, *) nlay
+      do 100 i = 1, nlay
+        read (10, *) a(i), b(i), c(i)
+100   continue
+      close (10)
+      end

--- a/test-data/prettyprint/labeled-continue/nested.f
+++ b/test-data/prettyprint/labeled-continue/nested.f
@@ -1,0 +1,11 @@
+      PROGRAM NESTED
+      INTEGER I,J, SUM
+      SUM = 0
+
+      DO 100 I = 1,5
+        DO 100 J = 1,5
+            SUM = SUM + 1
+100   CONTINUE
+
+      PRINT *, 'SUM = ', SUM
+      END

--- a/test-data/prettyprint/labeled-continue/nested.f.expected
+++ b/test-data/prettyprint/labeled-continue/nested.f.expected
@@ -1,0 +1,9 @@
+program nested
+integer :: i, j, sum
+sum = 0
+do 100 i = 1, 5
+do 100 j = 1, 5
+sum = (sum + 1)
+100 continue
+print *, 'SUM = ', sum
+end program nested

--- a/test-data/prettyprint/labeled-continue/nested.f.f77.expected
+++ b/test-data/prettyprint/labeled-continue/nested.f.f77.expected
@@ -1,0 +1,9 @@
+      program nested
+      integer i, j, sum
+      sum = 0
+      do 100 i = 1, 5
+        do 100 j = 1, 5
+          sum = (sum + 1)
+100     continue
+      print *, 'SUM = ', sum
+      end

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -624,7 +624,9 @@ testParseReprint version inputFile expectedFile = do
     Left err -> expectationFailure $ "Parse error: " ++ show err
     Right pf -> do
       let reprinted = B.pack $ show $ pprint version pf Nothing
-      reprinted `shouldBe` expectedContent
+      -- Normalize line endings: remove \r for cross-platform compatibility
+      let normalize = B.filter (/= '\r')
+      normalize reprinted `shouldBe` normalize expectedContent
 
 valueExpressions :: Expression () -> Maybe (Expression ())
 valueExpressions e@ExpValue{} = Just e

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -603,6 +603,11 @@ spec =
           let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f.expected"
           testParseReprint Fortran90 inputFile expectedFile
 
+        it "correctly reprints F90 nested labeled do loop (nested.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "nested.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "nested.f.expected"
+          testParseReprint Fortran90 inputFile expectedFile
+
       describe "Fortran 77" $ do
         it "correctly reprints F77 labeled continue statement (contalt.f)" $ do
           let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "contalt.f"
@@ -612,6 +617,11 @@ spec =
         it "correctly reprints F77 continue statement formatting (continue-bug.f)" $ do
           let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f"
           let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f.f77.expected"
+          testParseReprint Fortran77 inputFile expectedFile
+        
+        it "correctly reprints F77 nested labeled do loop (nested.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "nested.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "nested.f.f77.expected"
           testParseReprint Fortran77 inputFile expectedFile
 
 -- | Helper function to test parsing and reprinting a file

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -12,12 +12,16 @@ import Language.Fortran.AST as LFA
 import Language.Fortran.AST.Literal.Boz
 import Language.Fortran.Version
 import Language.Fortran.PrettyPrint
+import Language.Fortran.Parser
 
 import Text.PrettyPrint hiding ((<>))
 import Text.PrettyPrint.GenericPretty
 
 import Test.Hspec
 import TestUtil
+
+import qualified Data.ByteString.Char8 as B
+import System.FilePath ((</>))
 
 checkAll :: forall a b c . (Out c, Data c, Data a, Data b)
          => (b -> Maybe c) -> (c -> Spec) -> a -> Spec
@@ -586,6 +590,41 @@ spec =
         let input  = "      integer, parameter :: "
                   <> "variable_id_making_line_exactly_72_chars = 1"
         reformatMixedFormInsertContinuations input `shouldBe` input
+
+    describe "File-based parse and reprint tests" $ do
+      describe "Fortran 90" $ do
+        it "correctly reprints F90 labeled continue statement (contalt.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "contalt.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "contalt.f.expected"
+          testParseReprint Fortran90 inputFile expectedFile
+
+        it "correctly reprints F90 continue statement formatting (continue-bug.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f.expected"
+          testParseReprint Fortran90 inputFile expectedFile
+
+      describe "Fortran 77" $ do
+        it "correctly reprints F77 labeled continue statement (contalt.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "contalt.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "contalt.f.f77.expected"
+          testParseReprint Fortran77 inputFile expectedFile
+
+        it "correctly reprints F77 continue statement formatting (continue-bug.f)" $ do
+          let inputFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f"
+          let expectedFile = "test-data" </> "prettyprint" </> "labeled-continue" </> "continue-bug.f.f77.expected"
+          testParseReprint Fortran77 inputFile expectedFile
+
+-- | Helper function to test parsing and reprinting a file
+testParseReprint :: FortranVersion -> FilePath -> FilePath -> IO ()
+testParseReprint version inputFile expectedFile = do
+  inputContent <- B.readFile inputFile
+  expectedContent <- B.readFile expectedFile
+  let parser = byVer version
+  case parser inputFile inputContent of
+    Left err -> expectationFailure $ "Parse error: " ++ show err
+    Right pf -> do
+      let reprinted = B.pack $ show $ pprint version pf Nothing
+      reprinted `shouldBe` expectedContent
 
 valueExpressions :: Expression () -> Maybe (Expression ())
 valueExpressions e@ExpValue{} = Just e

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -373,7 +373,7 @@ spec =
           pprint Fortran90 bl Nothing `shouldBe` text expect
 
         it "prints vanilla labeled do loop" $ do
-          let body2 = body ++ [ BlStatement () u (Just $ intGen 42) (StContinue () u) ]
+          let body2 = body
           let bl = BlDo () u Nothing Nothing (Just $ intGen 42) (Just doSpec) body2 (Just $ intGen 42)
           let expect = unlines [ "      do 42 i = 1, 9, 2"
                                , "        print *, i"

--- a/test/Language/Fortran/PrettyPrintSpec.hs
+++ b/test/Language/Fortran/PrettyPrintSpec.hs
@@ -378,7 +378,7 @@ spec =
           let expect = unlines [ "      do 42 i = 1, 9, 2"
                                , "        print *, i"
                                , "        i = (i - 1)"
-                               , "42      continue" ]
+                               , "42    continue" ]
           pprint Fortran77 bl (Just 6) `shouldBe` text expect
 
       describe "If" $ do


### PR DESCRIPTION
This PR addresses issue #323 

Fortran 77 has unstructued do, e.g., with code like:
```
      DO 100 I = 1, NLAY
         READ(10, *) A(I), B(I), C(I)
     100 CONTINUE
```
fortran-src applies a grouping transformation internally which turns this into a do-block, throwing away the continue statement. However, when pretty-printing, we do not re-insert the continue statement, so get:
```
      DO 100 I = 1, NLAY
         READ(10, *) A(I), B(I), C(I)
```
We must re-insert such a continue statement otherwise the code will be invalid; note, there is no `end do` in Fortran 77 so the continue must go back in. Relatedly in >= Fortran 90  mode we seem to be failing to output an `end do` in this case too.

This PR adds this behaviour to the pretty printer, and also does something related in Fortran 90 mode when there is a labelled do with and end label. Tests added to check.


