### PR TITLE
Make `-Woperator-whitespace`-sane

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/*.cabal linguist-generated=true

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -294,7 +294,7 @@ showGenericMap = unlines . map (\ (k, v) -> show k ++ " : " ++ show v) . M.toLis
 showStringMap :: StringMap -> String
 showStringMap = showGenericMap
 showModuleMap :: ModuleMap -> String
-showModuleMap = concatMap (\ (n, m) -> show n ++ ":\n" ++ (unlines . map ("  "++) . lines . showGenericMap $ m)) . M.toList
+showModuleMap = concatMap (\ (n, m) -> show n ++ ":\n" ++ (unlines . map ("  " ++) . lines . showGenericMap $ m)) . M.toList
 showTypes :: TypeEnvExtended -> String
 showTypes tenv =
   let sortedInfo = sortBy (\(_, (_, sp1, _)) (_, (_, sp2, _)) -> compare sp1 sp2) $ M.toList tenv
@@ -388,7 +388,7 @@ options =
   , Option ['C']
       ["cpp"]
       (OptArg (\ cppOpts opts -> opts {
-                  cppOptions = Just (dropWhile (=='=') $ fromMaybe "" cppOpts) }
+                  cppOptions = Just (dropWhile (== '=') $ fromMaybe "" cppOpts) }
               ) "CPP-OPTS")
       "run the C Pre Processor on the Fortran files first"
   , Option ['I']

--- a/fortran-src.cabal
+++ b/fortran-src.cabal
@@ -190,14 +190,14 @@ library
       BinaryLiterals
       ScopedTypeVariables
       TypeOperators
-  ghc-options: -Wall -fno-warn-tabs
+  ghc-options: -Wall -Werror=operator-whitespace -fno-warn-tabs
   build-tools:
       alex >=3.1
     , happy >=1.19
   build-depends:
       GenericPretty >=1.2.2 && <2
     , array ==0.5.*
-    , base >=4.6 && <4.22
+    , base >=4.6 && <4.23
     , binary >=0.8.3.0 && <0.11
     , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.7
@@ -256,11 +256,11 @@ executable fortran-src
       BinaryLiterals
       ScopedTypeVariables
       TypeOperators
-  ghc-options: -Wall -fno-warn-tabs
+  ghc-options: -Wall -Werror=operator-whitespace -fno-warn-tabs
   build-depends:
       GenericPretty >=1.2.2 && <2
     , array ==0.5.*
-    , base >=4.6 && <4.22
+    , base >=4.6 && <4.23
     , binary >=0.8.3.0 && <0.11
     , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.7
@@ -351,14 +351,14 @@ test-suite spec
       BinaryLiterals
       ScopedTypeVariables
       TypeOperators
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror=operator-whitespace
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
       GenericPretty >=1.2.2 && <2
     , QuickCheck >=2.10 && <2.15
     , array ==0.5.*
-    , base >=4.6 && <4.22
+    , base >=4.6 && <4.23
     , binary >=0.8.3.0 && <0.11
     , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.7

--- a/package.yaml
+++ b/package.yaml
@@ -77,10 +77,11 @@ default-extensions:
 # --pedantic for building (not used for stack ghci)
 ghc-options:
 - -Wall
+- -Werror=operator-whitespace
 #- -Werror # appears bad to do in distribution, can be useful for development
 
 dependencies:
-- base >=4.6 && <4.22
+- base >=4.6 && <4.23
 - mtl >=2.2 && <3
 - array >=0.5 && <0.6
 - uniplate >=1.6 && <2

--- a/src/Language/Fortran/AST/Literal/Real.hs
+++ b/src/Language/Fortran/AST/Literal/Real.hs
@@ -77,8 +77,8 @@ parseRealLit r =
     -- | Ensure that the given decimal string is in form @x.y@.
     normalizeSignificand str = case span (/= '.') str of
                                  ([], d)  -> '0':d   --    .456
-                                 (i, ".") -> i<>".0" -- 123.
-                                 (i, "")  -> i<>".0" -- 123
+                                 (i, ".") -> i <> ".0" -- 123.
+                                 (i, "")  -> i <> ".0" -- 123
                                  _        -> str     -- 123.456
     parseExponent "" = Exponent { exponentLetter = ExpLetterE, exponentNum = "0" }
     parseExponent (l:str) =

--- a/src/Language/Fortran/Analysis/BBlocks.hs
+++ b/src/Language/Fortran/Analysis/BBlocks.hs
@@ -699,7 +699,7 @@ genSuperBBGr bbm = SuperBBGr { superBBGrGraph = superGraph''
     superGraph'' = BBGr { bbgrGr = delNode mainEntry .
                                    insEdges [ (0, m, l) | (_, m, l) <- out superGraph' mainEntry ] .
                                    insNode (0, []) $ superGraph'
-                        , bbgrEntries = (0:) . filter (/=mainEntry) . map snd . M.toList $ entryMap
+                        , bbgrEntries = (0:) . filter (/= mainEntry) . map snd . M.toList $ entryMap
                         , bbgrExits   = (-1:) . map snd . M.toList $ exitMap }
 
 fromJustMsg :: String -> Maybe a -> a
@@ -720,7 +720,7 @@ showBBGr (BBGr gr _ _) = execWriter . forM (labNodes gr) $ \ (n, bs) -> do
   let b = "BBLOCK " ++ show n ++ " -> " ++ show (map (\ (_, m, _) -> m) $ out gr n)
   tell $ "\n\n" ++ b
   tell $ "\n" ++ replicate (length b) '-' ++ "\n"
-  tell (((++"\n") . pretty) =<< bs)
+  tell (((++ "\n") . pretty) =<< bs)
 
 -- | Show a basic block graph without the clutter
 showAnalysedBBGr :: (Out a, Show a) => BBGr (Analysis a) -> String
@@ -925,7 +925,7 @@ showDecl (Declarator _ _ e mAdims length' initial) =
            ++ maybe "" (\e' -> " = " ++ showExpr e') initial
 
 showDim :: DimensionDeclarator a -> String
-showDim (DimensionDeclarator _ _ me1 me2) = maybe "" ((++":") . showExpr) me1 ++ maybe "" showExpr me2
+showDim (DimensionDeclarator _ _ me1 me2) = maybe "" ((++ ":") . showExpr) me1 ++ maybe "" showExpr me2
 
 aIntercalate :: [a1] -> (t a2 -> [a1]) -> AList t a2 -> [a1]
 aIntercalate sep f = intercalate sep . map f . aStrip

--- a/src/Language/Fortran/Analysis/SemanticTypes.hs
+++ b/src/Language/Fortran/Analysis/SemanticTypes.hs
@@ -60,20 +60,20 @@ type Dimensions = Dims NonEmpty (Maybe Int)
 instance Pretty SemType where
   pprint' v
     | v >= Fortran90 = \case
-      TInteger k -> "integer"<>pd k
-      TReal    k -> "real"<>pd k
-      TComplex k -> "complex"<>pd k
-      TLogical k -> "logical"<>pd k
-      TByte    k -> "byte"<>pd k
+      TInteger k -> "integer" <> pd k
+      TReal    k -> "real" <> pd k
+      TComplex k -> "complex" <> pd k
+      TLogical k -> "logical" <> pd k
+      TByte    k -> "byte" <> pd k
       TCharacter _ _ -> "character(TODO)"
       TArray st dims -> pprint' v st <> pdims v dims
       TCustom str -> pprint' v (TypeCustom str)
     | otherwise = \case
-      TInteger k -> "integer"<>ad k
-      TReal    k -> "real"<>ad k
-      TComplex k -> "complex"<>ad k
-      TLogical k -> "logical"<>ad k
-      TByte    k -> "byte"<>ad k
+      TInteger k -> "integer" <> ad k
+      TReal    k -> "real" <> ad k
+      TComplex k -> "complex" <> ad k
+      TLogical k -> "logical" <> ad k
+      TByte    k -> "byte" <> ad k
       TCharacter _ _ -> "character*TODO"
       TArray st dims -> pprint' v st <> pdims v dims
       TCustom str -> pprint' v (TypeCustom str)

--- a/src/Language/Fortran/Parser.hs
+++ b/src/Language/Fortran/Parser.hs
@@ -387,7 +387,7 @@ byVerInclude = \case
 readInDirs :: [String] -> String -> IO (String, B.ByteString)
 readInDirs [] f = fail $ "cannot find file: " ++ f
 readInDirs (d:ds) f = do
-  let path = d</>f
+  let path = d </> f
   b <- doesFileExist path
   if b then
     (path,) <$> B.readFile path

--- a/src/Language/Fortran/Parser/Fixed/Lexer.x
+++ b/src/Language/Fortran/Parser/Fixed/Lexer.x
@@ -326,8 +326,8 @@ doP fv ai = isPrefixOf "do" (reverse . lexemeMatch . aiLexeme $ ai) &&
         _ -> lexer $ f 0
     f !n t =
       case t of
-        TLeftPar{} -> lexer $ f (n+1)
-        TRightPar{} -> lexer $ f (n-1)
+        TLeftPar{} -> lexer $ f (n + 1)
+        TRightPar{} -> lexer $ f (n - 1)
         _ -> lexer $ f n
 
 ifP :: FortranVersion -> AlexInput -> Int -> AlexInput -> Bool
@@ -1089,7 +1089,7 @@ isCommentLine ai p
 
 takeLine :: Position -> AlexInput -> String
 takeLine p ai =
-  B.unpack . B.takeWhile (/='\n') . B.drop (fromIntegral _dropN) $ aiSourceBytes ai
+  B.unpack . B.takeWhile (/= '\n') . B.drop (fromIntegral _dropN) $ aiSourceBytes ai
   where
     _dropN = posAbsoluteOffset p
 

--- a/src/Language/Fortran/Parser/ParserUtils.hs
+++ b/src/Language/Fortran/Parser/ParserUtils.hs
@@ -38,7 +38,7 @@ exprToComplexLitPart e =
           ValReal    r mkp ->
             let r' = r { realLitSignificand = sign <> realLitSignificand r }
              in return $ ComplexPartReal a ss r' mkp
-          ValInteger i mkp -> return $ ComplexPartInt a ss (sign<>i) mkp
+          ValInteger i mkp -> return $ ComplexPartInt a ss (sign <> i) mkp
           ValVariable var  -> return $ ComplexPartNamed a ss var
           _                -> fail $ "Invalid COMPLEX literal @ " <> show ss
       _ -> fail $ "Invalid COMPLEX literal @ " <> show (getSpan e')

--- a/src/Language/Fortran/PrettyPrint.hs
+++ b/src/Language/Fortran/PrettyPrint.hs
@@ -74,7 +74,7 @@ newline = char '\n'
 type Indentation = Maybe Int
 
 incIndentation :: Indentation -> Indentation
-incIndentation indentation = (+2) <$> indentation
+incIndentation indentation = (+ 2) <$> indentation
 
 indent :: Indentation -> Doc -> Doc
 indent Nothing d = d
@@ -1233,18 +1233,18 @@ reformatMixedFormInsertContinuations = go stNewline
     -- line type uncertain: consume up to non-space, then decide
     go (RefmtStNewline col) (x:xs) =
         case x of
-            ' ' -> ' ' : go (RefmtStNewline (col+1)) xs
+            ' ' -> ' ' : go (RefmtStNewline (col + 1)) xs
             '!' -> '!' : go RefmtStComment           xs
-            _   -> x   : go (RefmtStStmt    (col+1)) xs
+            _   -> x   : go (RefmtStStmt    (col + 1)) xs
 
     -- in statement: break when required
     go (RefmtStStmt col)    (x:xs)
       -- Checking if we are at column 73, since col is counted from 0!
       | col == maxCol && x == '&' = -- already a continuation in `intersection` format
-                        '&' : go (RefmtStStmt (col+1)) xs
+                        '&' : go (RefmtStStmt (col + 1)) xs
       | col == maxCol = -- making continuation
                         '&' : '\n' : go stNewline ("     &" ++ x:xs)
-      | otherwise     = x : go (RefmtStStmt (col+1)) xs
+      | otherwise     = x : go (RefmtStStmt (col + 1)) xs
 
     maxCol = 72
     stNewline = RefmtStNewline 0

--- a/src/Language/Fortran/Repr/Eval/Value.hs
+++ b/src/Language/Fortran/Repr/Eval/Value.hs
@@ -344,7 +344,7 @@ evalFunctionCall fname args =
             pure $ MkFScalarValue $ FSVString $ Text.singleton c
           _ ->
             err $ EOpTypeError $
-                "char: expected INT(x), got "<>show (fScalarValueType v')
+                "char: expected INT(x), got " <> show (fScalarValueType v')
 
       "not"  -> do
         args' <- forceArgs 1 args
@@ -355,7 +355,7 @@ evalFunctionCall fname args =
             pure $ MkFScalarValue $ FSVInt $ fIntUOpInplace Data.Bits.complement i
           _ ->
             err $ EOpTypeError $
-                "not: expected INT(x), got "<>show (fScalarValueType v')
+                "not: expected INT(x), got " <> show (fScalarValueType v')
 
       "int"  ->
         case args of
@@ -369,7 +369,7 @@ evalFunctionCall fname args =
               FSVInt vkI -> (MkFScalarValue . FSVInt) <$> evalIntrinsicInt v vkI
               _ ->
                 err $ EOpTypeError $
-                    "int: kind argument must be INTEGER, got "<>show (fScalarValueType vk')
+                    "int: kind argument must be INTEGER, got " <> show (fScalarValueType vk')
           _ -> err $ EOpTypeError $ "int: expected 1 or 2 arguments, got >2"
 
       -- TODO all lies
@@ -384,7 +384,7 @@ evalFunctionCall fname args =
             pure $ MkFScalarValue $ FSVInt $ FInt2 $ fRealUOp truncate r
           _ ->
             err $ EOpTypeError $
-                "int: unsupported or unimplemented type: "<>show (fScalarValueType v')
+                "int: unsupported or unimplemented type: " <> show (fScalarValueType v')
 
       _      -> err $ EUnsupported $ "function call: " <> fname
 
@@ -432,7 +432,7 @@ evalIntrinsicIntXCoerce coerceToIX v = do
       FSVReal r -> pure $ fRealUOp truncate r
       _ ->
         err $ EOpTypeError $
-            "int: unsupported or unimplemented type: "<>show (fScalarValueType v')
+            "int: unsupported or unimplemented type: " <> show (fScalarValueType v')
 
 evalArg :: MonadFEvalValue m => F.Argument (FA.Analysis a) -> m FValue
 evalArg (F.Argument _ _ _ ae) =
@@ -459,7 +459,7 @@ forceArgs numArgs l =
     if   length l == numArgs
     then pure l
     else err $ EOpTypeError $
-            "expected "<>show numArgs<>" arguments; got "<>show (length l)
+            "expected " <> show numArgs <> " arguments; got " <> show (length l)
 
 evalIntrinsicIor
     :: MonadFEvalValue m => FScalarValue -> FScalarValue -> m FValue
@@ -488,7 +488,7 @@ evalIntrinsicMax = \case
                 go vNewMax vs
               _ ->
                 err $ EOpTypeError $
-                    "max: expected INT(x), got "<>show (fScalarValueType v)
+                    "max: expected INT(x), got " <> show (fScalarValueType v)
           FSVReal{} ->
             case v of
               FSVReal{} -> do
@@ -496,10 +496,10 @@ evalIntrinsicMax = \case
                 go vNewMax vs
               _ ->
                 err $ EOpTypeError $
-                    "max: expected REAL(x), got "<>show (fScalarValueType v)
+                    "max: expected REAL(x), got " <> show (fScalarValueType v)
           _ ->
             err $ EOpTypeError $
-                "max: unsupported type: "<> show (fScalarValueType vCurMax)
+                "max: unsupported type: " <> show (fScalarValueType vCurMax)
 
 -- | Evaluate a constant expression (F2018 10.1.12).
 evalConstExpr :: MonadFEvalValue m => F.Expression (FA.Analysis a) -> m FValue

--- a/src/Language/Fortran/Repr/Type/Scalar.hs
+++ b/src/Language/Fortran/Repr/Type/Scalar.hs
@@ -27,8 +27,8 @@ prettyScalarType = \case
   FSTReal    k -> prettyKinded k "REAL"
   FSTComplex k -> prettyKinded (FTComplexWrapper k) "COMPLEX"
   FSTLogical k -> prettyKinded k "LOGICAL"
-  FSTString  l -> "CHARACTER("<>prettyCharLen l<>")"
-  FSTCustom  t -> "TYPE("<>t<>")"
+  FSTString  l -> "CHARACTER(" <> prettyCharLen l <> ")"
+  FSTCustom  t -> "TYPE(" <> t <> ")"
 
 fScalarTypeKind :: FScalarType -> Maybe FKindLit
 fScalarTypeKind = \case
@@ -40,4 +40,4 @@ fScalarTypeKind = \case
   FSTCustom  t -> Nothing
 
 prettyKinded :: FKind a => a -> String -> String
-prettyKinded k name = name<>"("<>show (printFKind k)<>")"
+prettyKinded k name = name <> "(" <> show (printFKind k) <> ")"

--- a/src/Language/Fortran/Repr/Type/Scalar/String.hs
+++ b/src/Language/Fortran/Repr/Type/Scalar/String.hs
@@ -31,4 +31,4 @@ data CharLen
     deriving anyclass (Binary, Out)
 
 prettyCharLen :: Natural -> String
-prettyCharLen l = "LEN="<>show l
+prettyCharLen l = "LEN=" <> show l

--- a/src/Language/Fortran/Transformation/Grouping.hs
+++ b/src/Language/Fortran/Transformation/Grouping.hs
@@ -181,7 +181,7 @@ compLabel (Just (ExpValue _ _ (ValInteger l1 _)))
 compLabel _ _ = False
 
 strip :: String -> String
-strip = dropWhile (=='0')
+strip = dropWhile (== '0')
 
 isLabeledDo :: Statement a -> Bool
 isLabeledDo s = case s of

--- a/src/Language/Fortran/Util/Files.hs
+++ b/src/Language/Fortran/Util/Files.hs
@@ -62,7 +62,7 @@ runCPP (Just cppOpts) path   = do
                                                      newLineNo)
           where
             newLineNo = read . B.unpack . B.takeWhile isNumber . B.drop 2 $ curLine
-            linePath = B.unpack . B.takeWhile (/='"') . B.drop 1 . B.dropWhile (/='"') $ curLine
+            linePath = B.unpack . B.takeWhile (/= '"') . B.drop 1 . B.dropWhile (/= '"') $ curLine
 
   withSystemTempDirectory "fortran-src" $ \ tmpdir -> do
     let outfile = tmpdir </> "cpp.out"

--- a/test/Language/Fortran/Analysis/RenamingSpec.hs
+++ b/test/Language/Fortran/Analysis/RenamingSpec.hs
@@ -41,10 +41,10 @@ spec = do
   describe "Basic" $ do
     it "num-entries 1" $ do
       let entry = extractNameMap' ex3
-      shouldBe ( length (filter (=="f1") (elems entry))
-               , length (filter (=="a") (elems entry))
-               , length (filter (=="b") (elems entry))
-               , length (filter (=="d") (elems entry)) )
+      shouldBe ( length (filter (== "f1") (elems entry))
+               , length (filter (== "a") (elems entry))
+               , length (filter (== "b") (elems entry))
+               , length (filter (== "d") (elems entry)) )
                ( 1, 2, 2, 2 )
 
     -- Test that every symbol that is supposed to be renamed is renamed.
@@ -80,7 +80,7 @@ spec = do
 
     it "functions 1" $ do
       let entry = extractNameMap' ex3
-      length (filter (=="f1") (elems entry)) `shouldBe'` 1
+      length (filter (== "f1") (elems entry)) `shouldBe'` 1
 
   describe "Identity" $ do
     it "unrename-rename 1" $ do
@@ -107,7 +107,7 @@ spec = do
 
     it "exScope2 testing shadowing of variables" $ do
       let entry = extractNameMap' exScope2
-      length (filter (=="x") (elems entry)) `shouldBe` 2
+      length (filter (== "x") (elems entry)) `shouldBe` 2
 
     -- GitHub issue #190 https://github.com/camfort/fortran-src/issues/190
     it "doesn't generate same unique name in edge case" $ do
@@ -128,15 +128,15 @@ spec = do
   describe "Ordering" $
     it "exScope3 testing out-of-order definitions" $ do
       let entry = extractNameMap' exScope3
-      length (filter (=="f1") (elems entry)) `shouldBe` 1
-      length (filter (=="f2") (elems entry)) `shouldBe` 1
-      length (filter (=="s1") (elems entry)) `shouldBe` 1
-      length (filter (=="s2") (elems entry)) `shouldBe` 1
+      length (filter (== "f1") (elems entry)) `shouldBe` 1
+      length (filter (== "f2") (elems entry)) `shouldBe` 1
+      length (filter (== "s1") (elems entry)) `shouldBe` 1
+      length (filter (== "s2") (elems entry)) `shouldBe` 1
 
   describe "Common blocks" $
     it "common1" $ do
       let entry = extractNameMap' common1
-      length (filter (=="x") (elems entry)) `shouldBe` 2
+      length (filter (== "x") (elems entry)) `shouldBe` 2
       M.lookup "c_x_common" entry `shouldBe` Just "x"
       M.lookup "c_y_common" entry `shouldBe` Just "y"
 

--- a/test/Language/Fortran/AnalysisSpec.hs
+++ b/test/Language/Fortran/AnalysisSpec.hs
@@ -33,7 +33,7 @@ programAnal1LhsExprs =
   , ExpSubscript () u (ExpValue () u (ValVariable "a")) (AList () u [ ixSinGen 5 ]) ]
 
 programAnal1 :: String
-programAnal1 = unlines $ map (replicate 6 ' '++) [
+programAnal1 = unlines $ map (replicate 6 ' ' ++) [
       "program anal1"
     , "integer a, f"
     , "dimension a(10)"

--- a/test/Language/Fortran/Parser/Free/LexerSpec.hs
+++ b/test/Language/Fortran/Parser/Free/LexerSpec.hs
@@ -23,7 +23,7 @@ collectF03 :: String -> [Token]
 collectF03 = collectFreeTokens Fortran2003 . B.pack
 
 pseudoAssign :: (SrcSpan -> Token) -> [Token]
-pseudoAssign token = fmap ($u) [ flip TId "i", TOpAssign, token, TEOF ]
+pseudoAssign token = fmap ($ u) [ flip TId "i", TOpAssign, token, TEOF ]
 
 spec :: Spec
 spec =
@@ -32,31 +32,31 @@ spec =
       describe "Character sensitivity" $ do
         it "lexes lower case tokens" $
           shouldBe' (collectF90 "integer id") $
-                    fmap ($u) [ TInteger, flip TId "id", TEOF ]
+                    fmap ($ u) [ TInteger, flip TId "id", TEOF ]
 
         it "lexes mixed case tokens" $
           shouldBe' (collectF90 "InTEgeR ID") $
-                    fmap ($u) [ TInteger, flip TId "id", TEOF ]
+                    fmap ($ u) [ TInteger, flip TId "id", TEOF ]
 
       describe "Identifier" $ do
         it "lexes long ID names" $
           shouldBe' (collectF90 "program long_id_name") $
-                    fmap ($u) [ TProgram, flip TId "long_id_name", TEOF ]
+                    fmap ($ u) [ TProgram, flip TId "long_id_name", TEOF ]
 
         it "treats 'if' as ID if used in assignment" $
           shouldBe' (collectF90 "if = 20") $
-                    fmap ($u) [ flip TId "if", TOpAssign
+                    fmap ($ u) [ flip TId "if", TOpAssign
                               , flip TIntegerLiteral "20", TEOF ]
 
         it "'result' is an identifier in spec. context" $
           shouldBe' (collectF90 "integer :: result") $
-                    fmap ($u) [ TInteger, TDoubleColon , flip TId "result"
+                    fmap ($ u) [ TInteger, TDoubleColon , flip TId "result"
                               , TEOF ]
 
       describe "Types" $ do
         it "lexes length and kind selectors" $
           shouldBe' (collectF90 "integer (KIND=1, LEN=1) :: kind, len") $
-                    fmap ($u) [ TInteger, TLeftPar, TKind, TOpAssign
+                    fmap ($ u) [ TInteger, TLeftPar, TKind, TOpAssign
                               , flip TIntegerLiteral "1", TComma, TLen
                               , TOpAssign, flip TIntegerLiteral "1", TRightPar
                               , TDoubleColon , flip TId "kind", TComma
@@ -65,35 +65,35 @@ spec =
 
         it "lexes simple type tokens" $
           shouldBe' (collectF90 "character x") $
-                    fmap ($u) [ TCharacter, flip TId "x", TEOF ]
+                    fmap ($ u) [ TCharacter, flip TId "x", TEOF ]
 
         it "lexes simple type tokens in function" $
           shouldBe' (collectF90 "character function x") $
-                    fmap ($u) [ TCharacter, TFunction, flip TId "x", TEOF ]
+                    fmap ($ u) [ TCharacter, TFunction, flip TId "x", TEOF ]
 
         it "lexes character type with F77 length syntax (1)" $
           shouldBe' (collectF90 "character * (*) function x") $
-                    fmap ($u) [ TCharacter, TStar, TLeftPar, TStar, TRightPar, TFunction, flip TId "x", TEOF ]
+                    fmap ($ u) [ TCharacter, TStar, TLeftPar, TStar, TRightPar, TFunction, flip TId "x", TEOF ]
 
         it "lexes character type with F77 length syntax (2)" $
           shouldBe' (collectF90 "character * 20 function x") $
-                    fmap ($u) [ TCharacter, TStar, flip TIntegerLiteral "20", TFunction, flip TId "x", TEOF ]
+                    fmap ($ u) [ TCharacter, TStar, flip TIntegerLiteral "20", TFunction, flip TId "x", TEOF ]
 
         it "lexes derived type tokens in function" $
           shouldBe' (collectF90 "type (x) function x") $
-                    fmap ($u) [ TType, TLeftPar, flip TId "x", TRightPar
+                    fmap ($ u) [ TType, TLeftPar, flip TId "x", TRightPar
                               , TFunction, flip TId "x", TEOF ]
 
         it "lexes interleaved type recursive tokens" $
           shouldBe' (collectF90 "integer (KIND=10*2) recursive function x") $
-                    fmap ($u) [ TInteger, TLeftPar, TKind, TOpAssign
+                    fmap ($ u) [ TInteger, TLeftPar, TKind, TOpAssign
                               , flip TIntegerLiteral "10" , TStar
                               , flip TIntegerLiteral "2", TRightPar, TRecursive
                               , TFunction, flip TId "x", TEOF ]
 
         it "lexes interleaved type recursive tokens (reversed)" $
           shouldBe' (collectF90 "recursive integer (KIND=10*2) function x") $
-                    fmap ($u) [ TRecursive, TInteger, TLeftPar, TKind, TOpAssign
+                    fmap ($ u) [ TRecursive, TInteger, TLeftPar, TKind, TOpAssign
                               , flip TIntegerLiteral "10" , TStar
                               , flip TIntegerLiteral "2", TRightPar, TFunction
                               , flip TId "x", TEOF ]
@@ -101,125 +101,125 @@ spec =
       describe "Function" $ do
         it "lexes 'function fx ( a, b, c )'" $
           shouldBe' (collectF90 "function fx ( a, b )") $
-                    fmap ($u) [ TFunction, flip TId "fx", TLeftPar, flip TId "a"
+                    fmap ($ u) [ TFunction, flip TId "fx", TLeftPar, flip TId "a"
                               , TComma, flip TId "b", TRightPar, TEOF ]
 
         it "lexes functions with specific result" $
           shouldBe' (collectF90 "function fx (array) result (c_sum)") $
-                    fmap ($u) [ TFunction, flip TId "fx", TLeftPar
+                    fmap ($ u) [ TFunction, flip TId "fx", TLeftPar
                               , flip TId "array", TRightPar, TResult, TLeftPar
                               , flip TId "c_sum", TRightPar, TEOF ]
 
         it "lexes recursive functions" $
           shouldBe' (collectF90 "recursive function fx (array)") $
-                    fmap ($u) [ TRecursive, TFunction, flip TId "fx", TLeftPar
+                    fmap ($ u) [ TRecursive, TFunction, flip TId "fx", TLeftPar
                               , flip TId "array", TRightPar, TEOF ]
 
         it "lexes recursive functions with result specified" $
           shouldBe' (collectF90 "RECURSIVE FUNCTION FX (ARRAY) RESULT (C_SUM)") $
-                    fmap ($u) [ TRecursive, TFunction, flip TId "fx", TLeftPar
+                    fmap ($ u) [ TRecursive, TFunction, flip TId "fx", TLeftPar
                               , flip TId "array", TRightPar, TResult, TLeftPar
                               , flip TId "c_sum", TRightPar, TEOF ]
 
       describe "Attribute" $ do
         it "lexes PARAMETER attribute" $
           shouldBe' (collectF90 "integer, parameter :: x") $
-                    fmap ($u) [ TInteger, TComma, TParameter, TDoubleColon
+                    fmap ($ u) [ TInteger, TComma, TParameter, TDoubleColon
                               , flip TId "x", TEOF ]
 
         it "lexes INTENT attribute" $
           shouldBe' (collectF90 "integer, intent (inout) :: x") $
-                    fmap ($u) [ TInteger, TComma, TIntent, TLeftPar, TInOut
+                    fmap ($ u) [ TInteger, TComma, TIntent, TLeftPar, TInOut
                               , TRightPar, TDoubleColon , flip TId "x", TEOF ]
 
         it "lexes DIMENSION attribute" $
           shouldBe' (collectF90 "double precision, dimension (3:10) :: x") $
-                    fmap ($u) [ TDoublePrecision, TComma, TDimension, TLeftPar
+                    fmap ($ u) [ TDoublePrecision, TComma, TDimension, TLeftPar
                               , flip TIntegerLiteral "3", TColon
                               , flip TIntegerLiteral "10" , TRightPar
                               , TDoubleColon , flip TId "x", TEOF ]
 
         it "lexes variable declaration with multiple attributes" $
           shouldBe' (collectF90 "double precision, save, dimension(2), allocatable :: y") $
-                    fmap ($u) [ TDoublePrecision, TComma, TSave, TComma
+                    fmap ($ u) [ TDoublePrecision, TComma, TSave, TComma
                               , TDimension, TLeftPar, flip TIntegerLiteral "2"
                               , TRightPar, TComma, TAllocatable, TDoubleColon
                               , flip TId "y", TEOF ]
 
         it "try to trick lexer into parsing variables as attributes (1)" $
           shouldBe' (collectF90 "integer save, dimension(10), target") $
-                    fmap ($u) [ TInteger, flip TId "save", TComma
+                    fmap ($ u) [ TInteger, flip TId "save", TComma
                               , flip TId "dimension", TLeftPar, flip TIntegerLiteral "10", TRightPar, TComma
                               , flip TId "target", TEOF ]
 
         it "try to trick lexer into parsing variables as attributes (2)" $
           shouldBe' (collectF90 "type(foo) save, dimension(10), target") $
-                    fmap ($u) [ TType, TLeftPar, flip TId "foo", TRightPar, flip TId "save", TComma
+                    fmap ($ u) [ TType, TLeftPar, flip TId "foo", TRightPar, flip TId "save", TComma
                               , flip TId "dimension", TLeftPar, flip TIntegerLiteral "10", TRightPar, TComma
                               , flip TId "target", TEOF ]
 
         it "try to trick lexer into parsing variables as attributes (3)" $
           shouldBe' (collectF90 "allocate(type(foo) :: errmsg(stat, source), source=x)") $
-                    fmap ($u) [ TAllocate, TLeftPar, TType, TLeftPar, flip TId "foo", TRightPar, TDoubleColon
+                    fmap ($ u) [ TAllocate, TLeftPar, TType, TLeftPar, flip TId "foo", TRightPar, TDoubleColon
                               , flip TId "errmsg", TLeftPar, flip TId "stat", TComma, flip TId "source", TRightPar
                               , TComma, TSource, TOpAssign, flip TId "x", TRightPar, TEOF ]
 
       describe "Character" $ do
         it "lexes single quote literal" $
           shouldBe' (collectF90 "character c = 'heL\"Lo ''daRLing'") $
-                    fmap ($u) [ TCharacter, flip TId "c", TOpAssign
+                    fmap ($ u) [ TCharacter, flip TId "c", TOpAssign
                               , flip TString "heL\"Lo 'daRLing", TEOF ]
 
         it "lexes double quote literal" $
           shouldBe' (collectF90 "character c = \"heL'Lo \"\"daRLing\"") $
-                    fmap ($u) [ TCharacter, flip TId "c", TOpAssign
+                    fmap ($ u) [ TCharacter, flip TId "c", TOpAssign
                               , flip TString "heL'Lo \"daRLing", TEOF ]
 
       describe "Module" $ do
         it "lexes module statement" $
           shouldBe' (collectF90 "module Hello_mod") $
-                    fmap ($u) [ TModule, flip TId "hello_mod", TEOF ]
+                    fmap ($ u) [ TModule, flip TId "hello_mod", TEOF ]
 
         it "lexes use statement" $
           shouldBe' (collectF90 "use Hello_mod, hello => hi") $
-                    fmap ($u) [ TUse, flip TId "hello_mod", TComma
+                    fmap ($ u) [ TUse, flip TId "hello_mod", TComma
                               , flip TId "hello", TArrow, flip TId "hi", TEOF ]
 
         it "lexes use statement with only" $
           shouldBe' (collectF90 "use Hello_mod, only: a, b => c") $
-                    fmap ($u) [ TUse, flip TId "hello_mod", TComma, TOnly
+                    fmap ($ u) [ TUse, flip TId "hello_mod", TComma, TOnly
                               , TColon, flip TId "a", TComma, flip TId "b"
                               , TArrow, flip TId "c", TEOF ]
 
       describe "Label" $
         it "lexes simple label" $
           shouldBe' (collectF90 "010 print *, 'hello'") $
-                    fmap ($u) [ flip TIntegerLiteral "010", TPrint, TStar, TComma
+                    fmap ($ u) [ flip TIntegerLiteral "010", TPrint, TStar, TComma
                               , flip TString "hello", TEOF ]
 
       describe "Conditional" $ do
         it "lexes logical if with array assignment" $
           shouldBe' (collectF90 "if (.true.) a(1) = 42") $
-                    fmap ($u) [ TIf, TLeftPar, flip TLogicalLiteral True
+                    fmap ($ u) [ TIf, TLeftPar, flip TLogicalLiteral True
                               , TRightPar, flip TId "a", TLeftPar
                               , flip TIntegerLiteral "1", TRightPar, TOpAssign
                               , flip TIntegerLiteral "42", TEOF ]
 
         it "lexes block if statement" $
           shouldBe' (collectF90 "if (a > b) then") $
-                    fmap ($u) [ TIf, TLeftPar, flip TId "a", TOpGT, flip TId "b"
+                    fmap ($ u) [ TIf, TLeftPar, flip TId "a", TOpGT, flip TId "b"
                               , TRightPar, TThen, TEOF ]
 
         it "lexes arithmetic if statement" $
           shouldBe' (collectF90 "if (a) 10, 11, 12") $
-                    fmap ($u) [ TIf, TLeftPar, flip TId "a", TRightPar
+                    fmap ($ u) [ TIf, TLeftPar, flip TId "a", TRightPar
                               , flip TIntegerLiteral "10", TComma
                               , flip TIntegerLiteral "11", TComma
                               , flip TIntegerLiteral "12" , TEOF ]
 
         it "lexes logical if statement" $
           shouldBe' (collectF90 "if (a > b) print *, 'hello'") $
-                    fmap ($u) [ TIf, TLeftPar, flip TId "a", TOpGT, flip TId "b"
+                    fmap ($ u) [ TIf, TLeftPar, flip TId "a", TOpGT, flip TId "b"
                               , TRightPar, TPrint, TStar, TComma
                               , flip TString "hello", TEOF ]
 
@@ -233,29 +233,29 @@ spec =
             let litStr      = "10.5e2"
                 expectedLit = RealLit "10.5" (Exponent ExpLetterE "2")
                 expected    = pseudoAssign $ flip TRealLiteral expectedLit
-            collectF90 ("i = "<>litStr) `shouldBe'` expected
+            collectF90 ("i = " <> litStr) `shouldBe'` expected
 
           it "lexes real (2)" $ do
             let litStr      = "10."
                 expectedLit = RealLit "10.0" (Exponent ExpLetterE "0")
                 expected    = pseudoAssign $ flip TRealLiteral expectedLit
-            collectF90 ("i = "<>litStr) `shouldBe'` expected
+            collectF90 ("i = " <> litStr) `shouldBe'` expected
 
           it "lexes real (3)" $ do
             let litStr      = ".42"
                 expectedLit = RealLit "0.42" (Exponent ExpLetterE "0")
                 expected    = pseudoAssign $ flip TRealLiteral expectedLit
-            collectF90 ("i = "<>litStr) `shouldBe'` expected
+            collectF90 ("i = " <> litStr) `shouldBe'` expected
 
           it "lexes real (4)" $ do
             let litStr      = "42d-3"
                 expectedLit = RealLit "42.0" (Exponent ExpLetterD "-3")
                 expected    = pseudoAssign $ flip TRealLiteral expectedLit
-            collectF90 ("i = "<>litStr) `shouldBe'` expected
+            collectF90 ("i = " <> litStr) `shouldBe'` expected
 
           it "resolves disambiguity when xxx. follows relational operator" $
             shouldBe' (collectF90 "if (10.EQ. 20)") $
-                      fmap ($u) [ TIf, TLeftPar, flip TIntegerLiteral "10"
+                      fmap ($ u) [ TIf, TLeftPar, flip TIntegerLiteral "10"
                                 , TOpEQ, flip TIntegerLiteral "20"
                                 , TRightPar, TEOF ]
 
@@ -287,8 +287,8 @@ spec =
         -- posPragmaOffset is the difference between the given line and the current next line.
         let testPos = initPosition { posPragmaOffset = Just (40 - (2 + 1), "file.f") }
             testSS = SrcSpan testPos testPos
-            lpToks = fmap ($initSrcSpan) [ flip TId "i", TOpAssign] ++
-                     fmap ($testSS) [flip TIntegerLiteral "42", TEOF ]
+            lpToks = fmap ($ initSrcSpan) [ flip TId "i", TOpAssign] ++
+                     fmap ($ testSS) [flip TIntegerLiteral "42", TEOF ]
             ppoOf  = posPragmaOffset . ssFrom . getSpan
 
         it "Continuation with line pragma" $
@@ -307,8 +307,8 @@ spec =
         -- posPragmaOffset is the difference between the given line and the current next line.
         let testPos = initPosition { posPragmaOffset = Just (40 - (2 + 1), "file.f") }
             testSS = SrcSpan testPos testPos
-            lpToks = fmap ($initSrcSpan) [ flip TId "i", TOpAssign, flip TIntegerLiteral "42", TNewline ] ++
-                     fmap ($testSS) [flip TId "j", TOpAssign, flip TIntegerLiteral "42", TEOF ]
+            lpToks = fmap ($ initSrcSpan) [ flip TId "i", TOpAssign, flip TIntegerLiteral "42", TNewline ] ++
+                     fmap ($ testSS) [flip TId "j", TOpAssign, flip TIntegerLiteral "42", TEOF ]
             ppoOf  = posPragmaOffset . ssFrom . getSpan
 
         it "Line pragma" $
@@ -326,97 +326,97 @@ spec =
       describe "Comment" $ do
         it "Full line comment" $
           shouldBe' (collectF90 "! = & ! hi \n") $
-                    ($u) <$> [ flip TComment " = & ! hi ", TNewline , TEOF ]
+                    ($ u) <$> [ flip TComment " = & ! hi ", TNewline , TEOF ]
 
         it "Inline comment" $
           shouldBe' (collectF90 "i = 10 ! = & ! hi \n") $
-                    ($u) <$> [ flip TId "i", TOpAssign
+                    ($ u) <$> [ flip TId "i", TOpAssign
                              , flip TIntegerLiteral "10"
                              , flip TComment " = & ! hi ", TNewline , TEOF ]
         it "Empty comment" $
           shouldBe' (collectF90 "!\n") $
-                    ($u) <$> [ flip TComment "", TNewline , TEOF ]
+                    ($ u) <$> [ flip TComment "", TNewline , TEOF ]
 
       describe "Subscripting" $ do
         it "Strings nested in arrays" $
           shouldBe' (collectF90 "a(1)(2:3) = 'we'") $
-                    ($u) <$> [ flip TId "a", TLeftPar, flip TIntegerLiteral "1", TRightPar
+                    ($ u) <$> [ flip TId "a", TLeftPar, flip TIntegerLiteral "1", TRightPar
                              , TLeftPar, flip TIntegerLiteral "2", TColon, flip TIntegerLiteral "3", TRightPar
                              , TOpAssign, flip TString "we", TEOF ]
 
       describe "Fortran95" $ do
         it "lexes value attribute" $ do
           shouldBe' (collectF03 "value :: a, b") $
-                    fmap ($u) [ TValue, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TValue, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
           shouldBe' (collectF03 "integer, value :: a, b") $
-                    fmap ($u) [ TInteger, TComma, TValue, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TInteger, TComma, TValue, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
 
         it "lexes volatile attribute" $ do
           shouldBe' (collectF03 "volatile :: a, b") $
-                    fmap ($u) [ TVolatile, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TVolatile, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
           shouldBe' (collectF03 "integer, volatile :: a, b") $
-                    fmap ($u) [ TInteger, TComma, TVolatile, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TInteger, TComma, TVolatile, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
 
       describe "Fortran2003" $ do
         it "lexes procedures" $
           shouldBe' (collectF03 "PROCEDURE(a), SAVE :: b => c()") $
-            ($u) <$> [ TProcedure, TLeftPar, flip TId "a", TRightPar
+            ($ u) <$> [ TProcedure, TLeftPar, flip TId "a", TRightPar
                      , TComma, TSave, TDoubleColon
                      , flip TId "b", TArrow, flip TId "c", TLeftPar, TRightPar, TEOF ]
 
         it "lexes procedures with bind" $
           shouldBe' (collectF03 "PROCEDURE(a), BIND(C, NAME=\"d\") :: b => c()") $
-            ($u) <$> [ TProcedure, TLeftPar, flip TId "a", TRightPar
+            ($ u) <$> [ TProcedure, TLeftPar, flip TId "a", TRightPar
                      , TComma, TBind, TLeftPar, TC, TComma, TName, TOpAssign, flip TString "d", TRightPar, TDoubleColon
                      , flip TId "b", TArrow, flip TId "c", TLeftPar, TRightPar, TEOF ]
 
         it "lexes functions with bind" $
           shouldBe' (collectF03 "FUNCTION f(a) RESULT(x) BIND(C, NAME=\"d\")") $
-            ($u) <$> [ TFunction, flip TId "f", TLeftPar, flip TId "a", TRightPar
+            ($ u) <$> [ TFunction, flip TId "f", TLeftPar, flip TId "a", TRightPar
                      , TResult, TLeftPar, flip TId "x", TRightPar
                      , TBind, TLeftPar, TC, TComma, TName, TOpAssign, flip TString "d", TRightPar, TEOF ]
 
         it "lexes subroutines with bind" $
           shouldBe' (collectF03 "SUBROUTINE s(a) BIND(C, NAME=\"d\")") $
-            ($u) <$> [ TSubroutine, flip TId "s", TLeftPar, flip TId "a", TRightPar
+            ($ u) <$> [ TSubroutine, flip TId "s", TLeftPar, flip TId "a", TRightPar
                      , TBind, TLeftPar, TC, TComma, TName, TOpAssign, flip TString "d", TRightPar, TEOF ]
 
         it "lexes class decl (name)" $
           shouldBe' (collectF03 "procedure (class(c))") $
-                    fmap ($u) [ TProcedure, TLeftPar
+                    fmap ($ u) [ TProcedure, TLeftPar
                               , TClass, TLeftPar, flip TId "c", TRightPar, TRightPar, TEOF ]
 
         it "lexes class decl (*)" $
           shouldBe' (collectF03 "procedure (class(*))") $
-                    fmap ($u) [ TProcedure, TLeftPar
+                    fmap ($ u) [ TProcedure, TLeftPar
                               , TClass, TLeftPar, TStar, TRightPar, TRightPar, TEOF ]
 
         it "lexes import statements" $
           shouldBe' (collectF03 "import :: a, b") $
-                    fmap ($u) [ TImport, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TImport, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
 
         it "lexes asynchronous attribute" $ do
           shouldBe' (collectF03 "asynchronous :: a, b") $
-                    fmap ($u) [ TAsynchronous, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TAsynchronous, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
           shouldBe' (collectF03 "integer, asynchronous :: a, b") $
-                    fmap ($u) [ TInteger, TComma, TAsynchronous, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
+                    fmap ($ u) [ TInteger, TComma, TAsynchronous, TDoubleColon, flip TId "a", TComma, flip TId "b", TEOF ]
 
         it "lexes enums" $ do
-          shouldBe' (collectF03 "enum, bind(c)") $ fmap ($u) [ TEnum, TComma, TBind, TLeftPar, TC, TRightPar, TEOF ]
+          shouldBe' (collectF03 "enum, bind(c)") $ fmap ($ u) [ TEnum, TComma, TBind, TLeftPar, TC, TRightPar, TEOF ]
           shouldBe' (collectF03 "enumerator :: a = 1, b") $
-                    fmap ($u) [ TEnumerator, TDoubleColon, flip TId "a", TOpAssign, flip TIntegerLiteral "1"
+                    fmap ($ u) [ TEnumerator, TDoubleColon, flip TId "a", TOpAssign, flip TIntegerLiteral "1"
                               , TComma, flip TId "b", TEOF ]
-          shouldBe' (collectF03 "end enum") $ fmap ($u) [ TEndEnum, TEOF ]
+          shouldBe' (collectF03 "end enum") $ fmap ($ u) [ TEndEnum, TEOF ]
 
         it "lexes flush" $ do
           shouldBe' (collectF03 "flush(unit=1)") $
-            fmap ($u) [ TFlush, TLeftPar, TUnit, TOpAssign, flip TIntegerLiteral "1", TRightPar, TEOF ]
+            fmap ($ u) [ TFlush, TLeftPar, TUnit, TOpAssign, flip TIntegerLiteral "1", TRightPar, TEOF ]
           shouldBe' (collectF03 "flush(unit=1,iomsg=x,iostat=y,err=z)") $
-            fmap ($u) [ TFlush, TLeftPar, TUnit, TOpAssign, flip TIntegerLiteral "1", TComma
+            fmap ($ u) [ TFlush, TLeftPar, TUnit, TOpAssign, flip TIntegerLiteral "1", TComma
                       , TIOMsg, TOpAssign, flip TId "x", TComma
                       , TIOStat, TOpAssign, flip TId "y", TComma
                       , TErr, TOpAssign, flip TId "z", TRightPar, TEOF ]
 
         it "lexes protected" $ do
           shouldBe' (collectF03 "real, protected, public :: x") $
-            fmap ($u) [ TReal, TComma, TProtected, TComma, TPublic, TDoubleColon, flip TId "x", TEOF ]
+            fmap ($ u) [ TReal, TComma, TProtected, TComma, TPublic, TDoubleColon, flip TId "x", TEOF ]

--- a/test/Language/Fortran/Repr/EvalSpec.hs
+++ b/test/Language/Fortran/Repr/EvalSpec.hs
@@ -20,7 +20,7 @@ spec =
     prop "integer exponentation (+ve exponent) (INTEGER(4))" $
       \base (NonNegative (expo :: Int32)) ->
         let expr = expBinary Exponentiation (expValInt base) (expValInt expo)
-         in shouldEvalTo (FSVInt (FInt4 (base^expo))) (evalExpr expr)
+         in shouldEvalTo (FSVInt (FInt4 (base ^ expo))) (evalExpr expr)
 
 shouldEvalTo :: FScalarValue -> FEvalValuePure FValue -> Expectation
 shouldEvalTo checkVal prog =


### PR DESCRIPTION
I'm working on a code indexing system that currently trips over `$u`.

`-Woperator-whitespace` enforces more than what my system currently needs, but it is easy to enforce.

Before the code used used mix conventions, especially in regards to `"foo"<>show x<>"bar"` vs `"foo" <> show x <> "bar"`; now it is consistent everywhere.

Do you think this is an improvement in general?